### PR TITLE
mark libsnark code as vendored

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+src/camlsnark_c/libsnark-caml/* linguist-vendored


### PR DESCRIPTION
that way github doesn't think our code is 83.8% C++