### PR TITLE
Fix #3 Add Dockerfile and build instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN sudo apt-get -y update && \
   sudo apt-get -y install build-essential cmake git libgmp3-dev libprocps4-dev python-markdown libboost-all-dev libssl-dev libffi-dev
 
 ADD . /home/opam/snarky
-RUN sudo chmod -R opam:opam /home/opam/snarky
+RUN sudo chown -R opam:opam /home/opam/snarky
 RUN opam update -y && \
   opam pin add -y snarky /home/opam/snarky
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM ocaml/opam:ubuntu
+
+RUN sudo apt-get -y update && \
+  sudo apt-get -y upgrade && \
+  sudo apt-get -y install build-essential cmake git libgmp3-dev libprocps4-dev python-markdown libboost-all-dev libssl-dev libffi-dev
+
+ADD . /home/opam/snarky
+RUN sudo chmod -R opam:opam /home/opam/snarky
+RUN opam update -y && \
+  opam pin add -y snarky /home/opam/snarky
+

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ be used in production systems.
 - Then, make sure you have [opam](https://opam.ocaml.org/doc/Install.html) installed.
 - Then, install `snarky` by running
 ```bash
-opam pin add snarky git@github.com:o1-labs/snarky.git
+opam pin add snarky https://github.com/o1-labs/snarky.git
 ```
 and answering yes to the prompts.
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,24 @@ The best place to get started learning how to use the library are the annotated 
 - [Election](examples/election/election_main.ml): shows how to use Snarky to verify an election was run honestly.
 - [Merkle update](examples/merkle_update/merkle_update.ml): a simple example updating a Merkle tree.
 
+
+## Docker
+
+- First install [Docker](https://docs.docker.com/install/)
+- Next clone this repo 
+- Then build the container by running
+```bash
+docker build . -t snarky
+```
+- Finally build and run the examples (the .exe is not windows specific in this case)
+```bash
+docker run -it snarky
+# cd snarky/examples/election
+# jbuilder build election_main.exe
+# ./_build/default/election_main.exe
+``` 
+
+
 ## Design
 
 The intention of this library is to allow writing snarks by writing what look


### PR DESCRIPTION
 This adds a Dockerfile that builds snarky based on the opam docker image and also updated the docs to show how to use it.

Also updates the README to use https and not ssh when installing from Github which is a problem when a developer does not have ssh access to your repo.