### PR TITLE
Dockerfile: fix typo, missing pkg-config dep, and permissions issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get -q update && \
         ocaml \
         opam \
         nano \
+        pkg-config \
         python-markdown && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
@@ -30,39 +31,29 @@ RUN useradd snarky -m
 # Create a volume we can work in. For initial build, we'll copy the local
 # context. To update the snarky library itself later, bind mount your updated
 # source over this and run the build again.
-RUN mkdir -p /source && chown -R snarky:snarky /source
+ADD . /source
+RUN chown -R snarky:snarky /source
 VOLUME ["/source"]
 
 # Be the new user before initializing OPAM.
 USER snarky
-WORKDIR /home/snarky/
 
 # Move to a newer version of OCaml and install dune/jbuilder.
 RUN opam init -y && \
     opam switch $OCAML_VERSION && \
     opam install dune
 
-# Actually copy the source files here, for caching reasons.
-ADD . /source
-
-USER snarky
+WORKDIR /source
 
 # Pin and install the dependencies.
-RUN cd /source && \
-    eval `opam config env` && \
+RUN eval `opam config env` && \
     opam pin add -y interval_union .
-RUN cd /source && \
-    eval `opam config env` && \
+
+RUN eval `opam config env` && \
     opam pin add -y bitstring_lib .
 
-RUN cd /source && \
-    eval `opam config env` && \
-    opam pin add -y snary .
-
-# Do the build!
 RUN eval `opam config env` && \
-    opam install -y snarky
+    opam pin add -y snarky .
 
 # Use a slight hack to always have the current OCaml environment.
 CMD ["/bin/bash", "--init-file", "/home/snarky/.opam/opam-init/init.sh"]
-


### PR DESCRIPTION
This container can build snarky! Modification of #19 to fix lingering problems: `bitstring_lib` wanted pkg-config, and beyond that my build directory setup ended up being owned by root.

Closes #18 and resolves #3. The update from the private repo closes #8. This implicitly addresses #5, #12, #14, and #16 too but they'll need their own fixes for non-containerized builds.