### PR TITLE
Carry locations in the ast

### DIFF
--- a/meja/parser_impl.mly
+++ b/meja/parser_impl.mly
@@ -2,12 +2,12 @@
 open Location
 open Parsetypes
 
-let mkrhs rhs pos = mkloc rhs (rhs_loc pos)
+let mklocation (loc_start, loc_end) = {loc_start; loc_end; loc_ghost= false}
 
-let mktyp d = {type_desc= d; type_id= -1; type_loc= none}
-let mkpat d = {pat_desc= d; pat_loc= none}
-let mkexp d = {exp_desc= d; exp_loc= none}
-let mkstmt d = {stmt_desc= d; stmt_loc= none}
+let mktyp ~pos d = {type_desc= d; type_id= -1; type_loc= mklocation pos}
+let mkpat ~pos d = {pat_desc= d; pat_loc= mklocation pos}
+let mkexp ~pos d = {exp_desc= d; exp_loc= mklocation pos}
+let mkstmt ~pos d = {stmt_desc= d; stmt_loc= mklocation pos}
 %}
 %token <int> INT
 %token <string> LIDENT
@@ -44,13 +44,13 @@ file:
 
 structure_item:
   | LET x = pat EQUAL e = expr
-    { mkstmt (Value (x, e)) }
+    { mkstmt ~pos:$loc (Value (x, e)) }
 
 expr:
-  | x = LIDENT
-    { mkexp (Variable (mkrhs x 1)) }
+  | x = as_loc(LIDENT)
+    { mkexp ~pos:$loc (Variable x) }
   | x = INT
-    { mkexp (Int x) }
+    { mkexp ~pos:$loc (Int x) }
   | FUN LBRACKET f = function_from_args
     { f }
   | LBRACKET es = exprs RBRACKET
@@ -58,9 +58,9 @@ expr:
   | LBRACE es = block RBRACE
     { es }
   | LET x = pat EQUAL lhs = expr SEMI rhs = expr
-    { mkexp (Let (x, lhs, rhs)) }
+    { mkexp ~pos:$loc (Let (x, lhs, rhs)) }
   | f = expr LBRACKET es = expr_list RBRACKET
-    { mkexp (Apply (f, List.rev es)) }
+    { mkexp ~pos:$loc (Apply (f, List.rev es)) }
 
 expr_list:
   | e = expr
@@ -76,37 +76,37 @@ expr_list_multiple:
 
 function_from_args:
   | p = pat RBRACKET EQUALGT LBRACE body = block RBRACE
-    { mkexp (Fun (p, body)) }
+    { mkexp ~pos:$loc (Fun (p, body)) }
   | p = pat RBRACKET typ = type_expr EQUALGT LBRACE body = block RBRACE
-    { mkexp (Fun (p, mkexp (Constraint (body, typ)))) }
+    { mkexp ~pos:$loc (Fun (p, mkexp ~pos:$loc(typ) (Constraint (body, typ)))) }
   | p = pat COMMA f = function_from_args
-    { mkexp (Fun (p, f)) }
+    { mkexp ~pos:$loc (Fun (p, f)) }
 
 exprs:
   | e = expr
     { e }
   | e1 = expr SEMI rest = exprs
-    { mkexp (Seq (e1, rest)) }
+    { mkexp ~pos:$loc (Seq (e1, rest)) }
 
 block:
   | e = expr SEMI
     { e }
   | e1 = expr SEMI rest = block
-    { mkexp (Seq (e1, rest)) }
+    { mkexp ~pos:$loc (Seq (e1, rest)) }
 
 pat:
   | LBRACKET p = pat RBRACKET
     { p }
   | p = pat COLON typ = type_expr
-    { mkpat (PConstraint (p, typ)) }
-  | x = LIDENT
-    { mkpat (PVariable (mkrhs x 1)) }
+    { mkpat ~pos:$loc (PConstraint (p, typ)) }
+  | x = as_loc(LIDENT)
+    { mkpat ~pos:$loc (PVariable x) }
 
 simple_type_expr:
   | UNDERSCORE
-    { mktyp (Tvar (None, 0)) }
-  | x = LIDENT
-    { mktyp (Tconstr (mkrhs x 1)) }
+    { mktyp ~pos:$loc (Tvar (None, 0)) }
+  | x = as_loc(LIDENT)
+    { mktyp ~pos:$loc (Tconstr x) }
   | LBRACKET x = type_expr RBRACKET
     { x }
 
@@ -114,4 +114,7 @@ type_expr:
   | x = simple_type_expr
     { x }
   | x = simple_type_expr DASHGT y = type_expr
-    { mktyp (Tarrow (x, y)) }
+    { mktyp ~pos:$loc (Tarrow (x, y)) }
+
+%inline as_loc(X): x = X
+  { mkloc x (mklocation ($symbolstartpos, $endpos)) }

--- a/meja/parsetypes.ml
+++ b/meja/parsetypes.ml
@@ -1,6 +1,6 @@
 type str = string Location.loc
 
-type type_expr = {type_desc: type_desc; type_id: int}
+type type_expr = {type_desc: type_desc; type_id: int; type_loc: Location.t}
 
 and type_desc =
   (* A type variable. Name is None when not yet chosen. *)
@@ -9,9 +9,13 @@ and type_desc =
   (* A type name. *)
   | Tconstr of str
 
-type pattern = PVariable of str | PConstraint of pattern * type_expr
+type pattern = {pat_desc: pattern_desc; pat_loc: Location.t}
 
-type expression =
+and pattern_desc = PVariable of str | PConstraint of pattern * type_expr
+
+type expression = {exp_desc: expression_desc; exp_loc: Location.t}
+
+and expression_desc =
   | Apply of expression * expression list
   | Variable of str
   | Int of int
@@ -20,4 +24,6 @@ type expression =
   | Let of pattern * expression * expression
   | Constraint of expression * type_expr
 
-type statement = Value of pattern * expression
+type statement = {stmt_desc: statement_desc; stmt_loc: Location.t}
+
+and statement_desc = Value of pattern * expression

--- a/meja/to_ocaml.ml
+++ b/meja/to_ocaml.ml
@@ -5,33 +5,42 @@ open Parsetypes
 
 let mk_lid name = Location.mkloc (Longident.Lident name.txt) name.loc
 
-let rec of_typ typ =
-  match typ.type_desc with
+let rec of_type_desc typ =
+  match typ with
   | Tvar (None, _) -> Typ.any ()
   | Tvar (Some name, _) -> Typ.var name.txt
-  | Tarrow (typ1, typ2) -> Typ.arrow Nolabel (of_typ typ1) (of_typ typ2)
+  | Tarrow (typ1, typ2) ->
+      Typ.arrow Nolabel (of_type_expr typ1) (of_type_expr typ2)
   | Tconstr name -> Typ.constr (mk_lid name) []
 
-let rec of_pattern = function
-  | PVariable str -> Pat.var str
-  | PConstraint (p, typ) -> Pat.constraint_ (of_pattern p) (of_typ typ)
+and of_type_expr typ = of_type_desc typ.type_desc
 
-let rec of_expression = function
+let rec of_pattern_desc = function
+  | PVariable str -> Pat.var str
+  | PConstraint (p, typ) -> Pat.constraint_ (of_pattern p) (of_type_expr typ)
+
+and of_pattern pat = of_pattern_desc pat.pat_desc
+
+let rec of_expression_desc = function
   | Apply (f, es) ->
       Exp.apply (of_expression f)
         (List.map ~f:(fun x -> (Nolabel, of_expression x)) es)
   | Variable name -> Exp.ident (mk_lid name)
   | Int i -> Exp.constant (Const.int i)
   | Fun (p, body) -> Exp.fun_ Nolabel None (of_pattern p) (of_expression body)
-  | Constraint (e, typ) -> Exp.constraint_ (of_expression e) (of_typ typ)
+  | Constraint (e, typ) -> Exp.constraint_ (of_expression e) (of_type_expr typ)
   | Seq (e1, e2) -> Exp.sequence (of_expression e1) (of_expression e2)
   | Let (p, e_rhs, e) ->
       Exp.let_ Nonrecursive
         [Vb.mk (of_pattern p) (of_expression e_rhs)]
         (of_expression e)
 
-let of_statement = function
+and of_expression exp = of_expression_desc exp.exp_desc
+
+let of_statement_desc = function
   | Value (p, e) ->
       Str.value Nonrecursive [Vb.mk (of_pattern p) (of_expression e)]
+
+let of_statement stmt = of_statement_desc stmt.stmt_desc
 
 let of_file = List.map ~f:of_statement

--- a/meja/to_ocaml.ml
+++ b/meja/to_ocaml.ml
@@ -5,42 +5,42 @@ open Parsetypes
 
 let mk_lid name = Location.mkloc (Longident.Lident name.txt) name.loc
 
-let rec of_type_desc typ =
+let rec of_type_desc ?loc typ =
   match typ with
-  | Tvar (None, _) -> Typ.any ()
-  | Tvar (Some name, _) -> Typ.var name.txt
+  | Tvar (None, _) -> Typ.any ?loc ()
+  | Tvar (Some name, _) -> Typ.var ?loc name.txt
   | Tarrow (typ1, typ2) ->
-      Typ.arrow Nolabel (of_type_expr typ1) (of_type_expr typ2)
-  | Tconstr name -> Typ.constr (mk_lid name) []
+      Typ.arrow ?loc Nolabel (of_type_expr typ1) (of_type_expr typ2)
+  | Tconstr name -> Typ.constr ?loc (mk_lid name) []
 
-and of_type_expr typ = of_type_desc typ.type_desc
+and of_type_expr typ = of_type_desc ~loc:typ.type_loc typ.type_desc
 
-let rec of_pattern_desc = function
-  | PVariable str -> Pat.var str
-  | PConstraint (p, typ) -> Pat.constraint_ (of_pattern p) (of_type_expr typ)
+let rec of_pattern_desc ?loc = function
+  | PVariable str -> Pat.var ?loc str
+  | PConstraint (p, typ) -> Pat.constraint_ ?loc (of_pattern p) (of_type_expr typ)
 
-and of_pattern pat = of_pattern_desc pat.pat_desc
+and of_pattern pat = of_pattern_desc ~loc:pat.pat_loc pat.pat_desc
 
-let rec of_expression_desc = function
+let rec of_expression_desc ?loc = function
   | Apply (f, es) ->
-      Exp.apply (of_expression f)
+      Exp.apply ?loc (of_expression f)
         (List.map ~f:(fun x -> (Nolabel, of_expression x)) es)
-  | Variable name -> Exp.ident (mk_lid name)
-  | Int i -> Exp.constant (Const.int i)
-  | Fun (p, body) -> Exp.fun_ Nolabel None (of_pattern p) (of_expression body)
-  | Constraint (e, typ) -> Exp.constraint_ (of_expression e) (of_type_expr typ)
-  | Seq (e1, e2) -> Exp.sequence (of_expression e1) (of_expression e2)
+  | Variable name -> Exp.ident ?loc (mk_lid name)
+  | Int i -> Exp.constant ?loc (Const.int i)
+  | Fun (p, body) -> Exp.fun_ ?loc Nolabel None (of_pattern p) (of_expression body)
+  | Constraint (e, typ) -> Exp.constraint_ ?loc (of_expression e) (of_type_expr typ)
+  | Seq (e1, e2) -> Exp.sequence ?loc (of_expression e1) (of_expression e2)
   | Let (p, e_rhs, e) ->
-      Exp.let_ Nonrecursive
+      Exp.let_ ?loc Nonrecursive
         [Vb.mk (of_pattern p) (of_expression e_rhs)]
         (of_expression e)
 
-and of_expression exp = of_expression_desc exp.exp_desc
+and of_expression exp = of_expression_desc ~loc:exp.exp_loc exp.exp_desc
 
-let of_statement_desc = function
+let of_statement_desc ?loc = function
   | Value (p, e) ->
-      Str.value Nonrecursive [Vb.mk (of_pattern p) (of_expression e)]
+      Str.value ?loc Nonrecursive [Vb.mk (of_pattern p) (of_expression e)]
 
-let of_statement stmt = of_statement_desc stmt.stmt_desc
+let of_statement stmt = of_statement_desc ~loc:stmt.stmt_loc stmt.stmt_desc
 
 let of_file = List.map ~f:of_statement

--- a/meja/to_ocaml.ml
+++ b/meja/to_ocaml.ml
@@ -17,7 +17,8 @@ and of_type_expr typ = of_type_desc ~loc:typ.type_loc typ.type_desc
 
 let rec of_pattern_desc ?loc = function
   | PVariable str -> Pat.var ?loc str
-  | PConstraint (p, typ) -> Pat.constraint_ ?loc (of_pattern p) (of_type_expr typ)
+  | PConstraint (p, typ) ->
+      Pat.constraint_ ?loc (of_pattern p) (of_type_expr typ)
 
 and of_pattern pat = of_pattern_desc ~loc:pat.pat_loc pat.pat_desc
 
@@ -27,8 +28,10 @@ let rec of_expression_desc ?loc = function
         (List.map ~f:(fun x -> (Nolabel, of_expression x)) es)
   | Variable name -> Exp.ident ?loc (mk_lid name)
   | Int i -> Exp.constant ?loc (Const.int i)
-  | Fun (p, body) -> Exp.fun_ ?loc Nolabel None (of_pattern p) (of_expression body)
-  | Constraint (e, typ) -> Exp.constraint_ ?loc (of_expression e) (of_type_expr typ)
+  | Fun (p, body) ->
+      Exp.fun_ ?loc Nolabel None (of_pattern p) (of_expression body)
+  | Constraint (e, typ) ->
+      Exp.constraint_ ?loc (of_expression e) (of_type_expr typ)
   | Seq (e1, e2) -> Exp.sequence ?loc (of_expression e1) (of_expression e2)
   | Let (p, e_rhs, e) ->
       Exp.let_ ?loc Nonrecursive

--- a/meja/typechecker.ml
+++ b/meja/typechecker.ml
@@ -107,8 +107,7 @@ and check_binding (env : Envi.t) p e : 's =
   let e_type, env = get_expression env e in
   check_pattern ~add:Envi.add_final env e_type p
 
-let check_statement_desc env = function
-  | Value (p, e) -> check_binding env p e
+let check_statement_desc env = function Value (p, e) -> check_binding env p e
 
 let check_statement env stmt = check_statement_desc env stmt.stmt_desc
 

--- a/meja/typechecker.ml
+++ b/meja/typechecker.ml
@@ -52,14 +52,17 @@ let rec check_type_aux typ ctyp env =
 
 let check_type env typ constr_typ = check_type_aux typ constr_typ env
 
-let rec check_pattern ~add env typ = function
+let rec check_pattern_desc ~loc:_ ~add env typ = function
   | PVariable str -> add str typ env
   | PConstraint (p, constr_typ) ->
       let constr_typ, env = Envi.Type.import constr_typ env in
       let env = check_type env typ constr_typ in
       check_pattern ~add env constr_typ p
 
-let rec get_expression env = function
+and check_pattern ~add env typ pat =
+  check_pattern_desc ~loc:pat.pat_loc ~add env typ pat.pat_desc
+
+let rec get_expression_desc ~loc env = function
   | Apply (f, xs) ->
       let f_typ, env = get_expression env f in
       let rec apply_typ xs f_typ env =
@@ -67,23 +70,23 @@ let rec get_expression env = function
         | [] -> (f_typ, env)
         | x :: xs ->
             let x_typ, env = get_expression env x in
-            let retvar, env = Envi.Type.mkvar None env in
-            let arrow, env = Envi.Type.mk (Tarrow (x_typ, retvar)) env in
+            let retvar, env = Envi.Type.mkvar ~loc None env in
+            let arrow, env = Envi.Type.mk ~loc (Tarrow (x_typ, retvar)) env in
             let env = check_type env f_typ arrow in
             apply_typ xs retvar env
       in
       apply_typ xs f_typ env
   | Variable name -> Envi.get_name name env
-  | Int _ -> Envi.Type.mk (Tconstr {txt= "int"; loc= Location.none}) env
+  | Int _ -> Envi.Type.mk ~loc (Tconstr {txt= "int"; loc= Location.none}) env
   | Fun (p, body) ->
       let env = Envi.open_scope env in
-      let p_typ, env = Envi.Type.mkvar None env in
+      let p_typ, env = Envi.Type.mkvar ~loc None env in
       (* In OCaml, function arguments can't be polymorphic, so each check refines
        them rather than instantiating the parameters. *)
       let env = check_pattern ~add:Envi.add_in_progress env p_typ p in
       let body_typ, env = get_expression env body in
       let env = Envi.close_scope env in
-      Envi.Type.mk (Tarrow (p_typ, body_typ)) env
+      Envi.Type.mk ~loc (Tarrow (p_typ, body_typ)) env
   | Seq (e1, e2) ->
       let _, env = get_expression env e1 in
       get_expression env e2
@@ -97,12 +100,17 @@ let rec get_expression env = function
       let e_typ, env = get_expression env e in
       (typ, check_type env e_typ typ)
 
+and get_expression env exp =
+  get_expression_desc ~loc:exp.exp_loc env exp.exp_desc
+
 and check_binding (env : Envi.t) p e : 's =
   let e_type, env = get_expression env e in
   check_pattern ~add:Envi.add_final env e_type p
 
-let check_statement env = function Value (p, e) -> check_binding env p e
+let check_statement_desc env = function
+  | Value (p, e) -> check_binding env p e
+
+let check_statement env stmt = check_statement_desc env stmt.stmt_desc
 
 let check (ast : statement list) =
-  List.fold_left ast ~init:Envi.empty ~f:(fun env stmt ->
-      check_statement env stmt )
+  List.fold_left ast ~init:Envi.empty ~f:check_statement


### PR DESCRIPTION
This adds a location to all parts of the AST, so that we can have useful, located error messages later.