### PR TITLE
Rename Field.var and Field.Checked.t to Field.Var.t

### DIFF
--- a/examples/election/election.ml
+++ b/examples/election/election.ml
@@ -22,7 +22,7 @@ module Ballot = struct
     (* An opened ballot is a nonce along with a vote. *)
     type t = Nonce.t * Vote.t
 
-    type var = Nonce.var * Vote.var
+    type var = Nonce.Var.t * Vote.var
 
     (* A [typ] is a kind of specification of a type of data which makes it possible
        to use values of that type inside checked computations. In a future version of

--- a/examples/election/knapsack_hash.ml
+++ b/examples/election/knapsack_hash.ml
@@ -4,7 +4,7 @@ module M = Snarky.Knapsack.Make (Impl)
 
 let dimension = 1
 
-type var = Field.Checked.t list
+type var = Field.Var.t list
 
 type t = Field.t list
 

--- a/examples/tutorial/tutorial.ml
+++ b/examples/tutorial/tutorial.ml
@@ -54,10 +54,9 @@ let () =
 
    Here we assert that [x] is a square root of 9.
 *)
-let assert_is_square_root_of_9 (x : Field.var) : (unit, _) Checked.t =
+let assert_is_square_root_of_9 (x : Field.Var.t) : (unit, _) Checked.t =
   let%bind x_squared = Field.Checked.mul x x in
-  Field.Checked.Assert.equal x_squared
-    (Field.Checked.constant (Field.of_int 9))
+  Field.Checked.Assert.equal x_squared (Field.Var.constant (Field.of_int 9))
 
 (* Exercise 1:
    Write a function
@@ -82,7 +81,7 @@ let assert_is_square_root_of_9 (x : Field.var) : (unit, _) Checked.t =
 (* In this field, it happens to be the case that -3 is a square. *)
 let () = assert (Field.is_square (Field.of_int (-3)))
 
-let assert_is_cube_root_of_1 (x : Field.var) = failwith "Exercise 1"
+let assert_is_cube_root_of_1 (x : Field.Var.t) = failwith "Exercise 1"
 
 let cube_root_of_1 =
   let open Field in
@@ -215,7 +214,7 @@ module Exercise3 = struct
    * monad, and the Field.Checked version with the Checked monad
    *)
   module Mat_checked = struct
-    type t = Field.var array array
+    type t = Field.Var.t array array
 
     (* Exercise 3: fill me out *)
     let mul : t -> t -> (t, _) Checked.t =
@@ -231,7 +230,7 @@ module Exercise3 = struct
      matrix (the square of [1; 2]; [4; 5] )
   *)
   let assert_exists_sqrt sqrt_x =
-    let f x = Field.Checked.constant (Field.of_int x) in
+    let f x = Field.Var.constant (Field.of_int x) in
     assert_exists_mat_sqrt [|[|f 9; f 12|]; [|f 24; f 33|]|] sqrt_x
 
   (* Now the data_spec is more interesting:

--- a/src/curves.ml
+++ b/src/curves.ml
@@ -49,7 +49,7 @@ module Make_intf (Impl : Snark_intf.S) = struct
 
     type 'a t = 'a * 'a
 
-    type var = Field.Checked.t t
+    type var = Field.Var.t t
 
     type value = Field.t t
 
@@ -261,7 +261,7 @@ module Edwards = struct
      and type ('a, 'b) typ := ('a, 'b) Impl.Typ.t
      and type boolean_var := Impl.Boolean.var
      and type field := Impl.Field.t
-     and type var = Impl.Field.Checked.t * Impl.Field.Checked.t
+     and type var = Impl.Field.Var.t * Impl.Field.Var.t
      and type value = Impl.Field.t * Impl.Field.t
      and module Scalar = Scalar = struct
     open Impl
@@ -270,12 +270,11 @@ module Edwards = struct
 
     type 'a tup = 'a * 'a [@@deriving eq, sexp]
 
-    type var = Field.Checked.t tup
+    type var = Field.Var.t tup
 
     type value = Field.t tup [@@deriving eq, sexp]
 
-    let var_of_value (x, y) =
-      (Field.Checked.constant x, Field.Checked.constant y)
+    let var_of_value (x, y) = (Field.Var.constant x, Field.Var.constant y)
 
     let identity_value = identity
 
@@ -285,8 +284,7 @@ module Edwards = struct
       let open Let_syntax in
       let%bind x2 = Field.Checked.mul x x and y2 = Field.Checked.mul y y in
       let open Field.Checked.Infix in
-      assert_r1cs (Params.d * x2) y2
-        (x2 + y2 - Field.Checked.constant Field.one)
+      assert_r1cs (Params.d * x2) y2 (x2 + y2 - Field.Var.constant Field.one)
 
     let typ_unchecked : (var, value) Typ.t = Typ.(tuple2 field field)
 
@@ -313,17 +311,17 @@ module Edwards = struct
       end
 
       let%snarkydef add_known (x1, y1) (x2, y2) =
-        let x1x2 = Field.Checked.scale x1 x2
-        and y1y2 = Field.Checked.scale y1 y2
-        and x1y2 = Field.Checked.scale x1 y2
-        and y1x2 = Field.Checked.scale y1 x2 in
+        let x1x2 = Field.Var.scale x1 x2
+        and y1y2 = Field.Var.scale y1 y2
+        and x1y2 = Field.Var.scale x1 y2
+        and y1x2 = Field.Var.scale y1 x2 in
         let%bind p = Field.Checked.mul x1x2 y1y2 in
         let open Field.Checked.Infix in
         let p = Params.d * p in
         let%map a =
-          Field.Checked.div (x1y2 + y1x2) (Field.Checked.constant Field.one + p)
+          Field.Checked.div (x1y2 + y1x2) (Field.Var.constant Field.one + p)
         and b =
-          Field.Checked.div (y1y2 - x1x2) (Field.Checked.constant Field.one - p)
+          Field.Checked.div (y1y2 - x1x2) (Field.Var.constant Field.one - p)
         in
         (a, b)
 
@@ -337,9 +335,9 @@ module Edwards = struct
         let open Field.Checked.Infix in
         let p = Params.d * p in
         let%map a =
-          Field.Checked.div (x1y2 + x2y1) (Field.Checked.constant Field.one + p)
+          Field.Checked.div (x1y2 + x2y1) (Field.Var.constant Field.one + p)
         and b =
-          Field.Checked.div (y1y2 - x1x2) (Field.Checked.constant Field.one - p)
+          Field.Checked.div (y1y2 - x1x2) (Field.Var.constant Field.one - p)
         in
         (a, b)
 
@@ -351,13 +349,13 @@ module Edwards = struct
         let two = Field.of_int 2 in
         let%map a = Field.Checked.div (two * xy) (xx + yy)
         and b =
-          Field.Checked.div (yy - xx) (Field.Checked.constant two - xx - yy)
+          Field.Checked.div (yy - xx) (Field.Var.constant two - xx - yy)
         in
         (a, b)
 
       let if_value (b : Boolean.var) ~then_:(x1, y1) ~else_:(x2, y2) =
-        let not_b = (Boolean.not b :> Field.Checked.t) in
-        let b = (b :> Field.Checked.t) in
+        let not_b = (Boolean.not b :> Field.Var.t) in
+        let b = (b :> Field.Var.t) in
         let choose_field t e =
           let open Field.Checked in
           Infix.((t * b) + (e * not_b))
@@ -393,7 +391,7 @@ module Edwards = struct
                  ~f:(fun i r t e ->
                    let open Field.Checked.Infix in
                    Constraint.r1cs ~label:(sprintf "main_%d" i)
-                     (b :> Field.Checked.t)
+                     (b :> Field.Var.t)
                      (t - e) (r - e) )
                |> assert_all
              in
@@ -420,8 +418,8 @@ module Edwards = struct
       (* TODO: Unit test *)
       let%snarkydef cond_add ((x2, y2) : value) ~to_:((x1, y1) : var)
           ~if_:(b : Boolean.var) : (var, _) Checked.t =
-        let one = Field.Checked.constant Field.one in
-        let b = (b :> Field.Checked.t) in
+        let one = Field.Var.constant Field.one in
+        let b = (b :> Field.Var.t) in
         let open Let_syntax in
         let open Field.Checked.Infix in
         let res a1 a3 =
@@ -459,12 +457,12 @@ module Edwards = struct
         | [] -> failwith "scale_known: Empty bits"
         | b :: bs ->
             let acc =
-              let b = (b :> Field.Checked.t) in
+              let b = (b :> Field.Var.t) in
               let x_id, y_id = identity_value in
               let x_t, y_t = t in
               let open Field.Checked.Infix in
-              ( (Field.Infix.(x_t - x_id) * b) + Field.Checked.constant x_id
-              , (Field.Infix.(y_t - y_id) * b) + Field.Checked.constant y_id )
+              ( (Field.Infix.(x_t - x_id) * b) + Field.Var.constant x_id
+              , (Field.Infix.(y_t - y_id) * b) + Field.Var.constant y_id )
             in
             go 1 acc (double_value t) bs
     end
@@ -485,7 +483,7 @@ module Edwards = struct
      and type ('a, 'b) typ := ('a, 'b) Impl.Typ.t
      and type boolean_var := Impl.Boolean.var
      and type field := Impl.Field.t
-     and type var = Impl.Field.Checked.t * Impl.Field.Checked.t
+     and type var = Impl.Field.Var.t * Impl.Field.Var.t
      and type value = Impl.Field.t * Impl.Field.t =
     Extend (Impl) (Scalar) (Basic.Make (Impl.Field) (Params))
 end
@@ -575,10 +573,10 @@ module Make_weierstrass_checked
   Weierstrass_checked_intf
   with module Impl := Impl
    and type t := Curve.t
-   and type var := Impl.Field.var * Impl.Field.var = struct
+   and type var := Impl.Field.Var.t * Impl.Field.Var.t = struct
   open Impl
 
-  type var = Field.Checked.t * Field.Checked.t
+  type var = Field.Var.t * Field.Var.t
 
   type t = Curve.t
 
@@ -587,8 +585,7 @@ module Make_weierstrass_checked
     let%bind x2 = Field.Checked.square x in
     let%bind x3 = Field.Checked.mul x2 x in
     assert_square y
-      Field.Checked.Infix.(
-        x3 + (Params.a * x) + Field.Checked.constant Params.b)
+      Field.Checked.Infix.(x3 + (Params.a * x) + Field.Var.constant Params.b)
 
   let typ : (var, t) Typ.t =
     let unchecked =
@@ -598,12 +595,11 @@ module Make_weierstrass_checked
     in
     {unchecked with check= assert_on_curve}
 
-  let negate ((x, y) : var) : var =
-    (x, Field.Checked.scale y Field.(negate one))
+  let negate ((x, y) : var) : var = (x, Field.Var.scale y Field.(negate one))
 
   let constant (t : t) : var =
     let x, y = Curve.to_affine_coordinates t in
-    Field.Checked.(constant x, constant y)
+    Field.Var.(constant x, constant y)
 
   let assert_equal (x1, y1) (x2, y2) =
     assert_all [Constraint.equal x1 x2; Constraint.equal y1 y2]
@@ -616,9 +612,7 @@ module Make_weierstrass_checked
 
   let%snarkydef add' ~div (ax, ay) (bx, by) =
     let open Let_syntax in
-    let%bind lambda =
-      div (Field.Checked.sub by ay) (Field.Checked.sub bx ax)
-    in
+    let%bind lambda = div (Field.Var.sub by ay) (Field.Var.sub bx ax) in
     let%bind cx =
       exists Typ.field
         ~compute:
@@ -712,7 +706,7 @@ module Make_weierstrass_checked
           ~f:(fun i r t e ->
             let open Field.Checked.Infix in
             Constraint.r1cs ~label:(sprintf "main_%d" i)
-              (b :> Field.Checked.t)
+              (b :> Field.Var.t)
               (t - e) (r - e) )
         |> assert_all
       in
@@ -793,7 +787,7 @@ module Make_weierstrass_checked
     let open Field.Checked.Infix in
     let%map () =
       assert_r1cs (two * lambda) ay
-        ((Field.of_int 3 * x_squared) + Field.Checked.constant Params.a)
+        ((Field.of_int 3 * x_squared) + Field.Var.constant Params.a)
     and () = assert_square lambda (bx + (two * ax))
     and () = assert_r1cs lambda (ax - bx) (by + ay) in
     (bx, by)
@@ -801,10 +795,10 @@ module Make_weierstrass_checked
   let if_value (cond : Boolean.var) ~then_ ~else_ =
     let x1, y1 = Curve.to_affine_coordinates then_ in
     let x2, y2 = Curve.to_affine_coordinates else_ in
-    let cond = (cond :> Field.Checked.t) in
+    let cond = (cond :> Field.Var.t) in
     let choose a1 a2 =
       let open Field.Checked in
-      Infix.((a1 * cond) + (a2 * (constant Field.one - cond)))
+      Infix.((a1 * cond) + (a2 * (Field.Var.constant Field.one - cond)))
     in
     (choose x1 x2, choose y1 y2)
 
@@ -839,10 +833,10 @@ module Make_weierstrass_checked
       let open Field.Infix in
       let ( * ) = Field.Checked.Infix.( * ) in
       let ( +^ ) = Field.Checked.Infix.( + ) in
-      Field.Checked.constant a1
-      +^ ((a2 - a1) * (b0 :> Field.Checked.t))
-      +^ ((a3 - a1) * (b1 :> Field.Checked.t))
-      +^ ((a4 + a1 - a2 - a3) * (b0_and_b1 :> Field.Checked.t))
+      Field.Var.constant a1
+      +^ ((a2 - a1) * (b0 :> Field.Var.t))
+      +^ ((a3 - a1) * (b1 :> Field.Var.t))
+      +^ ((a4 + a1 - a2 - a3) * (b0_and_b1 :> Field.Var.t))
     in
     let x1, y1 = Curve.to_affine_coordinates t1
     and x2, y2 = Curve.to_affine_coordinates t2
@@ -854,7 +848,7 @@ module Make_weierstrass_checked
   let lookup_single_bit (b : Boolean.var) (t1, t2) =
     let lookup_one (a1, a2) =
       let open Field.Checked.Infix in
-      Field.Checked.constant a1 + (Field.sub a2 a1 * (b :> Field.Checked.t))
+      Field.Var.constant a1 + (Field.sub a2 a1 * (b :> Field.Var.t))
     in
     let x1, y1 = Curve.to_affine_coordinates t1
     and x2, y2 = Curve.to_affine_coordinates t2 in

--- a/src/enumerable.ml
+++ b/src/enumerable.ml
@@ -24,7 +24,7 @@ struct
     assert (n < Field.size_in_bits) ;
     n
 
-  type var = Field.Checked.t
+  type var = Field.Var.t
 
   let to_field t = Field.of_int (to_enum t)
 
@@ -37,7 +37,7 @@ struct
       if M.max = 1 then fun x -> assert_ (Constraint.boolean x)
       else fun x ->
         Field.Checked.Assert.lte ~bit_length x
-          (Field.Checked.constant (Field.of_int M.max))
+          (Field.Var.constant (Field.of_int M.max))
     in
     {(Typ.transport Field.typ ~there:to_field ~back:of_field) with check}
 
@@ -48,7 +48,7 @@ struct
 
   let if_ b ~(then_ : var) ~(else_ : var) = Field.Checked.if_ b ~then_ ~else_
 
-  let var t : var = Field.Checked.constant (to_field t)
+  let var t : var = Field.Var.constant (to_field t)
 
   let ( = ) = Field.Checked.equal
 end

--- a/src/enumerable.mli
+++ b/src/enumerable.mli
@@ -6,5 +6,5 @@ module Make
   with type ('a, 'b) checked := ('a, 'b) Impl.Checked.t
    and type ('a, 'b) typ := ('a, 'b) Impl.Typ.t
    and type bool_var := Impl.Boolean.var
-   and type var = Impl.Field.var
+   and type var = Impl.Field.Var.t
    and type t := M.t

--- a/src/gadget.ml
+++ b/src/gadget.ml
@@ -19,8 +19,8 @@ module Make
 
         val create :
              Libsnark.Protoboard.t
-          -> (Impl.Field.Checked.t -> Libsnark.Protoboard.Variable.t)
-          -> (Libsnark.Protoboard.Variable.t -> Impl.Field.Checked.t)
+          -> (Impl.Field.Var.t -> Libsnark.Protoboard.Variable.t)
+          -> (Libsnark.Protoboard.Variable.t -> Impl.Field.Var.t)
           -> input
           -> t
 
@@ -39,7 +39,7 @@ struct
     let num_input_vars = ref 0 in
     let var_pairs = ref [] in
     let conv cvar =
-      let c, terms = Field.Checked.to_constant_and_terms cvar in
+      let c, terms = Field.Var.to_constant_and_terms cvar in
       let lc =
         match c with
         | None -> Linear_combination.create ()

--- a/src/gm_verifier_gadget.ml
+++ b/src/gm_verifier_gadget.ml
@@ -19,7 +19,7 @@ module Make
 
       type t [@@deriving sexp]
 
-      type var = Field.var * Field.var
+      type var = Field.Var.t * Field.Var.t
 
       val typ : (var, t) Typ.t
 
@@ -168,7 +168,7 @@ struct
 
     type t = Field.t t_ [@@deriving sexp]
 
-    type var = Field.Checked.t t_
+    type var = Field.Var.t t_
 
     let bit_length (characterizing_length, sign_length) =
       (characterizing_length * Field.size_in_bits) + sign_length
@@ -215,15 +215,15 @@ struct
 
     module Checked = struct
       let constant ({sign; characterizing_up_to_sign} : t) : var =
-        { sign= List.map sign ~f:Field.Checked.constant
+        { sign= List.map sign ~f:Field.Var.constant
         ; characterizing_up_to_sign=
-            List.map characterizing_up_to_sign ~f:Field.Checked.constant }
+            List.map characterizing_up_to_sign ~f:Field.Var.constant }
 
       let if_value (choice : Boolean.var) ~then_:t1 ~else_:t2 =
         let if_value x y =
-          let choice = (choice :> Field.Checked.t) in
+          let choice = (choice :> Field.Var.t) in
           let open Field.Checked in
-          Infix.((x * choice) + (y * (constant Field.one - choice)))
+          Infix.((x * choice) + (y * (Field.Var.constant Field.one - choice)))
         in
         let if_list xs ys = List.map2_exn ~f:if_value xs ys in
         { characterizing_up_to_sign=
@@ -271,7 +271,7 @@ struct
 
     type t = (Inner_curve.t, Field.t) t_ [@@deriving sexp]
 
-    type var = (Inner_curve.var, Field.var) t_
+    type var = (Inner_curve.var, Field.Var.t) t_
 
     let of_hlist
         (H_list.([query_base; query; other_data]) :
@@ -434,11 +434,11 @@ struct
 
     let gadget_typ = ptr void
 
-    type t = {gadget: gadget; result: Field.Checked.t}
+    type t = {gadget: gadget; result: Field.Var.t}
 
     type input =
       { pvk: Preprocessed_verification_key.t
-      ; accumulated_input: Field.var * Field.var
+      ; accumulated_input: Field.Var.t * Field.Var.t
       ; proof: Proof.t }
 
     type witness = unit
@@ -457,8 +457,8 @@ struct
         @-> Pb.Variable.typ @-> Proof.typ @-> Pb.Variable.typ
         @-> returning gadget_typ )
 
-    let create pb (conv : Field.Checked.t -> Pb.Variable.t)
-        (conv_back : Pb.Variable.t -> Field.Checked.t)
+    let create pb (conv : Field.Var.t -> Pb.Variable.t)
+        (conv_back : Pb.Variable.t -> Field.Var.t)
         {pvk; accumulated_input= acc_x, acc_y; proof} =
       let acc_x = conv acc_x and acc_y = conv acc_y in
       let result_pb = Pb.allocate_variable pb in
@@ -501,8 +501,8 @@ struct
         ; vk: Verification_key_var.t
         ; proof: Proof.t
         ; result: Boolean.var
-        ; vk_characterizing_vars_up_to_sign: Field.Checked.t list
-        ; vk_sign_vars: Field.Checked.t list }
+        ; vk_characterizing_vars_up_to_sign: Field.Var.t list
+        ; vk_sign_vars: Field.Var.t list }
 
       type input = Inner_curve.var
 
@@ -539,19 +539,19 @@ struct
         let open Libsnark.Linear_combination in
         let var = Pb.Variable.of_int (Libsnark.Var.index (Term.var term)) in
         let coeff = Term.coeff term in
-        Field.Checked.scale (conv_back var) coeff
+        Field.Var.scale (conv_back var) coeff
 
       let conv_lc conv_back lc =
         let open Libsnark.Linear_combination in
         let terms = terms lc in
         let n = Term.Vector.length terms in
-        if Int.equal n 0 then Field.Checked.constant Field.zero
+        if Int.equal n 0 then Field.Var.constant Field.zero
         else
           let rec go i acc =
             if Int.equal i n then acc
             else
               let term = Term.Vector.get terms i in
-              let acc = Field.Checked.add (conv_term conv_back term) acc in
+              let acc = Field.Var.add (conv_term conv_back term) acc in
               go (i + 1) acc
           in
           go 1 (conv_term conv_back (Term.Vector.get terms 0))

--- a/src/knapsack.ml
+++ b/src/knapsack.ml
@@ -35,14 +35,14 @@ module Make (Impl : Snark_intf.S) = struct
 
   module Checked = struct
     let hash_to_field ({dimension; max_input_length; coefficients} : t)
-        (vs : Boolean.var list) : (Field.Checked.t list, _) Checked.t =
-      let vs = (vs :> Field.Checked.t list) in
+        (vs : Boolean.var list) : (Field.Var.t list, _) Checked.t =
+      let vs = (vs :> Field.Var.t list) in
       let input_len = List.length vs in
       if input_len > max_input_length then
         failwithf "Input size %d exceeded max %d" input_len max_input_length () ;
       List.map coefficients ~f:(fun cs ->
-          Field.Checked.linear_combination
-            (map2_lax cs vs ~f:(fun c v -> (c, v))) )
+          Field.Var.linear_combination (map2_lax cs vs ~f:(fun c v -> (c, v)))
+      )
       |> Checked.return
 
     let hash_to_bits (t : t) (vs : Boolean.var list) :
@@ -91,12 +91,12 @@ module Make (Impl : Snark_intf.S) = struct
         let open Field.Checked.Infix in
         assert_all
           (List.map3_exn
-             (xs :> Field.Checked.t list)
-             (ys :> Field.Checked.t list)
-             (res :> Field.Checked.t list)
+             (xs :> Field.Var.t list)
+             (ys :> Field.Var.t list)
+             (res :> Field.Var.t list)
              ~f:(fun x y r ->
                Constraint.r1cs ~label:"Knapsack.Hash.if_"
-                 (b :> Field.Checked.t)
+                 (b :> Field.Var.t)
                  (y - x) (r - x) ))
       in
       res

--- a/src/knapsack.mli
+++ b/src/knapsack.mli
@@ -29,7 +29,7 @@ module Make (M : Snark_intf.S) : sig
 
   module Checked : sig
     val hash_to_field :
-      t -> Boolean.var list -> (Field.Checked.t list, _) Checked.t
+      t -> Boolean.var list -> (Field.Var.t list, _) Checked.t
 
     val hash_to_bits : t -> Boolean.var list -> (Boolean.var list, _) Checked.t
   end

--- a/src/number.ml
+++ b/src/number.ml
@@ -17,7 +17,7 @@ module Make (Impl : Snark_intf.Basic) = struct
   type t =
     { upper_bound: Bignum_bigint.t
     ; lower_bound: Bignum_bigint.t
-    ; var: Field.Checked.t
+    ; var: Field.Var.t
     ; bits: Boolean.var list option }
 
   let two_to_the n =
@@ -76,7 +76,7 @@ module Make (Impl : Snark_intf.Basic) = struct
          let%bind fits = Field.Checked.equal t.var g in
          let%map r =
            Field.Checked.if_ fits ~then_:g
-             ~else_:(Field.Checked.constant Field.(sub (two_to_the n) one))
+             ~else_:(Field.Var.constant Field.(sub (two_to_the n) one))
          in
          { upper_bound= Bignum_bigint.(k - one)
          ; lower_bound= t.lower_bound
@@ -140,7 +140,7 @@ module Make (Impl : Snark_intf.Basic) = struct
     let n = Bigint.to_bignum_bigint tick_n in
     { upper_bound= n
     ; lower_bound= n
-    ; var= Field.Checked.constant x
+    ; var= Field.Var.constant x
     ; bits=
         Some
           (List.init (bigint_num_bits n) ~f:(fun i ->
@@ -166,7 +166,7 @@ module Make (Impl : Snark_intf.Basic) = struct
     if upper_bound < Field.size then
       { upper_bound
       ; lower_bound= x.lower_bound + y.lower_bound
-      ; var= Field.Checked.add x.var y.var
+      ; var= Field.Var.add x.var y.var
       ; bits= None }
     else
       failwithf "Number.+: Potential overflow: (%s + %s > Field.size)"
@@ -178,7 +178,7 @@ module Make (Impl : Snark_intf.Basic) = struct
     if x.lower_bound >= y.upper_bound then
       { upper_bound= x.upper_bound - y.lower_bound
       ; lower_bound= x.lower_bound - y.upper_bound
-      ; var= Field.Checked.sub x.var y.var
+      ; var= Field.Var.sub x.var y.var
       ; bits= None }
     else
       failwithf "Number.-: Potential underflow (%s < %s)"

--- a/src/number.ml
+++ b/src/number.ml
@@ -38,7 +38,7 @@ module Make (Impl : Snark_intf.Basic) = struct
     assert (n < Field.size_in_bits) ;
     { upper_bound= Bignum_bigint.(pow2 n - one)
     ; lower_bound= Bignum_bigint.zero
-    ; var= Field.Checked.pack bs
+    ; var= Field.Var.pack bs
     ; bits= Some bs }
 
   let mul_pow_2 n (`Two_to_the k) =
@@ -50,7 +50,7 @@ module Make (Impl : Snark_intf.Basic) = struct
     assert (Bignum_bigint.(upper_bound < Field.size)) ;
     { upper_bound
     ; lower_bound= Bignum_bigint.(n.lower_bound * pow (of_int 2) (of_int k))
-    ; var= Field.Checked.pack multiplied
+    ; var= Field.Var.pack multiplied
     ; bits= Some multiplied }
 
   let div_pow_2 n (`Two_to_the k) =
@@ -72,7 +72,7 @@ module Make (Impl : Snark_intf.Basic) = struct
        else
          let%bind bs = to_bits t in
          let bs' = List.take bs n in
-         let g = Field.Checked.project bs' in
+         let g = Field.Var.project bs' in
          let%bind fits = Field.Checked.equal t.var g in
          let%map r =
            Field.Checked.if_ fits ~then_:g

--- a/src/number.mli
+++ b/src/number.mli
@@ -2,5 +2,5 @@ module Make (Impl : Snark_intf.Basic) :
   Number_intf.S
   with type ('a, 'b) checked := ('a, 'b) Impl.Checked.t
    and type field := Impl.Field.t
-   and type field_var := Impl.Field.Checked.t
+   and type field_var := Impl.Field.Var.t
    and type bool_var := Impl.Boolean.var

--- a/src/pedersen.ml
+++ b/src/pedersen.ml
@@ -7,7 +7,7 @@ let local_function ~negate quad (b0, b1, b2) =
 
 module Make
     (Impl : Snark_intf.S) (Weierstrass_curve : sig
-        type var = Impl.Field.Checked.t * Impl.Field.Checked.t
+        type var = Impl.Field.Var.t * Impl.Field.Var.t
 
         type t [@@deriving eq]
 
@@ -44,7 +44,7 @@ module Make
   open Impl
 
   module Digest : sig
-    type var = Field.Checked.t
+    type var = Field.Var.t
 
     module Unpacked : sig
       type var = private Boolean.var list
@@ -53,7 +53,7 @@ module Make
 
       val typ : (var, t) Typ.t
 
-      val project : var -> Field.Checked.t
+      val project : var -> Field.Var.t
 
       val constant : t -> var
     end
@@ -117,10 +117,10 @@ end = struct
     let%bind s_and = Boolean.(s0 && s1) in
     let open Field.Checked.Infix in
     let lookup_one (a1, a2, a3, a4) =
-      Field.Checked.constant a1
-      + (Field.Infix.(a2 - a1) * (s0 :> Field.Checked.t))
-      + (Field.Infix.(a3 - a1) * (s1 :> Field.Checked.t))
-      + (Field.Infix.(a4 + a1 - a2 - a3) * (s_and :> Field.Checked.t))
+      Field.Var.constant a1
+      + (Field.Infix.(a2 - a1) * (s0 :> Field.Var.t))
+      + (Field.Infix.(a3 - a1) * (s1 :> Field.Var.t))
+      + (Field.Infix.(a4 + a1 - a2 - a3) * (s_and :> Field.Var.t))
     in
     let x_q, y_q = coords q in
     let x = lookup_one x_q in
@@ -128,8 +128,7 @@ end = struct
       let sign =
         (* sign = 1 if s2 = 0
           sign = -1 if s2 = 1 *)
-        Field.Checked.constant Field.one
-        - (Field.of_int 2 * (s2 :> Field.Checked.t))
+        Field.Var.constant Field.one - (Field.of_int 2 * (s2 :> Field.Var.t))
       in
       Field.Checked.mul sign (lookup_one y_q)
     in
@@ -150,7 +149,7 @@ end = struct
       let constant = List.map ~f:Boolean.var_of_value
     end
 
-    type var = Field.Checked.t
+    type var = Field.Var.t
 
     type t = Field.t
 

--- a/src/pedersen.ml
+++ b/src/pedersen.ml
@@ -144,7 +144,7 @@ end = struct
 
       let typ : (var, t) Typ.t = Typ.list Boolean.typ ~length:length_in_bits
 
-      let project = Field.Checked.project
+      let project = Field.Var.project
 
       let constant = List.map ~f:Boolean.var_of_value
     end

--- a/src/sha256.ml
+++ b/src/sha256.ml
@@ -330,14 +330,14 @@ end = struct
 
         type t =
           { gadget: Compression_gadget.t
-          ; output_unconstrained: Impl.Field.var list }
+          ; output_unconstrained: Impl.Field.Var.t list }
 
         let create pb conv conv_back {prev_state; block} =
           let conv_bits (bits : Boolean.var list) =
             let arr = Protoboard.Variable_array.create () in
             List.iter bits ~f:(fun b ->
                 Protoboard.Variable_array.emplace_back arr
-                  (conv (b :> Impl.Field.var)) ) ;
+                  (conv (b :> Impl.Field.Var.t)) ) ;
             arr
           in
           let prev_state = conv_bits prev_state in

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -1095,16 +1095,22 @@ module Make_basic (Backend : Backend_intf.S) = struct
         Bignum_bigint.(gen_incl zero (size - one))
         ~f:(fun x -> Bigint.(to_field (of_bignum_bigint x)))
 
-    type var = Cvar.t
+    type var__ = Cvar.t
 
     let typ = Typ.field
 
-    module Checked = struct
+    type var' = Var.t
+
+    module Var = struct
       include Cvar1
 
-      let to_constant : var -> Field0.t option = function
+      let to_constant : t -> Field0.t option = function
         | Constant x -> Some x
         | _ -> None
+    end
+
+    module Checked = struct
+      include Cvar1
 
       let equal = Checked.equal
 

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -1095,8 +1095,6 @@ module Make_basic (Backend : Backend_intf.S) = struct
         Bignum_bigint.(gen_incl zero (size - one))
         ~f:(fun x -> Bigint.(to_field (of_bignum_bigint x)))
 
-    type var__ = Cvar.t
-
     let typ = Typ.field
 
     type var' = Var.t

--- a/src/snark_intf.ml
+++ b/src/snark_intf.ml
@@ -446,8 +446,6 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
       end
     end
 
-    type var__ = Var.t
-
     val typ : (Var.t, t) Typ.t
   end
 

--- a/src/snark_intf.ml
+++ b/src/snark_intf.ml
@@ -73,19 +73,18 @@ module type Basic = sig
 
   (** Rank-1 constraints over {!type:Var.t}s. *)
   module rec Constraint : sig
-    type t = Field.Checked.t Constraint0.t
+    type t = Field.Var.t Constraint0.t
 
     type 'k with_constraint_args = ?label:string -> 'k
 
-    val boolean : (Field.Checked.t -> t) with_constraint_args
+    val boolean : (Field.Var.t -> t) with_constraint_args
 
-    val equal : (Field.Checked.t -> Field.Checked.t -> t) with_constraint_args
+    val equal : (Field.Var.t -> Field.Var.t -> t) with_constraint_args
 
     val r1cs :
-      (Field.Checked.t -> Field.Checked.t -> Field.Checked.t -> t)
-      with_constraint_args
+      (Field.Var.t -> Field.Var.t -> Field.Var.t -> t) with_constraint_args
 
-    val square : (Field.Checked.t -> Field.Checked.t -> t) with_constraint_args
+    val square : (Field.Var.t -> Field.Var.t -> t) with_constraint_args
   end
   
   (** The data specification for checked computations. *)
@@ -109,31 +108,29 @@ module type Basic = sig
   and Typ : sig
     module Store : sig
       include
-        Monad.S
-        with type 'a t = ('a, Field.t, Field.Checked.t) Typ_monads.Store.t
+        Monad.S with type 'a t = ('a, Field.t, Field.Var.t) Typ_monads.Store.t
 
-      val store : field -> Field.Checked.t t
+      val store : field -> Field.Var.t t
     end
 
     module Alloc : sig
-      include Monad.S with type 'a t = ('a, Field.Checked.t) Typ_monads.Alloc.t
+      include Monad.S with type 'a t = ('a, Field.Var.t) Typ_monads.Alloc.t
 
-      val alloc : Field.Checked.t t
+      val alloc : Field.Var.t t
     end
 
     module Read : sig
       include
-        Monad.S
-        with type 'a t = ('a, Field.t, Field.Checked.t) Typ_monads.Read.t
+        Monad.S with type 'a t = ('a, Field.t, Field.Var.t) Typ_monads.Read.t
 
-      val read : Field.Checked.t -> field t
+      val read : Field.Var.t -> field t
     end
 
     type ('var, 'value) t =
       ( 'var
       , 'value
       , Field.t
-      , Field.Checked.t
+      , Field.Var.t
       , R1CS_constraint_system.t )
       Types.Typ.t
 
@@ -151,7 +148,7 @@ module type Basic = sig
 
     val unit : (unit, unit) t
 
-    val field : (Field.Checked.t, field) t
+    val field : (Field.Var.t, field) t
 
     (** Common constructors: *)
 
@@ -217,7 +214,7 @@ module type Basic = sig
       [false] to {!val:Field.zero}, adding a check in {!val:Boolean.typ} to
       ensure that these are the only vales. *)
   and Boolean : sig
-    type var = Field.Checked.t Boolean0.t
+    type var = Field.Var.t Boolean0.t
 
     type value = bool
 
@@ -237,7 +234,7 @@ module type Basic = sig
 
     val all : var list -> (var, _) Checked.t
 
-    val of_field : Field.Checked.t -> (var, _) Checked.t
+    val of_field : Field.Var.t -> (var, _) Checked.t
     (** Convert a value in a field to a boolean, adding checks to the R1CS that
        it is a valid boolean value. *)
 
@@ -275,7 +272,7 @@ module type Basic = sig
     end
 
     module Unsafe : sig
-      val of_cvar : Field.Checked.t -> var
+      val of_cvar : Field.Var.t -> var
     end
 
     module Assert : sig
@@ -304,8 +301,8 @@ module type Basic = sig
         do further checked computations. For example (using
         {{:https://github.com/janestreet/ppx_let}monad let-syntax}):
 {[
-let multiply3 (x : Field.Checked.t) (y : Field.Checked.t) (z : Field.Checked.t)
-  : (Field.Checked.t, _) Checked.t =
+let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
+  : (Field.Var.t, _) Checked.t =
   open Checked.Let_syntax in
   let%bind x_times_y = Field.Checked.mul x y in
   Field.Checked.mul x_times_y z
@@ -317,7 +314,7 @@ let multiply3 (x : Field.Checked.t) (y : Field.Checked.t) (z : Field.Checked.t)
                   ( 'a
                   , 's
                   , Field.t
-                  , Field.Checked.t
+                  , Field.Var.t
                   , R1CS_constraint_system.t )
                   Types.Checked.t
 
@@ -355,7 +352,9 @@ let multiply3 (x : Field.Checked.t) (y : Field.Checked.t) (z : Field.Checked.t)
     val project : bool list -> t
     (** Convert a list of bits into a field element. *)
 
-    module Checked : sig
+    type var' = Var.t
+
+    module Var : sig
       type t = (field, Var.t) Cvar.t
 
       val length : t -> int
@@ -380,73 +379,76 @@ let multiply3 (x : Field.Checked.t) (y : Field.Checked.t) (z : Field.Checked.t)
       val sub : t -> t -> t
 
       val scale : t -> field -> t
+    end
 
-      val mul : t -> t -> (t, _) Checked.t
+    module Checked : sig
+      val mul : Var.t -> Var.t -> (Var.t, _) Checked.t
 
-      val square : t -> (t, _) Checked.t
+      val square : Var.t -> (Var.t, _) Checked.t
 
-      val div : t -> t -> (t, _) Checked.t
+      val div : Var.t -> Var.t -> (Var.t, _) Checked.t
 
-      val inv : t -> (t, _) Checked.t
+      val inv : Var.t -> (Var.t, _) Checked.t
 
-      val equal : t -> t -> (Boolean.var, 's) Checked.t
+      val equal : Var.t -> Var.t -> (Boolean.var, 's) Checked.t
 
-      val project : Boolean.var list -> t
+      val project : Boolean.var list -> Var.t
 
-      val pack : Boolean.var list -> t
+      val pack : Boolean.var list -> Var.t
 
-      val unpack : t -> length:int -> (Boolean.var list, _) Checked.t
+      val unpack : Var.t -> length:int -> (Boolean.var list, _) Checked.t
 
       val unpack_flagged :
-           t
+           Var.t
         -> length:int
         -> (Boolean.var list * [`Success of Boolean.var], _) Checked.t
 
       val unpack_full :
-        t -> (Boolean.var Bitstring_lib.Bitstring.Lsb_first.t, _) Checked.t
+        Var.t -> (Boolean.var Bitstring_lib.Bitstring.Lsb_first.t, _) Checked.t
 
       val choose_preimage_var :
-        t -> length:int -> (Boolean.var list, _) Checked.t
+        Var.t -> length:int -> (Boolean.var list, _) Checked.t
 
       type comparison_result = {less: Boolean.var; less_or_equal: Boolean.var}
 
       val compare :
-        bit_length:int -> t -> t -> (comparison_result, _) Checked.t
+        bit_length:int -> Var.t -> Var.t -> (comparison_result, _) Checked.t
 
-      val if_ : Boolean.var -> then_:t -> else_:t -> (t, _) Checked.t
+      val if_ :
+        Boolean.var -> then_:Var.t -> else_:Var.t -> (Var.t, _) Checked.t
 
       module Infix : sig
-        val ( + ) : t -> t -> t
+        val ( + ) : Var.t -> Var.t -> Var.t
 
-        val ( - ) : t -> t -> t
+        val ( - ) : Var.t -> Var.t -> Var.t
 
-        val ( * ) : field -> t -> t
+        val ( * ) : field -> Var.t -> Var.t
       end
 
       module Unsafe : sig
-        val of_var : Var.t -> t
+        val of_var : var' -> Var.t
       end
 
       module Assert : sig
-        val lte : bit_length:int -> t -> t -> (unit, _) Checked.t
+        val lte : bit_length:int -> Var.t -> Var.t -> (unit, _) Checked.t
 
-        val gte : bit_length:int -> t -> t -> (unit, _) Checked.t
+        val gte : bit_length:int -> Var.t -> Var.t -> (unit, _) Checked.t
 
-        val lt : bit_length:int -> t -> t -> (unit, _) Checked.t
+        val lt : bit_length:int -> Var.t -> Var.t -> (unit, _) Checked.t
 
-        val gt : bit_length:int -> t -> t -> (unit, _) Checked.t
+        val gt : bit_length:int -> Var.t -> Var.t -> (unit, _) Checked.t
 
-        val not_equal : t -> t -> (unit, _) Checked.t
+        val not_equal : Var.t -> Var.t -> (unit, _) Checked.t
 
-        val equal : t -> t -> (unit, _) Checked.t
+        val equal : Var.t -> Var.t -> (unit, _) Checked.t
 
-        val non_zero : t -> (unit, _) Checked.t
+        val non_zero : Var.t -> (unit, _) Checked.t
       end
     end
 
-    type var = Checked.t
+    type var__ = Var.t
 
-    val typ : (var, t) Typ.t
+    val typ : (Var.t, t) Typ.t
   end
 
   include Monad.Syntax2 with type ('a, 's) t := ('a, 's) Checked.t
@@ -499,7 +501,7 @@ let multiply3 (x : Field.Checked.t) (y : Field.Checked.t) (z : Field.Checked.t)
 
     val map2 : ('a, 's) t -> ('b, 's) t -> f:('a -> 'b -> 'c) -> ('c, 's) t
 
-    val read_var : Field.Checked.t -> (field, 'prover_state) t
+    val read_var : Field.Var.t -> (field, 'prover_state) t
 
     val get_state : ('prover_state, 'prover_state) t
 
@@ -525,13 +527,13 @@ let multiply3 (x : Field.Checked.t) (y : Field.Checked.t) (z : Field.Checked.t)
 
   val assert_r1cs :
        ?label:string
-    -> Field.Checked.t
-    -> Field.Checked.t
-    -> Field.Checked.t
+    -> Field.Var.t
+    -> Field.Var.t
+    -> Field.Var.t
     -> (unit, _) Checked.t
 
   val assert_square :
-    ?label:string -> Field.Checked.t -> Field.Checked.t -> (unit, _) Checked.t
+    ?label:string -> Field.Var.t -> Field.Var.t -> (unit, _) Checked.t
 
   val as_prover : (unit, 's) As_prover.t -> (unit, 's) Checked.t
 
@@ -631,7 +633,7 @@ module type S = sig
     Number_intf.S
     with type ('a, 'b) checked := ('a, 'b) Checked.t
      and type field := field
-     and type field_var := Field.Checked.t
+     and type field_var := Field.Var.t
      and type bool_var := Boolean.var
 
   module Enumerable (M : sig
@@ -641,6 +643,6 @@ module type S = sig
     with type ('a, 'b) checked := ('a, 'b) Checked.t
      and type ('a, 'b) typ := ('a, 'b) Typ.t
      and type bool_var := Boolean.var
-     and type var = Field.var
+     and type var = Field.Var.t
      and type t := M.t
 end

--- a/src/snark_intf.ml
+++ b/src/snark_intf.ml
@@ -379,6 +379,10 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
       val sub : t -> t -> t
 
       val scale : t -> field -> t
+
+      val project : Boolean.var list -> t
+
+      val pack : Boolean.var list -> t
     end
 
     module Checked : sig
@@ -391,10 +395,6 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
       val inv : Var.t -> (Var.t, _) Checked.t
 
       val equal : Var.t -> Var.t -> (Boolean.var, 's) Checked.t
-
-      val project : Boolean.var list -> Var.t
-
-      val pack : Boolean.var list -> Var.t
 
       val unpack : Var.t -> length:int -> (Boolean.var list, _) Checked.t
 


### PR DESCRIPTION
This PR is the snarky portion of CodaProtocol/Coda#1409. It renames `Field.var`/`Field.Checked.t` to Field.Var.t and moves the unchecked functions on `Field.Var.t` into `Field.Var`.

Functions moved are: `length`, `var_indices`, `to_constant_and_terms`, `constant`, `to_constant`, `linear_combination`, `sum`, `add`, `sub` and `scale`.