### PR TITLE
Add CI for Snarky

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,12 @@
+version: 2
+jobs:
+    build:
+        docker:
+        # For now, just reuse coda's Docker toolchain. In the future, we should compose Coda's from Snarky's somehow
+        - image: codaprotocol/coda:toolchain-7df6b2b12bc316cb71592b12255d80e19396831e
+        steps:
+            - checkout
+            - run: eval `opam config env` && make build
+            - run: eval `opam config env` && make examples
+
+

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,15 @@
 
 all : docker googlecloud minikube
-.PHONY : all
 
 build :
 	dune build --root=.
+
+examples :
+	dune exec --root=. ./examples/election/election_main.exe
+	# TODO: Re-enable when fixed, see #41
+	# dune exec --root=. ./examples/merkle_update/merkle_update.exe
+	# tutorial.exe intentionally is unimplemented, but it should still compile
+	dune build --root=. ./examples/tutorial/tutorial.exe
 
 docker :
 	./rebuild-docker.sh ocaml-camlsnark
@@ -13,4 +19,6 @@ minikube :
 
 googlecloud :
 	./rebuild-googlecloud.sh ocaml-camlsnark
+
+.PHONY : all build examples docker minikube googlecloud
 


### PR DESCRIPTION
`make build` ensures that the build works
`make examples` ensures that examples build and run