### PR TITLE
Pull everything out of Snarky functors that doesn't depend on Backend

### DIFF
--- a/src/as_prover.ml
+++ b/src/as_prover.ml
@@ -2,8 +2,6 @@ open Core_kernel
 
 type ('a, 'e, 's) t = ('a, 'e, 's) As_prover0.t
 
-type ('a, 'e, 's) as_prover = ('a, 'e, 's) t
-
 module type S = sig
   type var
 
@@ -32,12 +30,12 @@ module type S = sig
     type 'a t
  
     val create :
-         ('a, env, 'prover_state) as_prover
+         ('a, env, 'prover_state) As_prover0.t
       -> ('a t, 'prover_state, field, var, 'sys) Checked.t
  
-    val get : 'a t -> ('a, env, _) as_prover
+    val get : 'a t -> ('a, env, _) As_prover0.t
  
-    val set : 'a t -> 'a -> (unit, env, _) as_prover
+    val set : 'a t -> 'a -> (unit, env, _) As_prover0.t
   end
 end
 

--- a/src/as_prover.ml
+++ b/src/as_prover.ml
@@ -1,6 +1,8 @@
 open Core_kernel
 
-type ('a, 'e, 's) t = 'e -> 's -> 's * 'a
+type ('a, 'e, 's) t = ('a, 'e, 's) As_prover0.t
+
+type ('a, 'e, 's) as_prover = ('a, 'e, 's) t
 
 module type S = sig
   type var
@@ -22,36 +24,46 @@ module type S = sig
   val map2 : ('a, 's) t -> ('b, 's) t -> f:('a -> 'b -> 'c) -> ('c, 's) t
 
   val read_var : var -> (field, 's) t
+
+  val read :
+    ('var, 'value, field, var, 'sys) Typ.t -> 'var -> ('value, 'prover_state) t
+
+  module Ref : sig
+    type 'a t
+ 
+    val create :
+         ('a, env, 'prover_state) as_prover
+      -> ('a t, 'prover_state, field, var, 'sys) Checked.t
+ 
+    val get : 'a t -> ('a, env, _) as_prover
+ 
+    val set : 'a t -> 'a -> (unit, env, _) as_prover
+  end
 end
 
 module T = struct
-  let map t ~f tbl s =
-    let s', x = t tbl s in
-    (s', f x)
-
-  let bind t ~f tbl s =
-    let s', x = t tbl s in
-    f x tbl s'
-
-  let return x _ s = (s, x)
-
-  let run t tbl s = t tbl s
-
-  let get_state _tbl s = (s, s)
-
-  let read_var v tbl s = (s, tbl v)
-
-  let set_state s tbl _ = (s, ())
-
-  let modify_state f _tbl s = (f s, ())
-
-  let map2 x y ~f tbl s =
-    let s, x = x tbl s in
-    let s, y = y tbl s in
-    (s, f x y)
-
-  let read_var (v : 'var) : ('field, 'var -> 'field, 's) t =
-   fun tbl s -> (s, tbl v)
+  include As_prover0.T
+ 
+  let read ({read; _} : ('var, 'value, 'field, 'cvar, 'sys) Typ.t) (var : 'var)
+      : ('value, 'cvar -> 'field, 'prover_state) t =
+   fun tbl s -> (s, Typ_monads.Read.run (read var) tbl)
+ 
+  module Ref = struct
+    type 'a t = 'a option ref
+ 
+    let create (x : ('a, 'cvar -> 'field, 's) As_prover0.t) :
+        ('a t, 's, 'field, 'cvar, 'sys) Checked.t =
+      let r = ref None in
+      let open Checked in
+      let%map () =
+        Checked.as_prover (As_prover0.map x ~f:(fun x -> r := Some x))
+      in
+      r
+ 
+    let get (r : 'a t) _tbl s = (s, Option.value_exn !r)
+ 
+    let set (r : 'a t) x _tbl s = (s, (r := Some x))
+  end
 end
 
 module Make (Env : sig

--- a/src/as_prover.mli
+++ b/src/as_prover.mli
@@ -2,8 +2,6 @@ open Core_kernel
 
 include Monad.S3 with type ('a, 'e, 's) t = 'e -> 's -> 's * 'a
 
-type ('a, 'e, 's) as_prover = ('a, 'e, 's) t
-
 val run : ('a, 'e, 's) t -> 'e -> 's -> 's * 'a
 
 module type S = sig
@@ -34,12 +32,12 @@ module type S = sig
     type 'a t
 
     val create :
-         ('a, env, 'prover_state) as_prover
+         ('a, env, 'prover_state) As_prover0.t
       -> ('a t, 'prover_state, field, var, 'sys) Checked.t
 
-    val get : 'a t -> ('a, env, _) as_prover
+    val get : 'a t -> ('a, env, _) As_prover0.t
 
-    val set : 'a t -> 'a -> (unit, env, _) as_prover
+    val set : 'a t -> 'a -> (unit, env, _) As_prover0.t
   end
 end
 

--- a/src/as_prover.mli
+++ b/src/as_prover.mli
@@ -2,6 +2,8 @@ open Core_kernel
 
 include Monad.S3 with type ('a, 'e, 's) t = 'e -> 's -> 's * 'a
 
+type ('a, 'e, 's) as_prover = ('a, 'e, 's) t
+
 val run : ('a, 'e, 's) t -> 'e -> 's -> 's * 'a
 
 module type S = sig
@@ -24,6 +26,21 @@ module type S = sig
   val map2 : ('a, 's) t -> ('b, 's) t -> f:('a -> 'b -> 'c) -> ('c, 's) t
 
   val read_var : var -> (field, 's) t
+
+  val read :
+    ('var, 'value, field, var, 'sys) Typ.t -> 'var -> ('value, 'prover_state) t
+
+  module Ref : sig
+    type 'a t
+
+    val create :
+         ('a, env, 'prover_state) as_prover
+      -> ('a t, 'prover_state, field, var, 'sys) Checked.t
+
+    val get : 'a t -> ('a, env, _) as_prover
+
+    val set : 'a t -> 'a -> (unit, env, _) as_prover
+  end
 end
 
 module Make (Env : sig

--- a/src/as_prover.mli
+++ b/src/as_prover.mli
@@ -5,7 +5,11 @@ include Monad.S3 with type ('a, 'e, 's) t = 'e -> 's -> 's * 'a
 val run : ('a, 'e, 's) t -> 'e -> 's -> 's * 'a
 
 module type S = sig
-  type env
+  type var
+
+  type field
+
+  type env = var -> field
 
   include Monad.S2 with type ('a, 's) t = ('a, env, 's) t
 
@@ -18,8 +22,12 @@ module type S = sig
   val modify_state : ('s -> 's) -> (unit, 's) t
 
   val map2 : ('a, 's) t -> ('b, 's) t -> f:('a -> 'b -> 'c) -> ('c, 's) t
+
+  val read_var : var -> (field, 's) t
 end
 
 module Make (Env : sig
-  type t
-end) : S with type env := Env.t
+  type var
+
+  type field
+end) : S with type var := Env.var with type field := Env.field

--- a/src/as_prover0.ml
+++ b/src/as_prover0.ml
@@ -1,0 +1,45 @@
+open Core_kernel
+
+type ('a, 'e, 's) t = 'e -> 's -> 's * 'a
+
+module T = struct
+  let map t ~f tbl s =
+    let s', x = t tbl s in
+    (s', f x)
+
+  let bind t ~f tbl s =
+    let s', x = t tbl s in
+    f x tbl s'
+
+  let return x _ s = (s, x)
+
+  let run t tbl s = t tbl s
+
+  let get_state _tbl s = (s, s)
+
+  let read_var v tbl s = (s, tbl v)
+
+  let set_state s tbl _ = (s, ())
+
+  let modify_state f _tbl s = (f s, ())
+
+  let map2 x y ~f tbl s =
+    let s, x = x tbl s in
+    let s, y = y tbl s in
+    (s, f x y)
+
+  let read_var (v : 'var) : ('field, 'var -> 'field, 's) t =
+   fun tbl s -> (s, tbl v)
+end
+
+include T
+
+include Monad.Make3 (struct
+  type nonrec ('a, 'e, 's) t = ('a, 'e, 's) t
+
+  let map = `Custom map
+
+  let bind = bind
+
+  let return = return
+end)

--- a/src/checked.ml
+++ b/src/checked.ml
@@ -1,0 +1,47 @@
+type ('a, 's, 'field, 'var, 'sys) t =
+  ('a, 's, 'field, 'var, 'sys) Types.Checked.t
+
+module T = struct
+  open Types.Checked
+
+  let return x = Pure x
+
+  let as_prover x = As_prover (x, return ())
+
+  let rec map : type s a b field var sys.
+      (a, s, field, var, sys) t -> f:(a -> b) -> (b, s, field, var, sys) t =
+   fun t ~f ->
+    match t with
+    | Pure x -> Pure (f x)
+    | With_label (s, t, k) -> With_label (s, t, fun b -> map (k b) ~f)
+    | With_constraint_system (c, k) -> With_constraint_system (c, map k ~f)
+    | As_prover (x, k) -> As_prover (x, map k ~f)
+    | Add_constraint (c, t1) -> Add_constraint (c, map t1 ~f)
+    | With_state (p, and_then, t_sub, k) ->
+        With_state (p, and_then, t_sub, fun b -> map (k b) ~f)
+    | With_handler (h, t, k) -> With_handler (h, t, fun b -> map (k b) ~f)
+    | Clear_handler (t, k) -> Clear_handler (t, fun b -> map (k b) ~f)
+    | Exists (typ, c, k) -> Exists (typ, c, fun v -> map (k v) ~f)
+    | Next_auxiliary k -> Next_auxiliary (fun x -> map (k x) ~f)
+
+  let map = `Custom map
+
+  let rec bind : type s a b field var sys.
+         (a, s, field, var, sys) t
+      -> f:(a -> (b, s, field, var, sys) t)
+      -> (b, s, field, var, sys) t =
+   fun t ~f ->
+    match t with
+    | Pure x -> f x
+    | With_label (s, t, k) -> With_label (s, t, fun b -> bind (k b) ~f)
+    | With_constraint_system (c, k) -> With_constraint_system (c, bind k ~f)
+    | As_prover (x, k) -> As_prover (x, bind k ~f)
+    (* Someday: This case is probably a performance bug *)
+    | Add_constraint (c, t1) -> Add_constraint (c, bind t1 ~f)
+    | With_state (p, and_then, t_sub, k) ->
+        With_state (p, and_then, t_sub, fun b -> bind (k b) ~f)
+    | With_handler (h, t, k) -> With_handler (h, t, fun b -> bind (k b) ~f)
+    | Clear_handler (t, k) -> Clear_handler (t, fun b -> bind (k b) ~f)
+    | Exists (typ, c, k) -> Exists (typ, c, fun v -> bind (k v) ~f)
+    | Next_auxiliary k -> Next_auxiliary (fun x -> bind (k x) ~f)
+end

--- a/src/checked.ml
+++ b/src/checked.ml
@@ -52,6 +52,8 @@ let rec all_unit = function
   | t :: ts -> T0.bind t ~f:(fun () -> all_unit ts)
 
 module Let_syntax = struct
+  let return = T0.return
+
   let bind = T0.bind
 
   let map =
@@ -59,7 +61,23 @@ module Let_syntax = struct
     | `Define_using_bind -> fun ma ~f -> bind ma ~f:(fun a -> T0.return (f a))
     | `Custom x -> x
 
+  let ( >>= ) t f = bind t ~f
+
+  let ( >>| ) t f = map t ~f
+
   let both a b = bind a ~f:(fun a -> map b ~f:(fun b -> (a, b)))
+
+  module Let_syntax = struct
+    let return = return
+
+    let bind = bind
+
+    let map = map
+
+    let both a b = a >>= fun a -> b >>| fun b -> (a, b)
+
+    module Open_on_rhs = struct end
+  end
 end
 
 module T = struct

--- a/src/checked.ml
+++ b/src/checked.ml
@@ -69,8 +69,6 @@ module T = struct
       (r : ('value Request.t, 'cvar -> 'field, 's) As_prover.t) =
     Exists (typ, Request r, fun h -> return (Handle.var h))
 
-  (*let perform req = request_witness Typ.unit req*)
-
   let request ?such_that typ r =
     match such_that with
     | None -> request_witness typ (As_prover.return r)
@@ -136,4 +134,8 @@ module T = struct
       Add_constraint
         ( map_concat_rev ~f:(fun c -> Constraint.override_label c label) cs
         , return () )
+
+    let assert_equal ?label x y = assert_ (Constraint.equal ?label x y)
 end
+
+include T

--- a/src/checked.ml
+++ b/src/checked.ml
@@ -1,9 +1,10 @@
+open Core_kernel
+open Types.Checked
+
 type ('a, 's, 'field, 'var, 'sys) t =
   ('a, 's, 'field, 'var, 'sys) Types.Checked.t
 
-module T = struct
-  open Types.Checked
-
+module T0 = struct
   let return x = Pure x
 
   let as_prover x = As_prover (x, return ())
@@ -44,4 +45,95 @@ module T = struct
     | Clear_handler (t, k) -> Clear_handler (t, fun b -> bind (k b) ~f)
     | Exists (typ, c, k) -> Exists (typ, c, fun v -> bind (k v) ~f)
     | Next_auxiliary k -> Next_auxiliary (fun x -> bind (k x) ~f)
+end
+
+let rec all_unit = function
+  | [] -> T0.return ()
+  | t :: ts -> T0.bind t ~f:(fun () -> all_unit ts)
+
+module Let_syntax = struct
+  let bind = T0.bind
+
+  let map =
+    match T0.map with
+    | `Define_using_bind -> fun ma ~f -> bind ma ~f:(fun a -> T0.return (f a))
+    | `Custom x -> x
+
+  let both a b = bind a ~f:(fun a -> map b ~f:(fun b -> (a, b)))
+end
+
+module T = struct
+  include T0
+
+  let request_witness (typ : ('var, 'value, 'field, 'cvar, 'sys) Types.Typ.t)
+      (r : ('value Request.t, 'cvar -> 'field, 's) As_prover.t) =
+    Exists (typ, Request r, fun h -> return (Handle.var h))
+
+  (*let perform req = request_witness Typ.unit req*)
+
+  let request ?such_that typ r =
+    match such_that with
+    | None -> request_witness typ (As_prover.return r)
+    | Some such_that ->
+        let open Let_syntax in
+        let%bind x = request_witness typ (As_prover.return r) in
+        let%map () = such_that x in
+        x
+
+  let exists ?request ?compute typ =
+    let provider =
+      let request =
+        Option.value request ~default:(As_prover.return Request.Fail)
+      in
+      match compute with
+      | None -> Provider.Request request
+      | Some c -> Provider.Both (request, c)
+    in
+    Exists (typ, provider, fun h -> return (Handle.var h))
+
+  type response = Request.response
+
+  let unhandled = Request.unhandled
+
+  type request = Request.request =
+    | With :
+        { request: 'a Request.t
+        ; respond: 'a Request.Response.t -> response }
+        -> request
+
+  let handle t k = With_handler (Request.Handler.create_single k, t, return)
+
+  let next_auxiliary = Next_auxiliary return
+
+  let with_constraint_system f = With_constraint_system (f, return ())
+
+  let with_label s t = With_label (s, t, return)
+
+  let do_nothing _ = As_prover.return ()
+
+  let with_state ?(and_then = do_nothing) f sub =
+    With_state (f, and_then, sub, return)
+
+  let assert_ ?label c =
+    Add_constraint
+      (List.map c ~f:(fun c -> Constraint.override_label c label), return ())
+
+  let assert_r1cs ?label a b c = assert_ (Constraint.r1cs ?label a b c)
+
+  let assert_square ?label a c = assert_ (Constraint.square ?label a c)
+
+  let assert_all =
+    let map_concat_rev xss ~f =
+      let rec go acc xs xss =
+        match (xs, xss) with
+        | [], [] -> acc
+        | [], xs :: xss -> go acc xs xss
+        | x :: xs, _ -> go (f x :: acc) xs xss
+      in
+      go [] [] xss
+    in
+    fun ?label cs ->
+      Add_constraint
+        ( map_concat_rev ~f:(fun c -> Constraint.override_label c label) cs
+        , return () )
 end

--- a/src/checked.ml
+++ b/src/checked.ml
@@ -66,22 +66,22 @@ module T = struct
   include T0
 
   let request_witness (typ : ('var, 'value, 'field, 'cvar, 'sys) Types.Typ.t)
-      (r : ('value Request.t, 'cvar -> 'field, 's) As_prover.t) =
+      (r : ('value Request.t, 'cvar -> 'field, 's) As_prover0.t) =
     Exists (typ, Request r, fun h -> return (Handle.var h))
 
   let request ?such_that typ r =
     match such_that with
-    | None -> request_witness typ (As_prover.return r)
+    | None -> request_witness typ (As_prover0.return r)
     | Some such_that ->
         let open Let_syntax in
-        let%bind x = request_witness typ (As_prover.return r) in
+        let%bind x = request_witness typ (As_prover0.return r) in
         let%map () = such_that x in
         x
 
   let exists ?request ?compute typ =
     let provider =
       let request =
-        Option.value request ~default:(As_prover.return Request.Fail)
+        Option.value request ~default:(As_prover0.return Request.Fail)
       in
       match compute with
       | None -> Provider.Request request
@@ -107,7 +107,7 @@ module T = struct
 
   let with_label s t = With_label (s, t, return)
 
-  let do_nothing _ = As_prover.return ()
+  let do_nothing _ = As_prover0.return ()
 
   let with_state ?(and_then = do_nothing) f sub =
     With_state (f, and_then, sub, return)

--- a/src/constraint.ml
+++ b/src/constraint.ml
@@ -11,3 +11,24 @@ type 'v basic_with_annotation = {basic: 'v basic; annotation: string option}
 [@@deriving sexp]
 
 type 'v t = 'v basic_with_annotation list [@@deriving sexp]
+
+module T = struct
+  let create_basic ?label basic = {basic; annotation= label}
+
+  let override_label {basic; annotation= a} label_opt =
+    {basic; annotation= (match label_opt with Some x -> Some x | None -> a)}
+
+  let equal ?label x y = [create_basic ?label (Equal (x, y))]
+
+  let boolean ?label x = [create_basic ?label (Boolean x)]
+
+  let r1cs ?label a b c = [create_basic ?label (R1CS (a, b, c))]
+
+  let square ?label a c = [create_basic ?label (Square (a, c))]
+
+  let annotation (t : 'a t) =
+    String.concat ~sep:"; "
+      (List.filter_map t ~f:(fun {annotation; _} -> annotation))
+end
+
+include T

--- a/src/handle.ml
+++ b/src/handle.ml
@@ -2,7 +2,7 @@ open Core_kernel
 
 type ('var, 'value) t = {var: 'var; value: 'value option}
 
-let value (t : ('var, 'value) t) : ('value, 'cvar -> 'field, 's) As_prover.t =
+let value (t : ('var, 'value) t) : ('value, 'cvar -> 'field, 's) As_prover0.t =
  fun _ s -> (s, Option.value_exn t.value)
 
 let var {var; _} = var

--- a/src/handle.ml
+++ b/src/handle.ml
@@ -1,1 +1,8 @@
+open Core_kernel
+
 type ('var, 'value) t = {var: 'var; value: 'value option}
+
+let value (t : ('var, 'value) t) : ('value, 'cvar -> 'field, 's) As_prover.t =
+ fun _ s -> (s, Option.value_exn t.value)
+
+let var {var; _} = var

--- a/src/provider.ml
+++ b/src/provider.ml
@@ -1,16 +1,16 @@
 type ('a, 'e, 's) t =
-  | Request of ('a Request.t, 'e, 's) As_prover.t
-  | Compute of ('a, 'e, 's) As_prover.t
-  | Both of ('a Request.t, 'e, 's) As_prover.t * ('a, 'e, 's) As_prover.t
+  | Request of ('a Request.t, 'e, 's) As_prover0.t
+  | Compute of ('a, 'e, 's) As_prover0.t
+  | Both of ('a Request.t, 'e, 's) As_prover0.t * ('a, 'e, 's) As_prover0.t
 
 let run t tbl s (handler : Request.Handler.t) =
   match t with
   | Request rc ->
-      let s', r = As_prover.run rc tbl s in
+      let s', r = As_prover0.run rc tbl s in
       (s', Request.Handler.run handler r)
-  | Compute c -> As_prover.run c tbl s
+  | Compute c -> As_prover0.run c tbl s
   | Both (rc, c) -> (
-      let s', r = As_prover.run rc tbl s in
+      let s', r = As_prover0.run rc tbl s in
       match Request.Handler.run handler r with
-      | exception _ -> As_prover.run c tbl s
+      | exception _ -> As_prover0.run c tbl s
       | x -> (s', x) )

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -268,10 +268,10 @@ module Make_basic (Backend : Backend_intf.S) = struct
 
   module As_prover0 = struct
     include As_prover.Make (struct
-      type t = Cvar.t -> Field.t
-    end)
+      type var = Cvar.t
 
-    let read_var (v : Cvar.t) : (Field.t, 's) t = fun tbl s -> (s, tbl v)
+      type field = Field.t
+    end)
   end
 
   module Handler = struct

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -283,44 +283,9 @@ module Make_basic (Backend : Backend_intf.S) = struct
       open Types.Checked
 
       type ('a, 's) t =
-        ('a, 's, Field.t, Cvar.t, R1CS_constraint_system.t) Types.Checked.t
+        ('a, 's, Field.t, Cvar.t, R1CS_constraint_system.t) Checked.t
 
-      let return x = Pure x
-
-      let as_prover x = As_prover (x, return ())
-
-      let rec map : type s a b. (a, s) t -> f:(a -> b) -> (b, s) t =
-       fun t ~f ->
-        match t with
-        | Pure x -> Pure (f x)
-        | With_label (s, t, k) -> With_label (s, t, fun b -> map (k b) ~f)
-        | With_constraint_system (c, k) -> With_constraint_system (c, map k ~f)
-        | As_prover (x, k) -> As_prover (x, map k ~f)
-        | Add_constraint (c, t1) -> Add_constraint (c, map t1 ~f)
-        | With_state (p, and_then, t_sub, k) ->
-            With_state (p, and_then, t_sub, fun b -> map (k b) ~f)
-        | With_handler (h, t, k) -> With_handler (h, t, fun b -> map (k b) ~f)
-        | Clear_handler (t, k) -> Clear_handler (t, fun b -> map (k b) ~f)
-        | Exists (typ, c, k) -> Exists (typ, c, fun v -> map (k v) ~f)
-        | Next_auxiliary k -> Next_auxiliary (fun x -> map (k x) ~f)
-
-      let map = `Custom map
-
-      let rec bind : type s a b. (a, s) t -> f:(a -> (b, s) t) -> (b, s) t =
-       fun t ~f ->
-        match t with
-        | Pure x -> f x
-        | With_label (s, t, k) -> With_label (s, t, fun b -> bind (k b) ~f)
-        | With_constraint_system (c, k) -> With_constraint_system (c, bind k ~f)
-        | As_prover (x, k) -> As_prover (x, bind k ~f)
-        (* Someday: This case is probably a performance bug *)
-        | Add_constraint (c, t1) -> Add_constraint (c, bind t1 ~f)
-        | With_state (p, and_then, t_sub, k) ->
-            With_state (p, and_then, t_sub, fun b -> bind (k b) ~f)
-        | With_handler (h, t, k) -> With_handler (h, t, fun b -> bind (k b) ~f)
-        | Clear_handler (t, k) -> Clear_handler (t, fun b -> bind (k b) ~f)
-        | Exists (typ, c, k) -> Exists (typ, c, fun v -> bind (k v) ~f)
-        | Next_auxiliary k -> Next_auxiliary (fun x -> bind (k x) ~f)
+      include Checked.T
     end
 
     include T

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -142,6 +142,7 @@ module Make_basic (Backend : Backend_intf.S) = struct
 
   module Constraint = struct
     open Constraint
+    include Constraint.T
 
     type basic = Cvar.t Constraint.basic
 
@@ -178,19 +179,6 @@ module Make_basic (Backend : Backend_intf.S) = struct
           R1CS_constraint.set_is_square constr false ;
           constr
 
-    let create_basic ?label basic = {basic; annotation= label}
-
-    let override_label {basic; annotation= a} label_opt =
-      {basic; annotation= (match label_opt with Some x -> Some x | None -> a)}
-
-    let equal ?label x y = [create_basic ?label (Equal (x, y))]
-
-    let boolean ?label x = [create_basic ?label (Boolean x)]
-
-    let r1cs ?label a b c = [create_basic ?label (R1CS (a, b, c))]
-
-    let square ?label a c = [create_basic ?label (Square (a, c))]
-
     let stack_to_string = String.concat ~sep:"\n"
 
     let add ~stack (t : t) system =
@@ -212,10 +200,6 @@ module Make_basic (Backend : Backend_intf.S) = struct
 
     let eval t get_value =
       List.for_all t ~f:(fun {basic; _} -> eval_basic basic get_value)
-
-    let annotation (t : t) =
-      String.concat ~sep:"; "
-        (List.filter_map t ~f:(fun {annotation; _} -> annotation))
   end
 
   module Typ_monads = struct

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -606,11 +606,6 @@ module Make_basic (Backend : Backend_intf.S) = struct
 
   module Handle = struct
     include Handle
-
-    let value (t : ('var, 'value) t) : ('value, 's) As_prover0.t =
-     fun _ s -> (s, Option.value_exn t.value)
-
-    let var {var; _} = var
   end
 
   module Checked = struct

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -279,6 +279,7 @@ module Make_basic (Backend : Backend_intf.S) = struct
   module Typ = struct
     open Types.Typ
     include Typ_monads
+    include Typ.T
 
     type ('var, 'value) t =
       ('var, 'value, Field.t, Cvar.t, R1CS_constraint_system.t) Types.Typ.t
@@ -303,32 +304,9 @@ module Make_basic (Backend : Backend_intf.S) = struct
         go 0 t
     end
 
-    let store ({store; _} : ('var, 'value) t) (x : 'value) : 'var Store.t =
-      store x
+    let unit : (unit, unit) t = unit ()
 
-    let read ({read; _} : ('var, 'value) t) (v : 'var) : 'value Read.t = read v
-
-    let alloc ({alloc; _} : ('var, 'value) t) : 'var Alloc.t = alloc
-
-    let check ({check; _} : ('var, 'value) t) (v : 'var) :
-        (unit, 's) Checked0.t =
-      let do_nothing : (unit, _) As_prover0.t = fun _ s -> (s, ()) in
-      With_state (do_nothing, (fun () -> do_nothing), check v, Checked0.return)
-
-    let unit : (unit, unit) t =
-      let s = Store.return () in
-      let r = Read.return () in
-      let c = Checked0.return () in
-      { store= (fun () -> s)
-      ; read= (fun () -> r)
-      ; check= (fun () -> c)
-      ; alloc= Alloc.return () }
-
-    let field : (Cvar.t, Field.t) t =
-      { store= Store.store
-      ; read= Read.read
-      ; alloc= Alloc.alloc
-      ; check= (fun _ -> Checked0.return ()) }
+    let field : (Cvar.t, Field.t) t = field ()
 
     let hlist (type k_var k_value)
         (spec0 : (unit, unit, k_var, k_value) Data_spec.t) :
@@ -402,22 +380,6 @@ module Make_basic (Backend : Backend_intf.S) = struct
       in
       {read; store; alloc; check}
 
-    let transport ({read; store; alloc; check} : ('var1, 'value1) t)
-        ~(there : 'value2 -> 'value1) ~(back : 'value1 -> 'value2) :
-        ('var1, 'value2) t =
-      { alloc
-      ; store= (fun x -> store (there x))
-      ; read= (fun v -> Read.map ~f:back (read v))
-      ; check }
-
-    let transport_var ({read; store; alloc; check} : ('var1, 'value) t)
-        ~(there : 'var2 -> 'var1) ~(back : 'var1 -> 'var2) : ('var2, 'value) t
-        =
-      { alloc= Alloc.map alloc ~f:back
-      ; store= (fun x -> Store.map (store x) ~f:back)
-      ; read= (fun x -> read (there x))
-      ; check= (fun x -> check (there x)) }
-
     (* TODO: Do a CPS style thing instead if it ends up being an issue converting
      back and forth. *)
     let of_hlistable (spec : (unit, unit, 'k_var, 'k_value) Data_spec.t)
@@ -431,50 +393,6 @@ module Make_basic (Backend : Backend_intf.S) = struct
       ; store= (fun x -> Store.map ~f:var_of_hlist (store (value_to_hlist x)))
       ; alloc= Alloc.map ~f:var_of_hlist alloc
       ; check= (fun v -> check (var_to_hlist v)) }
-
-    let list ~length ({read; store; alloc; check} : ('elt_var, 'elt_value) t) :
-        ('elt_var list, 'elt_value list) t =
-      let store ts =
-        let n = List.length ts in
-        if n <> length then
-          failwithf "Typ.list: Expected length %d, got %d" length n () ;
-        Store.all (List.map ~f:store ts)
-      in
-      let alloc = Alloc.all (List.init length ~f:(fun _ -> alloc)) in
-      let check ts = Checked0.all_unit (List.map ts ~f:check) in
-      let read vs = Read.all (List.map vs ~f:read) in
-      {read; store; alloc; check}
-
-    (* TODO-someday: Make more efficient *)
-    let array ~length ({read; store; alloc; check} : ('elt_var, 'elt_value) t)
-        : ('elt_var array, 'elt_value array) t =
-      let store ts =
-        assert (Array.length ts = length) ;
-        Store.map ~f:Array.of_list
-          (Store.all (List.map ~f:store (Array.to_list ts)))
-      in
-      let alloc =
-        let open Alloc.Let_syntax in
-        let%map vs = Alloc.all (List.init length ~f:(fun _ -> alloc)) in
-        Array.of_list vs
-      in
-      let read vs =
-        assert (Array.length vs = length) ;
-        Read.map ~f:Array.of_list
-          (Read.all (List.map ~f:read (Array.to_list vs)))
-      in
-      let check ts =
-        assert (Array.length ts = length) ;
-        let open Checked0.Let_syntax in
-        let rec go i =
-          if i = length then return ()
-          else
-            let%map () = check ts.(i) and () = go (i + 1) in
-            ()
-        in
-        go 0
-      in
-      {read; store; alloc; check}
 
     (* TODO: Assert that a stored value has the same shape as the template. *)
     module Of_traversable (T : Traversable.S) = struct
@@ -509,59 +427,6 @@ module Make_basic (Backend : Backend_intf.S) = struct
         let check t = Checked0.map (traverse_checked t ~f:check) ~f:ignore in
         {read; store; alloc; check}
     end
-
-    let tuple2 (typ1 : ('var1, 'value1) t) (typ2 : ('var2, 'value2) t) :
-        ('var1 * 'var2, 'value1 * 'value2) t =
-      let alloc =
-        let open Alloc.Let_syntax in
-        let%map x = typ1.alloc and y = typ2.alloc in
-        (x, y)
-      in
-      let read (x, y) =
-        let open Read.Let_syntax in
-        let%map x = typ1.read x and y = typ2.read y in
-        (x, y)
-      in
-      let store (x, y) =
-        let open Store.Let_syntax in
-        let%map x = typ1.store x and y = typ2.store y in
-        (x, y)
-      in
-      let check (x, y) =
-        let open Checked0.Let_syntax in
-        let%map () = typ1.check x and () = typ2.check y in
-        ()
-      in
-      {read; store; alloc; check}
-
-    let ( * ) = tuple2
-
-    let tuple3 (typ1 : ('var1, 'value1) t) (typ2 : ('var2, 'value2) t)
-        (typ3 : ('var3, 'value3) t) :
-        ('var1 * 'var2 * 'var3, 'value1 * 'value2 * 'value3) t =
-      let alloc =
-        let open Alloc.Let_syntax in
-        let%map x = typ1.alloc and y = typ2.alloc and z = typ3.alloc in
-        (x, y, z)
-      in
-      let read (x, y, z) =
-        let open Read.Let_syntax in
-        let%map x = typ1.read x and y = typ2.read y and z = typ3.read z in
-        (x, y, z)
-      in
-      let store (x, y, z) =
-        let open Store.Let_syntax in
-        let%map x = typ1.store x and y = typ2.store y and z = typ3.store z in
-        (x, y, z)
-      in
-      let check (x, y, z) =
-        let open Checked0.Let_syntax in
-        let%map () = typ1.check x
-        and () = typ2.check y
-        and () = typ3.check z in
-        ()
-      in
-      {read; store; alloc; check}
   end
 
   module As_prover = struct

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -278,20 +278,12 @@ module Make_basic (Backend : Backend_intf.S) = struct
     type t = Request.request -> Request.response
   end
 
-  module Typ0 = struct
-    type ('var, 'value) t =
-      ('var, 'value, Field.t, Cvar.t, R1CS_constraint_system.t) Types.Typ.t
-  end
-
   module Checked0 = struct
-    type ('a, 's) t =
-      ('a, 's, Field.t, Cvar.t, R1CS_constraint_system.t) Types.Checked.t
-  end
-
-  module Checked1 = struct
     module T = struct
       open Types.Checked
-      include Checked0
+
+      type ('a, 's) t =
+        ('a, 's, Field.t, Cvar.t, R1CS_constraint_system.t) Types.Checked.t
 
       let return x = Pure x
 
@@ -338,7 +330,9 @@ module Make_basic (Backend : Backend_intf.S) = struct
   module Typ = struct
     open Types.Typ
     include Typ_monads
-    include Typ0
+
+    type ('var, 'value) t =
+      ('var, 'value, Field.t, Cvar.t, R1CS_constraint_system.t) Types.Typ.t
 
     type ('var, 'value) typ = ('var, 'value) t
 
@@ -368,14 +362,14 @@ module Make_basic (Backend : Backend_intf.S) = struct
     let alloc ({alloc; _} : ('var, 'value) t) : 'var Alloc.t = alloc
 
     let check ({check; _} : ('var, 'value) t) (v : 'var) :
-        (unit, 's) Checked1.t =
+        (unit, 's) Checked0.t =
       let do_nothing : (unit, _) As_prover0.t = fun _ s -> (s, ()) in
-      With_state (do_nothing, (fun () -> do_nothing), check v, Checked1.return)
+      With_state (do_nothing, (fun () -> do_nothing), check v, Checked0.return)
 
     let unit : (unit, unit) t =
       let s = Store.return () in
       let r = Read.return () in
-      let c = Checked1.return () in
+      let c = Checked0.return () in
       { store= (fun () -> s)
       ; read= (fun () -> r)
       ; check= (fun () -> c)
@@ -385,7 +379,7 @@ module Make_basic (Backend : Backend_intf.S) = struct
       { store= Store.store
       ; read= Read.read
       ; alloc= Alloc.alloc
-      ; check= (fun _ -> Checked1.return ()) }
+      ; check= (fun _ -> Checked0.return ()) }
 
     let hlist (type k_var k_value)
         (spec0 : (unit, unit, k_var, k_value) Data_spec.t) :
@@ -440,15 +434,15 @@ module Make_basic (Backend : Backend_intf.S) = struct
         in
         go spec0
       in
-      let check xs0 : (unit, unit) Checked1.t =
+      let check xs0 : (unit, unit) Checked0.t =
         let rec go : type k_var k_value.
                (unit, unit, k_var, k_value) Data_spec.t
             -> (unit, k_var) H_list.t
-            -> (unit, unit) Checked1.t =
+            -> (unit, unit) Checked0.t =
          fun spec0 xs0 ->
           let open Data_spec in
           let open H_list in
-          let open Checked1.Let_syntax in
+          let open Checked0.Let_syntax in
           match (spec0, xs0) with
           | [], [] -> return ()
           | s :: spec, x :: xs ->
@@ -498,7 +492,7 @@ module Make_basic (Backend : Backend_intf.S) = struct
         Store.all (List.map ~f:store ts)
       in
       let alloc = Alloc.all (List.init length ~f:(fun _ -> alloc)) in
-      let check ts = Checked1.all_unit (List.map ts ~f:check) in
+      let check ts = Checked0.all_unit (List.map ts ~f:check) in
       let read vs = Read.all (List.map vs ~f:read) in
       {read; store; alloc; check}
 
@@ -522,7 +516,7 @@ module Make_basic (Backend : Backend_intf.S) = struct
       in
       let check ts =
         assert (Array.length ts = length) ;
-        let open Checked1.Let_syntax in
+        let open Checked0.Let_syntax in
         let rec go i =
           if i = length then return ()
           else
@@ -554,7 +548,7 @@ module Make_basic (Backend : Backend_intf.S) = struct
           let module M =
             T.Traverse
               (Restrict_monad.Make2
-                 (Checked1)
+                 (Checked0)
                  (struct
                    type t = unit
                  end)) in
@@ -563,7 +557,7 @@ module Make_basic (Backend : Backend_intf.S) = struct
         let read var = traverse_read var ~f:read in
         let store value = traverse_store value ~f:store in
         let alloc = traverse_alloc template ~f:(fun () -> alloc) in
-        let check t = Checked1.map (traverse_checked t ~f:check) ~f:ignore in
+        let check t = Checked0.map (traverse_checked t ~f:check) ~f:ignore in
         {read; store; alloc; check}
     end
 
@@ -585,7 +579,7 @@ module Make_basic (Backend : Backend_intf.S) = struct
         (x, y)
       in
       let check (x, y) =
-        let open Checked1.Let_syntax in
+        let open Checked0.Let_syntax in
         let%map () = typ1.check x and () = typ2.check y in
         ()
       in
@@ -612,7 +606,7 @@ module Make_basic (Backend : Backend_intf.S) = struct
         (x, y, z)
       in
       let check (x, y, z) =
-        let open Checked1.Let_syntax in
+        let open Checked0.Let_syntax in
         let%map () = typ1.check x
         and () = typ2.check y
         and () = typ3.check z in
@@ -633,10 +627,10 @@ module Make_basic (Backend : Backend_intf.S) = struct
     module Ref = struct
       type 'a t = 'a option ref
 
-      let create (x : ('a, 's) As_prover0.t) : ('a t, 's) Checked1.t =
+      let create (x : ('a, 's) As_prover0.t) : ('a t, 's) Checked0.t =
         let r = ref None in
-        let open Checked1.Let_syntax in
-        let%map () = Checked1.as_prover (map x ~f:(fun x -> r := Some x)) in
+        let open Checked0.Let_syntax in
+        let%map () = Checked0.as_prover (map x ~f:(fun x -> r := Some x)) in
         r
 
       let get (r : 'a t) _tbl s = (s, Option.value_exn !r)
@@ -656,7 +650,7 @@ module Make_basic (Backend : Backend_intf.S) = struct
 
   module Checked = struct
     open Types.Checked
-    include Checked1
+    include Checked0
 
     let request_witness (typ : ('var, 'value) Typ.t)
         (r : ('value Request.t, 's) As_prover.t) =
@@ -1050,7 +1044,7 @@ module Make_basic (Backend : Backend_intf.S) = struct
         create Cvar.Infix.((true_ :> Cvar.t) - (x :> Cvar.t))
 
       let if_ b ~(then_ : var) ~(else_ : var) =
-        Checked1.map ~f:create
+        Checked0.map ~f:create
           (if_ b ~then_:(then_ :> Cvar.t) ~else_:(else_ :> Cvar.t))
 
       let ( && ) (x : var) (y : var) =
@@ -1163,8 +1157,8 @@ module Make_basic (Backend : Backend_intf.S) = struct
           match t with
           | Not t -> eval t >>| not
           | Var v -> return v
-          | And ts -> Checked1.all (List.map ~f:eval ts) >>= all
-          | Or ts -> Checked1.all (List.map ~f:eval ts) >>= any
+          | And ts -> Checked0.all (List.map ~f:eval ts) >>= all
+          | Or ts -> Checked0.all (List.map ~f:eval ts) >>= any
 
         let assert_ t = eval t >>= Assert.is_true
 
@@ -1230,7 +1224,7 @@ module Make_basic (Backend : Backend_intf.S) = struct
 
     module List =
       Monad_sequence.List
-        (Checked1)
+        (Checked0)
         (struct
           type t = Boolean.var
 

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -596,77 +596,7 @@ module Make_basic (Backend : Backend_intf.S) = struct
     open Types.Checked
     include Checked0
 
-    let request_witness (typ : ('var, 'value) Typ.t)
-        (r : ('value Request.t, 's) As_prover.t) =
-      Exists (typ, Request r, fun h -> return (Handle.var h))
-
     let perform req = request_witness Typ.unit req
-
-    let request ?such_that typ r =
-      match such_that with
-      | None -> request_witness typ (As_prover.return r)
-      | Some such_that ->
-          let open Let_syntax in
-          let%bind x = request_witness typ (As_prover.return r) in
-          let%map () = such_that x in
-          x
-
-    let exists ?request ?compute typ =
-      let provider =
-        let request =
-          Option.value request ~default:(As_prover.return Request.Fail)
-        in
-        match compute with
-        | None -> Provider.Request request
-        | Some c -> Provider.Both (request, c)
-      in
-      Exists (typ, provider, fun h -> return (Handle.var h))
-
-    type response = Request.response
-
-    let unhandled = Request.unhandled
-
-    type request = Request.request =
-      | With :
-          { request: 'a Request.t
-          ; respond: 'a Request.Response.t -> response }
-          -> request
-
-    let handle t k = With_handler (Request.Handler.create_single k, t, return)
-
-    let next_auxiliary = Next_auxiliary return
-
-    let with_constraint_system f = With_constraint_system (f, return ())
-
-    let with_label s t = With_label (s, t, return)
-
-    let do_nothing _ = As_prover.return ()
-
-    let with_state ?(and_then = do_nothing) f sub =
-      With_state (f, and_then, sub, return)
-
-    let assert_ ?label c =
-      Add_constraint
-        (List.map c ~f:(fun c -> Constraint.override_label c label), return ())
-
-    let assert_r1cs ?label a b c = assert_ (Constraint.r1cs ?label a b c)
-
-    let assert_square ?label a c = assert_ (Constraint.square ?label a c)
-
-    let assert_all =
-      let map_concat_rev xss ~f =
-        let rec go acc xs xss =
-          match (xs, xss) with
-          | [], [] -> acc
-          | [], xs :: xss -> go acc xs xss
-          | x :: xs, _ -> go (f x :: acc) xs xss
-        in
-        go [] [] xss
-      in
-      fun ?label cs ->
-        Add_constraint
-          ( map_concat_rev ~f:(fun c -> Constraint.override_label c label) cs
-          , return () )
 
     let assert_equal ?label x y = assert_ (Constraint.equal ?label x y)
 

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -250,14 +250,6 @@ module Make_basic (Backend : Backend_intf.S) = struct
     end
   end
 
-  module As_prover0 = struct
-    include As_prover.Make (struct
-      type var = Cvar.t
-
-      type field = Field.t
-    end)
-  end
-
   module Handler = struct
     type t = Request.request -> Request.response
   end
@@ -430,27 +422,13 @@ module Make_basic (Backend : Backend_intf.S) = struct
   end
 
   module As_prover = struct
-    include As_prover0
-
+    include As_prover.Make (struct
+      type var = Cvar.t
+ 
+      type field = Field.t
+    end)
+ 
     type ('a, 'prover_state) as_prover = ('a, 'prover_state) t
-
-    let read ({read; _} : ('var, 'value) Typ.t) (var : 'var) :
-        ('value, 'prover_state) t =
-     fun tbl s -> (s, Typ.Read.run (read var) tbl)
-
-    module Ref = struct
-      type 'a t = 'a option ref
-
-      let create (x : ('a, 's) As_prover0.t) : ('a t, 's) Checked0.t =
-        let r = ref None in
-        let open Checked0.Let_syntax in
-        let%map () = Checked0.as_prover (map x ~f:(fun x -> r := Some x)) in
-        r
-
-      let get (r : 'a t) _tbl s = (s, Option.value_exn !r)
-
-      let set (r : 'a t) x _tbl s = (s, (r := Some x))
-    end
   end
 
   module Handle = struct

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -463,8 +463,6 @@ module Make_basic (Backend : Backend_intf.S) = struct
 
     let perform req = request_witness Typ.unit req
 
-    let assert_equal ?label x y = assert_ (Constraint.equal ?label x y)
-
     let constraint_count ?(log = fun ?start _ _ -> ()) (t : (_, _) t) : int =
       let next_auxiliary = ref 1 in
       let alloc_var () =

--- a/src/typ.ml
+++ b/src/typ.ml
@@ -25,7 +25,7 @@ module T = struct
   let check (type field cvar)
       ({check; _} : ('var, 'value, field, cvar, 'sys) t) (v : 'var) :
       (unit, 's, field, cvar, 'sys) Types.Checked.t =
-    let do_nothing : (unit, cvar -> field, _) As_prover.t =
+    let do_nothing : (unit, cvar -> field, _) As_prover0.t =
      fun _ s -> (s, ())
     in
     With_state (do_nothing, (fun () -> do_nothing), check v, Checked.return)

--- a/src/typ.ml
+++ b/src/typ.ml
@@ -1,0 +1,173 @@
+open Core_kernel
+
+type ('var, 'value, 'field, 'cvar, 'sys) t =
+  ('var, 'value, 'field, 'cvar, 'sys) Types.Typ.t
+
+type ('var, 'value, 'field, 'cvar, 'sys) typ =
+  ('var, 'value, 'field, 'cvar, 'sys) t
+
+module T = struct
+  open Types.Typ
+  open Typ_monads
+
+  let store ({store; _} : ('var, 'value, 'field, 'cvar, 'sys) t) (x : 'value) :
+      ('var, 'field, 'cvar) Store.t =
+    store x
+
+  let read ({read; _} : ('var, 'value, 'field, 'cvar, 'sys) t) (v : 'var) :
+      ('value, 'field, 'cvar) Read.t =
+    read v
+
+  let alloc ({alloc; _} : ('var, 'value, 'field, 'cvar, 'sys) t) :
+      ('var, 'cvar) Alloc.t =
+    alloc
+
+  let check (type field cvar)
+      ({check; _} : ('var, 'value, field, cvar, 'sys) t) (v : 'var) :
+      (unit, 's, field, cvar, 'sys) Types.Checked.t =
+    let do_nothing : (unit, cvar -> field, _) As_prover.t =
+     fun _ s -> (s, ())
+    in
+    With_state (do_nothing, (fun () -> do_nothing), check v, Checked.return)
+
+  let unit () : (unit, unit, 'field, 'cvar, 'sys) t =
+    let s = Store.return () in
+    let r = Read.return () in
+    let c = Checked.return () in
+    { store= (fun () -> s)
+    ; read= (fun () -> r)
+    ; check= (fun () -> c)
+    ; alloc= Alloc.return () }
+
+  let field () : ('cvar, 'field, 'field, 'cvar, 'sys) t =
+    { store= Store.store
+    ; read= Read.read
+    ; alloc= Alloc.alloc
+    ; check= (fun _ -> Checked.return ()) }
+
+  let transport
+      ({read; store; alloc; check} : ('var1, 'value1, 'field, 'cvar, 'sys) t)
+      ~(there : 'value2 -> 'value1) ~(back : 'value1 -> 'value2) :
+      ('var1, 'value2, 'field, 'cvar, 'sys) t =
+    { alloc
+    ; store= (fun x -> store (there x))
+    ; read= (fun v -> Read.map ~f:back (read v))
+    ; check }
+
+  let transport_var
+      ({read; store; alloc; check} : ('var1, 'value, 'field, 'cvar, 'sys) t)
+      ~(there : 'var2 -> 'var1) ~(back : 'var1 -> 'var2) :
+      ('var2, 'value, 'field, 'cvar, 'sys) t =
+    { alloc= Alloc.map alloc ~f:back
+    ; store= (fun x -> Store.map (store x) ~f:back)
+    ; read= (fun x -> read (there x))
+    ; check= (fun x -> check (there x)) }
+
+  let list ~length
+      ({read; store; alloc; check} :
+        ('elt_var, 'elt_value, 'field, 'cvar, 'sys) t) :
+      ('elt_var list, 'elt_value list, 'field, 'cvar, 'sys) t =
+    let store ts =
+      let n = List.length ts in
+      if n <> length then
+        failwithf "Typ.list: Expected length %d, got %d" length n () ;
+      Store.all (List.map ~f:store ts)
+    in
+    let alloc = Alloc.all (List.init length ~f:(fun _ -> alloc)) in
+    let check ts = Checked.all_unit (List.map ts ~f:check) in
+    let read vs = Read.all (List.map vs ~f:read) in
+    {read; store; alloc; check}
+
+  (* TODO-someday: Make more efficient *)
+  let array ~length
+      ({read; store; alloc; check} :
+        ('elt_var, 'elt_value, 'field, 'cvar, 'sys) t) :
+      ('elt_var array, 'elt_value array, 'field, 'cvar, 'sys) t =
+    let store ts =
+      assert (Array.length ts = length) ;
+      Store.map ~f:Array.of_list
+        (Store.all (List.map ~f:store (Array.to_list ts)))
+    in
+    let alloc =
+      let open Alloc.Let_syntax in
+      let%map vs = Alloc.all (List.init length ~f:(fun _ -> alloc)) in
+      Array.of_list vs
+    in
+    let read vs =
+      assert (Array.length vs = length) ;
+      Read.map ~f:Array.of_list
+        (Read.all (List.map ~f:read (Array.to_list vs)))
+    in
+    let check ts =
+      assert (Array.length ts = length) ;
+      let open Checked in
+      let rec go i =
+        if i = length then return ()
+        else
+          let%map () = check ts.(i) and () = go (i + 1) in
+          ()
+      in
+      go 0
+    in
+    {read; store; alloc; check}
+
+  let tuple2 (typ1 : ('var1, 'value1, 'field, 'cvar, 'sys) t)
+      (typ2 : ('var2, 'value2, 'field, 'cvar, 'sys) t) :
+      ('var1 * 'var2, 'value1 * 'value2, 'field, 'cvar, 'sys) t =
+    let alloc =
+      let open Alloc.Let_syntax in
+      let%map x = typ1.alloc and y = typ2.alloc in
+      (x, y)
+    in
+    let read (x, y) =
+      let open Read.Let_syntax in
+      let%map x = typ1.read x and y = typ2.read y in
+      (x, y)
+    in
+    let store (x, y) =
+      let open Store.Let_syntax in
+      let%map x = typ1.store x and y = typ2.store y in
+      (x, y)
+    in
+    let check (x, y) =
+      let open Checked in
+      let%map () = typ1.check x and () = typ2.check y in
+      ()
+    in
+    {read; store; alloc; check}
+
+  let ( * ) = tuple2
+
+  let tuple3 (typ1 : ('var1, 'value1, 'field, 'cvar, 'sys) t)
+      (typ2 : ('var2, 'value2, 'field, 'cvar, 'sys) t)
+      (typ3 : ('var3, 'value3, 'field, 'cvar, 'sys) t) :
+      ( 'var1 * 'var2 * 'var3
+      , 'value1 * 'value2 * 'value3
+      , 'field
+      , 'cvar
+      , 'sys )
+      t =
+    let alloc =
+      let open Alloc.Let_syntax in
+      let%map x = typ1.alloc and y = typ2.alloc and z = typ3.alloc in
+      (x, y, z)
+    in
+    let read (x, y, z) =
+      let open Read.Let_syntax in
+      let%map x = typ1.read x and y = typ2.read y and z = typ3.read z in
+      (x, y, z)
+    in
+    let store (x, y, z) =
+      let open Store.Let_syntax in
+      let%map x = typ1.store x and y = typ2.store y and z = typ3.store z in
+      (x, y, z)
+    in
+    let check (x, y, z) =
+      let open Checked in
+      let%map () = typ1.check x and () = typ2.check y and () = typ3.check z in
+      ()
+    in
+    {read; store; alloc; check}
+end
+
+include T

--- a/src/types.ml
+++ b/src/types.ml
@@ -22,14 +22,14 @@ and Checked : sig
         ('sys -> unit) * ('a, 's, 'f, 'v, 'sys) t
         -> ('a, 's, 'f, 'v, 'sys) t
     | As_prover :
-        (unit, 'v -> 'f, 's) As_prover.t * ('a, 's, 'f, 'v, 'sys) t
+        (unit, 'v -> 'f, 's) As_prover0.t * ('a, 's, 'f, 'v, 'sys) t
         -> ('a, 's, 'f, 'v, 'sys) t
     | With_label :
         string * ('a, 's, 'f, 'v, 'sys) t * ('a -> ('b, 's, 'f, 'v, 'sys) t)
         -> ('b, 's, 'f, 'v, 'sys) t
     | With_state :
-        ('s1, 'v -> 'f, 's) As_prover.t
-        * ('s1 -> (unit, 'v -> 'f, 's) As_prover.t)
+        ('s1, 'v -> 'f, 's) As_prover0.t
+        * ('s1 -> (unit, 'v -> 'f, 's) As_prover0.t)
         * ('b, 's1, 'f, 'v, 'sys) t
         * ('b -> ('a, 's, 'f, 'v, 'sys) t)
         -> ('a, 's, 'f, 'v, 'sys) t


### PR DESCRIPTION
This PR pulls out nearly everything from `Snark0` that doesn't explicitly depend on the `Backend` module in some way. Exceptions are:
- `Data_spec.t` and friends
  * pulling it out forces us to parametrise over the `Field.t`, `Cvar.t` and `R1CS_constraint_system.t` in the exposed type, which feels particularly un-user-friendly. (Think `('r_var, 'r_value, 'k_var, 'k_value, Field.t, Cvar.t, R1CS_constraint_system.t) t`.)
- `Checked.perform`
  * This is the only place where `Checked` depends on `Typ`; it felt cleaner to keep this single definition inline, instead of having a whole module file dedicated to adding in this one function.

@imeckler this is CodaProtocol/coda#1412