### PR TITLE
Expose Stringable.S on Snark_intf.Proof.t

### DIFF
--- a/src/snark_intf.ml
+++ b/src/snark_intf.ml
@@ -453,6 +453,8 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
 
   module Proof : sig
     type t
+
+    include Stringable.S with type t := t
   end
 
   module Bitstring_checked : sig


### PR DESCRIPTION
From a question on gitter:

> Howdy! I've been playing around with the election example and have been trying to split up the proving from the verifying. For that, I need to serialize the proof. However, as a OCaml n00b, I'm having trouble understanding how to do that, as the type of the proof `Proof.t` is quite opaque to me. Could anyone help me out here?

This PR includes the backend's `Proof.to_string`/`of_string` functions in the `Snark_intf.Proof` module, to make them easier to find.