### PR TITLE
fix: allow unpack to work when length is exactly the max field bit size

### DIFF
--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -1328,7 +1328,7 @@ module Checked = struct
   ;;
 
   let unpack v ~length =
-    assert (length < Field.size_in_bits);
+    assert (length <= Field.size_in_bits);
     choose_preimage v ~length
   ;;
 


### PR DESCRIPTION
Summary: The `unpack` function defined in `snark0.ml` should work when the length of the argument passed is equal to `Field.size_in_bits`.

This PR also fixes the merkle_update proof example.