### PR TITLE
Add missing deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get -q update && \
         ocaml \
         opam \
         nano \
+        pkg-config \
         python-markdown && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
@@ -30,39 +31,29 @@ RUN useradd snarky -m
 # Create a volume we can work in. For initial build, we'll copy the local
 # context. To update the snarky library itself later, bind mount your updated
 # source over this and run the build again.
-RUN mkdir -p /source && chown -R snarky:snarky /source
+ADD . /source
+RUN chown -R snarky:snarky /source
 VOLUME ["/source"]
 
 # Be the new user before initializing OPAM.
 USER snarky
-WORKDIR /home/snarky/
 
 # Move to a newer version of OCaml and install dune/jbuilder.
 RUN opam init -y && \
     opam switch $OCAML_VERSION && \
     opam install dune
 
-# Actually copy the source files here, for caching reasons.
-ADD . /source
-
-USER snarky
+WORKDIR /source
 
 # Pin and install the dependencies.
-RUN cd /source && \
-    eval `opam config env` && \
+RUN eval `opam config env` && \
     opam pin add -y interval_union .
-RUN cd /source && \
-    eval `opam config env` && \
+
+RUN eval `opam config env` && \
     opam pin add -y bitstring_lib .
 
-RUN cd /source && \
-    eval `opam config env` && \
-    opam pin add -y snary .
-
-# Do the build!
 RUN eval `opam config env` && \
-    opam install -y snarky
+    opam pin add -y snarky .
 
 # Use a slight hack to always have the current OCaml environment.
 CMD ["/bin/bash", "--init-file", "/home/snarky/.opam/opam-init/init.sh"]
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,68 @@
+# Creates an environment for building both snarky and things that use snarky.
+FROM debian:buster-slim
+
+# Sometimes you need a specific version.
+ARG OCAML_VERSION=4.07.0
+
+# Install the libsnark dependencies and a bootstrap OCaml environment.
+RUN apt-get -q update && \
+    apt-get -q -y install \
+        build-essential \
+        cmake \
+        git \
+        libboost-dev \
+        libboost-program-options-dev \
+        libffi-dev \
+        libgmp-dev \
+        libgmp3-dev \
+        libprocps-dev \
+        libssl-dev \
+        ocaml \
+        opam \
+        nano \
+        python-markdown && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# We want to drop root! First, add a user to be and create a homedir.
+RUN useradd snarky -m
+
+# Create a volume we can work in. For initial build, we'll copy the local
+# context. To update the snarky library itself later, bind mount your updated
+# source over this and run the build again.
+RUN mkdir -p /source && chown -R snarky:snarky /source
+VOLUME ["/source"]
+
+# Be the new user before initializing OPAM.
+USER snarky
+WORKDIR /home/snarky/
+
+# Move to a newer version of OCaml and install dune/jbuilder.
+RUN opam init -y && \
+    opam switch $OCAML_VERSION && \
+    opam install dune
+
+# Actually copy the source files here, for caching reasons.
+ADD . /source
+
+USER snarky
+
+# Pin and install the dependencies.
+RUN cd /source && \
+    eval `opam config env` && \
+    opam pin add -y interval_union .
+RUN cd /source && \
+    eval `opam config env` && \
+    opam pin add -y bitstring_lib .
+
+RUN cd /source && \
+    eval `opam config env` && \
+    opam pin add -y snary .
+
+# Do the build!
+RUN eval `opam config env` && \
+    opam install -y snarky
+
+# Use a slight hack to always have the current OCaml environment.
+CMD ["/bin/bash", "--init-file", "/home/snarky/.opam/opam-init/init.sh"]
+

--- a/README.md
+++ b/README.md
@@ -8,15 +8,17 @@ Disclaimer: This code has not been thoroughly audited and should not
 be used in production systems.
 
 ## Getting started
-- First install libsnark's dependencies as specified [here](https://github.com/scipr-lab/libsnark#dependencies)
-- Then, make sure you have [opam](https://opam.ocaml.org/doc/Install.html) installed.
-- Then, install `snarky` by running
+
+- Install [Docker](https://www.docker.com/)
+
 ```bash
-opam pin add snarky git@github.com:o1-labs/snarky.git
+docker build -t snarky .
+
+docker run -it snarky
 ```
-and answering yes to the prompts.
 
 The best place to get started learning how to use the library are the annotated examples.
+- [Tutorial](examples/tutorial/tutorial.ml): teaches you the basics
 - [Election](examples/election/election_main.ml): shows how to use Snarky to verify an election was run honestly.
 - [Merkle update](examples/merkle_update/merkle_update.ml): a simple example updating a Merkle tree.
 

--- a/bitstring_lib.opam
+++ b/bitstring_lib.opam
@@ -1,0 +1,7 @@
+opam-version: "1.2"
+version: "0.1"
+build: [
+  ["jbuilder" "build" "--only" "bitstring_lib" "--root" "." "-j" jobs "@install"]
+]
+depends: [ "core" "ppx_deriving" "ppx_jane" ]
+

--- a/bitstring_lib/bitstring.ml
+++ b/bitstring_lib/bitstring.ml
@@ -1,0 +1,27 @@
+open Core_kernel
+
+module type S = sig
+  type 'a t = private 'a list
+
+  include Container.S1 with type 'a t := 'a t
+
+  val of_list : 'a list -> 'a t
+end
+
+module T = struct
+  include List
+
+  let of_list bs = bs
+end
+
+module Msb_first = struct
+  include T
+
+  let of_lsb_first = List.rev
+end
+
+module Lsb_first = struct
+  include T
+
+  let of_msb_first = List.rev
+end

--- a/bitstring_lib/bitstring.mli
+++ b/bitstring_lib/bitstring.mli
@@ -1,0 +1,21 @@
+open Core_kernel
+
+module type S = sig
+  type 'a t = private 'a list
+
+  include Container.S1 with type 'a t := 'a t
+
+  val of_list : 'a list -> 'a t
+end
+
+module rec Msb_first : sig
+  include S
+
+  val of_lsb_first : 'a Lsb_first.t -> 'a t
+end
+
+and Lsb_first : sig
+  include S
+
+  val of_msb_first : 'a Lsb_first.t -> 'a t
+end

--- a/bitstring_lib/jbuild
+++ b/bitstring_lib/jbuild
@@ -1,0 +1,13 @@
+(jbuild_version 1)
+
+(library
+ ((name bitstring_lib)
+  (public_name bitstring_lib)
+  (flags (:standard -short-paths -warn-error -58))
+  (library_flags (-linkall))
+  (inline_tests)
+  (libraries
+    ( core_kernel ))
+  (preprocess (pps (ppx_jane ppx_deriving.eq)))
+  (synopsis "Bitstring library")))
+

--- a/interval_union.opam
+++ b/interval_union.opam
@@ -1,0 +1,7 @@
+opam-version: "1.2"
+version: "0.1"
+build: [
+  ["jbuilder" "build" "--only" "interval_union" "--root" "." "-j" jobs "@install"]
+]
+depends: [ "core" "ppx_deriving" "ppx_jane" ]
+

--- a/interval_union/interval_union.ml
+++ b/interval_union/interval_union.ml
@@ -1,0 +1,139 @@
+open Core_kernel
+
+module Interval = struct
+  (* Semantically (a, b) : t is the closed interval [a, b] *)
+  type t = int * int [@@deriving eq, sexp]
+
+  let before (_, b1) (a2, _) = b1 <= a2
+
+  let gen_from start =
+    let open Quickcheck.Generator.Let_syntax in
+    let%bind x = Int.gen_incl start Int.max_value_30_bits in
+    let%map y = Int.gen_incl x Int.max_value_30_bits in
+    (x, y)
+
+  let gen =
+    let open Quickcheck.Generator.Let_syntax in
+    let%bind x = Int.gen_incl Int.min_value Int.max_value_30_bits in
+    let%map y = Int.gen_incl x Int.max_value_30_bits in
+    (x, y)
+
+  let%test_unit "gen is correct" =
+    Quickcheck.test gen ~f:(fun (x, y) -> assert (x <= y))
+end
+
+(* Simplest possible implementation. Should be an increasing list of
+   disjoint intervals. 
+   Semantically is the set of ints corresponding to the union of these 
+   ntervals. *)
+type t = Interval.t list [@@deriving eq, sexp]
+
+let empty : t = []
+
+let union_intervals_exn (a1, b1) (a2, b2) =
+  let ( = ) = Int.( = ) in
+  if b1 = a2 then `Combine (a1, b2)
+  else if b2 = a1 then `Combine (a2, b1)
+  else if b1 < a2 then `Disjoint_ordered
+  else if b2 < a1 then `Disjoint_inverted
+  else failwith "Intervals not disjoint"
+
+let of_interval i = [i]
+
+let rec canonicalize = function
+  | [] -> []
+  | [i1] -> [i1]
+  | (a1, a2) :: (a3, a4) :: t ->
+      if a2 = a3 then canonicalize ((a1, a4) :: t)
+      else (a1, a2) :: canonicalize ((a3, a4) :: t)
+
+let rec disjoint_union_exn t1 t2 =
+  match (t1, t2) with
+  | t, [] | [], t -> t
+  | i1 :: t1', i2 :: t2' ->
+    match union_intervals_exn i1 i2 with
+    | `Combine (a, b) -> (a, b) :: disjoint_union_exn t1' t2'
+    | `Disjoint_ordered -> i1 :: disjoint_union_exn t1' t2
+    | `Disjoint_inverted -> i2 :: disjoint_union_exn t1 t2'
+
+let disjoint_union_exn t1 t2 = canonicalize (disjoint_union_exn t1 t2)
+
+let rec disjoint t1 t2 =
+  match (t1, t2) with
+  | _, [] | [], _ -> true
+  | i1 :: t1', i2 :: t2' ->
+      if Interval.before i1 i2 then disjoint t1' t2
+      else if Interval.before i2 i1 then disjoint t1 t2'
+      else false
+
+(* Someday: inefficient *)
+let of_intervals_exn is =
+  match is with
+  | [] -> []
+  | i :: is ->
+      List.fold is ~init:(of_interval i) ~f:(fun acc x ->
+          disjoint_union_exn (of_interval x) acc )
+
+let to_interval = function
+  | [i] -> Ok i
+  | ([] | _ :: _ :: _) as xs ->
+      Or_error.error_string
+        (Printf.sprintf
+           !"Interval_union.to_interval: was not an interval %{sexp: \
+             Interval.t list}\n"
+           xs)
+
+let invariant t =
+  let rec go = function
+    | [(a, b)] -> assert (a <= b)
+    | [] -> ()
+    | (a1, b1) :: ((a2, _) :: _ as t) ->
+        assert (a1 <= b1) ;
+        assert (b1 < a2) ;
+        go t
+  in
+  go t
+
+let gen_from ?(min_size= 0) start =
+  let open Quickcheck.Generator.Let_syntax in
+  let rec go acc size start =
+    if size = 0 then return (of_intervals_exn (List.rev acc))
+    else
+      let%bind ((_, y) as i) = Interval.gen_from start in
+      go (i :: acc) (size - 1) y
+  in
+  let%bind size = Quickcheck.Generator.small_positive_int in
+  go [] (min_size + size) start
+
+let gen = gen_from Int.min_value
+
+let%test_unit "check invariant" = Quickcheck.test gen ~f:invariant
+
+let gen_disjoint_pair =
+  let open Quickcheck.Generator.Let_syntax in
+  let%bind t1 = gen in
+  let y = List.last_exn t1 |> snd in
+  let%map t2 = gen_from y in
+  (t1, t2)
+
+let%test_unit "canonicalize" = assert (canonicalize [(1, 2); (2, 3)] = [(1, 3)])
+
+let%test_unit "disjoint union doesn't care about order" =
+  Quickcheck.test gen_disjoint_pair ~f:(fun (a, b) ->
+      assert (disjoint_union_exn a b = disjoint_union_exn b a) )
+
+let%test_unit "check invariant on disjoint union" =
+  Quickcheck.test gen_disjoint_pair ~f:(fun (a, b) ->
+      invariant (disjoint_union_exn a b) )
+
+let%test_unit "disjoint_union works with holes" =
+  let gen =
+    let open Quickcheck.Generator.Let_syntax in
+    let s = 1000000 in
+    let%bind y0 = Int.gen_incl 0 s in
+    let%bind y1 = Int.gen_incl (y0 + 1) (y0 + s) in
+    let%bind y2 = Int.gen_incl (y1 + 1) (y1 + s) in
+    let%bind y3 = Int.gen_incl (y2 + 1) (y2 + s) in
+    return (of_interval (y1, y2), of_intervals_exn [(y0, y1); (y2, y3)])
+  in
+  Quickcheck.test gen ~f:(fun (x, y) -> invariant (disjoint_union_exn x y))

--- a/interval_union/interval_union.mli
+++ b/interval_union/interval_union.mli
@@ -1,0 +1,19 @@
+open Core_kernel
+
+module Interval : sig
+  type t = int * int [@@deriving eq, sexp]
+end
+
+type t [@@deriving eq, sexp]
+
+val empty : t
+
+val of_interval : Interval.t -> t
+
+val of_intervals_exn : Interval.t list -> t
+
+val disjoint_union_exn : t -> t -> t
+
+val disjoint : t -> t -> bool
+
+val to_interval : t -> Interval.t Or_error.t

--- a/interval_union/jbuild
+++ b/interval_union/jbuild
@@ -1,0 +1,13 @@
+(jbuild_version 1)
+
+(library
+ ((name interval_union)
+  (public_name interval_union)
+  (flags (:standard -short-paths -warn-error -58))
+  (library_flags (-linkall))
+  (inline_tests)
+  (libraries
+    ( core_kernel ))
+  (preprocess (pps (ppx_jane ppx_deriving.eq)))
+  (synopsis "Union of intervals data structure")))
+

--- a/snarky.opam
+++ b/snarky.opam
@@ -16,6 +16,8 @@ depends: [
   "ppx_driver"
   "ppx_jane"
   "bignum"
+  "bitstring_lib"
+  "interval_union"
   "jbuilder"                {build & >= "1.0+beta12"}
 ]
 available: [ ocaml-version >= "4.04.1" ]


### PR DESCRIPTION
As noted in #18 , I forgot to include two libraries that we made dependencies of snarky since the last update.

I included them here (`interval_union` and `bitstring_lib`)

I included the Dockerfile @gtank created and modified it to include the two libraries, but I'm getting a strange error in the docker container when I try to build it.

I spent a bit tonight trying to get the Dockerfile to build but I'm not super familiar with opam pinning, just local dune builds. I'm getting a weird error what seems like the end of the build and seems unrelated to the actual ocaml code.

Can anyone help me get this work? cc @nholland94 