### PR TITLE
Add local versions for snarkydef ppx, globally qualify the others

### DIFF
--- a/ppx/snarkydef.ml
+++ b/ppx/snarkydef.ml
@@ -15,48 +15,56 @@ let located_label_string ~loc str =
       [%e Exp.constant ~loc (Const.string (str ^ ": "))]
       Pervasives.__LOC__]
 
-let with_label ~loc exprs = Exp.apply ~loc [%expr with_label] exprs
+let with_label ~local ~loc exprs =
+  let with_label_expr =
+    if local then [%expr with_label] else [%expr Snarky.Checked.with_label]
+  in
+  Exp.apply ~loc with_label_expr exprs
 
-let with_label_one ~loc ~path:_ expr =
-  with_label ~loc [(Nolabel, located_label_expr expr)]
+let with_label_one ~local ~loc ~path:_ expr =
+  with_label ~local ~loc [(Nolabel, located_label_expr expr)]
 
-let rec snarkydef_inject ~loc ~name expr =
+let rec snarkydef_inject ~local ~loc ~name expr =
   match expr.pexp_desc with
   | Pexp_fun (lbl, default, pat, body) ->
       { expr with
         pexp_desc=
-          Pexp_fun (lbl, default, pat, snarkydef_inject ~loc ~name body) }
+          Pexp_fun (lbl, default, pat, snarkydef_inject ~local ~loc ~name body)
+      }
   | Pexp_newtype (typname, body) ->
       { expr with
-        pexp_desc= Pexp_newtype (typname, snarkydef_inject ~loc ~name body) }
+        pexp_desc=
+          Pexp_newtype (typname, snarkydef_inject ~local ~loc ~name body) }
   | Pexp_function _ ->
       Location.raise_errorf ~loc:expr.pexp_loc
         "%%snarkydef currently doesn't support 'function'"
   | _ ->
-      with_label ~loc
+      with_label ~local ~loc
         [(Nolabel, located_label_string ~loc name); (Nolabel, expr)]
 
-let snarkydef ~loc ~path:_ name expr =
+let snarkydef ~local ~loc ~path:_ name expr =
   [%stri
     let [%p Pat.var ~loc (Located.mk ~loc name)] =
-      [%e snarkydef_inject ~loc ~name expr]]
+      [%e snarkydef_inject ~local ~loc ~name expr]]
 
-let with_label_ext =
-  Extension.declare "with_label" Extension.Context.expression
+let with_label_ext ~local name =
+  Extension.declare name Extension.Context.expression
     Ast_pattern.(single_expr_payload __)
-    with_label_one
+    (with_label_one ~local)
 
-let snarkydef_ext =
-  Extension.declare "snarkydef" Extension.Context.structure_item
+let snarkydef_ext ~local name =
+  Extension.declare name Extension.Context.structure_item
     Ast_pattern.(
       pstr
         ( pstr_value nonrecursive
             (value_binding ~pat:(ppat_var __) ~expr:__ ^:: nil)
         ^:: nil ))
-    snarkydef
+    (snarkydef ~local)
 
 let main () =
   Driver.register_transformation name
     ~rules:
-      [ Context_free.Rule.extension with_label_ext
-      ; Context_free.Rule.extension snarkydef_ext ]
+      [ Context_free.Rule.extension (with_label_ext ~local:false "with_label")
+      ; Context_free.Rule.extension (with_label_ext ~local:true "with_label_")
+      ; Context_free.Rule.extension (snarkydef_ext ~local:false "snarkydef")
+      ; Context_free.Rule.extension (snarkydef_ext ~local:true "snarkydef_") ]

--- a/src/curves.ml
+++ b/src/curves.ml
@@ -312,7 +312,7 @@ module Edwards = struct
           ()
       end
 
-      let%snarkydef add_known (x1, y1) (x2, y2) =
+      let%snarkydef_ add_known (x1, y1) (x2, y2) =
         let x1x2 = Field.Checked.scale x1 x2
         and y1y2 = Field.Checked.scale y1 y2
         and x1y2 = Field.Checked.scale x1 y2
@@ -328,7 +328,7 @@ module Edwards = struct
         (a, b)
 
       (* TODO: Optimize -- could probably shave off one constraint. *)
-      let%snarkydef add (x1, y1) (x2, y2) =
+      let%snarkydef_ add (x1, y1) (x2, y2) =
         let%bind x1x2 = Field.Checked.mul x1 x2
         and y1y2 = Field.Checked.mul y1 y2
         and x1y2 = Field.Checked.mul x1 y2
@@ -343,7 +343,7 @@ module Edwards = struct
         in
         (a, b)
 
-      let%snarkydef double (x, y) =
+      let%snarkydef_ double (x, y) =
         let%bind xy = Field.Checked.mul x y
         and xx = Field.Checked.mul x x
         and yy = Field.Checked.mul y y in
@@ -399,7 +399,7 @@ module Edwards = struct
              in
              r)
 
-      let%snarkydef scale t (c : Scalar.var) =
+      let%snarkydef_ scale t (c : Scalar.var) =
         let rec go i acc pt = function
           | [] -> return acc
           | b :: bs ->
@@ -418,7 +418,7 @@ module Edwards = struct
             go 1 acc pt bs
 
       (* TODO: Unit test *)
-      let%snarkydef cond_add ((x2, y2) : value) ~to_:((x1, y1) : var)
+      let%snarkydef_ cond_add ((x2, y2) : value) ~to_:((x1, y1) : var)
           ~if_:(b : Boolean.var) : (var, _) Checked.t =
         let one = Field.Checked.constant Field.one in
         let b = (b :> Field.Checked.t) in
@@ -446,7 +446,7 @@ module Edwards = struct
         let%map x_res = res x1 x3 and y_res = res y1 y3 in
         (x_res, y_res)
 
-      let%snarkydef scale_known (t : value) (c : Scalar.var) =
+      let%snarkydef_ scale_known (t : value) (c : Scalar.var) =
         let rec go i acc pt = function
           | b :: bs ->
               let%bind acc' =
@@ -614,7 +614,7 @@ module Make_weierstrass_checked
     let equal = assert_equal
   end
 
-  let%snarkydef add' ~div (ax, ay) (bx, by) =
+  let%snarkydef_ add' ~div (ax, ay) (bx, by) =
     let open Let_syntax in
     let%bind lambda =
       div (Field.Checked.sub by ay) (Field.Checked.sub bx ax)
@@ -758,7 +758,7 @@ module Make_weierstrass_checked
       (module M : S)
   end
 
-  let%snarkydef double (ax, ay) =
+  let%snarkydef_ double (ax, ay) =
     let open Let_syntax in
     let%bind x_squared = Field.Checked.square ax in
     let%bind lambda =
@@ -808,7 +808,7 @@ module Make_weierstrass_checked
     in
     (choose x1 x2, choose y1 y2)
 
-  let%snarkydef scale (type shifted)
+  let%snarkydef_ scale (type shifted)
       (module Shifted : Shifted.S with type t = shifted) t
       (c : Boolean.var Bitstring_lib.Bitstring.Lsb_first.t) ~(init : shifted) :
       (shifted, _) Checked.t =

--- a/src/merkle_tree.ml
+++ b/src/merkle_tree.ml
@@ -396,7 +396,7 @@ struct
     | Set : Address.value * Elt.value -> unit Request.t
 
   (* addr0 should have least significant bit first *)
-  let%snarkydef modify_req ~(depth : int) root addr0 ~f :
+  let%snarkydef_ modify_req ~(depth : int) root addr0 ~f :
       (Hash.var, 's) Checked.t =
     let open Let_syntax in
     let%bind prev, prev_path =
@@ -422,7 +422,7 @@ struct
     implied_root next_entry_hash addr0 prev_path
 
   (* addr0 should have least significant bit first *)
-  let%snarkydef get_req ~(depth : int) root addr0 : (Elt.var, 's) Checked.t =
+  let%snarkydef_ get_req ~(depth : int) root addr0 : (Elt.var, 's) Checked.t =
     let open Let_syntax in
     let%bind prev, prev_path =
       request_witness
@@ -437,7 +437,7 @@ struct
     return prev
 
   (* addr0 should have least significant bit first *)
-  let%snarkydef update_req ~(depth : int) ~root ~prev ~next addr0 :
+  let%snarkydef_ update_req ~(depth : int) ~root ~prev ~next addr0 :
       (Hash.var, _) Checked.t =
     let open Let_syntax in
     let%bind prev_entry_hash = Elt.hash prev
@@ -461,7 +461,7 @@ struct
     implied_root next_entry_hash addr0 prev_path
 
   (* addr0 should have least significant bit first *)
-  let%snarkydef update ~(depth : int) ~root ~prev ~next addr0 :
+  let%snarkydef_ update ~(depth : int) ~root ~prev ~next addr0 :
       (Hash.var, (Hash.value, Elt.value) merkle_tree) Checked.t =
     let open Let_syntax in
     let%bind prev_entry_hash = Elt.hash prev

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -714,7 +714,7 @@ module Make_basic (Backend : Backend_intf.S) = struct
         let%bind y_inv = inv y in
         mul x y_inv)
 
-    let%snarkydef if_ (b : Cvar.t Boolean.t) ~(then_ : Cvar.t)
+    let%snarkydef_ if_ (b : Cvar.t Boolean.t) ~(then_ : Cvar.t)
         ~(else_ : Cvar.t) =
       let open Let_syntax in
       (* r = e + b (t - e)
@@ -739,7 +739,7 @@ module Make_basic (Backend : Backend_intf.S) = struct
           in
           r
 
-    let%snarkydef assert_non_zero (v : Cvar.t) =
+    let%snarkydef_ assert_non_zero (v : Cvar.t) =
       let open Let_syntax in
       let%map _ = inv v in
       ()
@@ -852,15 +852,15 @@ module Make_basic (Backend : Backend_intf.S) = struct
 
         let is_true (v : var) = v = true_
 
-        let%snarkydef any (bs : var list) =
+        let%snarkydef_ any (bs : var list) =
           assert_non_zero (Cvar.sum (bs :> Cvar.t list))
 
-        let%snarkydef all (bs : var list) =
+        let%snarkydef_ all (bs : var list) =
           assert_equal
             (Cvar.sum (bs :> Cvar.t list))
             (Cvar.constant (Field.of_int (List.length bs)))
 
-        let%snarkydef exactly_one (bs : var list) =
+        let%snarkydef_ exactly_one (bs : var list) =
           assert_equal (Cvar.sum (bs :> Cvar.t list)) (Cvar.constant Field.one)
       end
 
@@ -1126,7 +1126,7 @@ module Make_basic (Backend : Backend_intf.S) = struct
       let compare ~bit_length a b =
         let open Checked in
         let open Let_syntax in
-        [%with_label "compare"]
+        [%with_label_ "compare"]
           (let alpha_packed =
              Cvar.Infix.(Cvar.constant (two_to_the bit_length) + b - a)
            in


### PR DESCRIPTION
This PR changes the `snarkydef`and `with_label` ppx to output `Snarky.Checked.with_label`, and adds `snarkydef_` and `with_label_` for use inside the Snarky module itself.

This fixes #40.