### PR TITLE
[Meja] Add Tpoly for tracking polymorphic variables

### DIFF
--- a/meja/envi.ml
+++ b/meja/envi.ml
@@ -82,7 +82,7 @@ module Type = struct
           let var, env = mkvar ~loc name env in
           (var, {env with type_env= TypeEnvi.add_variable x var env.type_env})
       )
-    | Tconstr _ -> mk ~loc typ.type_desc env
+    | Tctor _ -> mk ~loc typ.type_desc env
     | Ttuple typs ->
         let env, typs =
           List.fold_map typs ~init:env ~f:(fun e t ->

--- a/meja/envi.ml
+++ b/meja/envi.ml
@@ -208,7 +208,7 @@ module Type = struct
           (flattened_typ, add_instance typ typ' env)
       | None -> (typ, env) )
     | Tpoly (vars, typ) ->
-        let (env, var_set) =
+        let env, var_set =
           List.fold vars
             ~init:(env, Set.empty (module Comparator))
             ~f:(fun (env, set) var ->

--- a/meja/envi.ml
+++ b/meja/envi.ml
@@ -1,24 +1,27 @@
 open Core_kernel
 open Parsetypes
 
-type 'a ready = Final of 'a | In_progress of 'a
-
 type 'a name_map = (string, 'a, String.comparator_witness) Base.Map.t
 
 type 'a int_map = (int, 'a, Int.comparator_witness) Base.Map.t
 
 module Scope = struct
-  type t = {names: type_expr ready name_map}
+  type t = {names: type_expr name_map; type_variables: type_expr name_map}
 
-  let empty = {names= Map.empty (module String)}
+  let empty =
+    { names= Map.empty (module String)
+    ; type_variables= Map.empty (module String) }
 
-  let add_final {Location.txt= name; _} typ scope =
-    {names= Map.update scope.names name ~f:(fun _ -> Final typ)}
-
-  let add_in_progress {Location.txt= name; _} typ scope =
-    {names= Map.update scope.names name ~f:(fun _ -> In_progress typ)}
+  let add_name {Location.txt= name; _} typ scope =
+    {scope with names= Map.update scope.names name ~f:(fun _ -> typ)}
 
   let get_name {Location.txt= name; _} {names; _} = Map.find names name
+
+  let add_type_variable name typ scope =
+    { scope with
+      type_variables= Map.update scope.type_variables name ~f:(fun _ -> typ) }
+
+  let find_type_variable name scope = Map.find scope.type_variables name
 end
 
 module TypeEnvi = struct
@@ -43,58 +46,12 @@ module TypeEnvi = struct
   let clear_instance (typ : type_expr) env =
     {env with variable_instances= Map.remove env.variable_instances typ.type_id}
 
-  let add_variable name typ env =
-    {env with variables= Map.update env.variables name ~f:(fun _ -> typ)}
-
-  let find_variable name env = Map.find env.variables name
-
   let next_id env = (env.type_id, {env with type_id= env.type_id + 1})
 end
 
 type t = {scope_stack: Scope.t list; type_env: TypeEnvi.t; depth: int}
 
 let empty = {scope_stack= [Scope.empty]; type_env= TypeEnvi.empty; depth= 0}
-
-module Type = struct
-  let mk ~loc type_desc env =
-    let type_id, type_env = TypeEnvi.next_id env.type_env in
-    let env = {env with type_env} in
-    ({type_desc; type_id; type_loc= loc}, env)
-
-  let mkvar ~loc name env = mk ~loc (Tvar (name, env.depth)) env
-
-  let instance env typ = TypeEnvi.instance env.type_env typ
-
-  let map_env ~f env = {env with type_env= f env.type_env}
-
-  let add_instance typ typ' = map_env ~f:(TypeEnvi.add_instance typ typ')
-
-  let clear_instance typ = map_env ~f:(TypeEnvi.clear_instance typ)
-
-  let rec import typ env =
-    let loc = typ.type_loc in
-    match typ.type_desc with
-    | Tvar (None, _) -> mkvar ~loc None env
-    | Tvar ((Some {txt= x; _} as name), _) -> (
-      match TypeEnvi.find_variable x env.type_env with
-      | Some var -> (var, env)
-      | None ->
-          let var, env = mkvar ~loc name env in
-          (var, {env with type_env= TypeEnvi.add_variable x var env.type_env})
-      )
-    | Tctor _ -> mk ~loc typ.type_desc env
-    | Ttuple typs ->
-        let env, typs =
-          List.fold_map typs ~init:env ~f:(fun e t ->
-              let t, e = import t e in
-              (e, t) )
-        in
-        mk ~loc (Ttuple typs) env
-    | Tarrow (typ1, typ2) ->
-        let typ1, env = import typ1 env in
-        let typ2, env = import typ2 env in
-        mk ~loc (Tarrow (typ1, typ2)) env
-end
 
 let current_scope {scope_stack; _} =
   match List.hd scope_stack with
@@ -115,13 +72,134 @@ let map_current_scope ~f env =
       {env with scope_stack= f current_scope :: scope_stack}
   | [] -> failwith "No environment scopes are open"
 
-let add_final name typ = map_current_scope ~f:(Scope.add_final name typ)
+let add_type_variable name typ =
+  map_current_scope ~f:(Scope.add_type_variable name typ)
 
-let add_in_progress name typ =
-  map_current_scope ~f:(Scope.add_in_progress name typ)
+let find_type_variable name env =
+  List.find_map ~f:(Scope.find_type_variable name) env.scope_stack
+
+module Type = struct
+  let mk ~loc type_desc env =
+    let type_id, type_env = TypeEnvi.next_id env.type_env in
+    let env = {env with type_env} in
+    ({type_desc; type_id; type_loc= loc}, env)
+
+  let mkvar ~loc name env = mk ~loc (Tvar (name, env.depth)) env
+
+  let instance env typ = TypeEnvi.instance env.type_env typ
+
+  let map_env ~f env = {env with type_env= f env.type_env}
+
+  let add_instance typ typ' = map_env ~f:(TypeEnvi.add_instance typ typ')
+
+  let clear_instance typ = map_env ~f:(TypeEnvi.clear_instance typ)
+
+  let rec import ?(force_new = false) typ env =
+    let loc = typ.type_loc in
+    match typ.type_desc with
+    | Tvar (None, _) -> mkvar ~loc None env
+    | Tvar ((Some {txt= x; _} as name), _) -> (
+        let var = if force_new then None else find_type_variable x env in
+        match var with
+        | Some var -> (var, env)
+        | None ->
+            let var, env = mkvar ~loc name env in
+            (var, add_type_variable x var env) )
+    | Tpoly (vars, typ) ->
+        let env = open_scope env in
+        let env, vars =
+          List.fold_map vars ~init:env ~f:(fun e t ->
+              let t, e = import ~force_new:true t e in
+              (e, t) )
+        in
+        let typ, env = import typ env in
+        let env = close_scope env in
+        mk ~loc (Tpoly (vars, typ)) env
+    | Tctor _ -> mk ~loc typ.type_desc env
+    | Ttuple typs ->
+        let env, typs =
+          List.fold_map typs ~init:env ~f:(fun e t ->
+              let t, e = import t e in
+              (e, t) )
+        in
+        mk ~loc (Ttuple typs) env
+    | Tarrow (typ1, typ2) ->
+        let typ1, env = import typ1 env in
+        let typ2, env = import typ2 env in
+        mk ~loc (Tarrow (typ1, typ2)) env
+
+  let rec copy typ new_vars_map env =
+    let loc = typ.type_loc in
+    match typ.type_desc with
+    | Tvar _ -> (
+      match Map.find new_vars_map typ.type_id with
+      | Some var -> (var, env)
+      | None -> (typ, env) )
+    | Tpoly (vars, typ) ->
+        let env, vars =
+          List.fold_map vars ~init:env ~f:(fun e t ->
+              let t, e = import ~force_new:true t e in
+              (e, t) )
+        in
+        let new_vars_map =
+          List.fold ~init:new_vars_map vars ~f:(fun map var ->
+              Map.update map var.type_id ~f:(fun _ -> var) )
+        in
+        let typ, env = copy typ new_vars_map env in
+        mk ~loc (Tpoly (vars, typ)) env
+    | Tctor _ -> mk ~loc typ.type_desc env
+    | Ttuple typs ->
+        let env, typs =
+          List.fold_map typs ~init:env ~f:(fun e t ->
+              let t, e = copy t new_vars_map e in
+              (e, t) )
+        in
+        mk ~loc (Ttuple typs) env
+    | Tarrow (typ1, typ2) ->
+        let typ1, env = copy typ1 new_vars_map env in
+        let typ2, env = copy typ2 new_vars_map env in
+        mk ~loc (Tarrow (typ1, typ2)) env
+
+  let rec flatten typ env =
+    let loc = typ.type_loc in
+    match typ.type_desc with
+    | Tvar _ -> (
+      match instance env typ with
+      | Some typ' ->
+          let flattened_typ, env = flatten typ' (clear_instance typ env) in
+          (flattened_typ, add_instance typ typ' env)
+      | None -> (typ, env) )
+    | Tpoly (vars, typ) ->
+        let typ, env = flatten typ env in
+        mk ~loc (Tpoly (vars, typ)) env
+    | Tctor _ -> mk ~loc typ.type_desc env
+    | Ttuple typs ->
+        let env, typs =
+          List.fold_map typs ~init:env ~f:(fun e t ->
+              let t, e = flatten t e in
+              (e, t) )
+        in
+        mk ~loc (Ttuple typs) env
+    | Tarrow (typ1, typ2) ->
+        let typ1, env = flatten typ1 env in
+        let typ2, env = flatten typ2 env in
+        mk ~loc (Tarrow (typ1, typ2)) env
+
+  module T = struct
+    type t = type_expr
+
+    let compare typ1 typ2 = Int.compare typ1.type_id typ2.type_id
+
+    let sexp_of_t typ = Int.sexp_of_t typ.type_id
+  end
+
+  include T
+  include Comparator.Make (T)
+end
+
+let add_name name typ = map_current_scope ~f:(Scope.add_name name typ)
 
 let get_name name env =
   match List.find_map ~f:(Scope.get_name name) env.scope_stack with
-  | Some (In_progress typ) -> (typ, env)
-  | Some (Final typ) -> Type.import typ env
+  | Some typ -> Type.copy typ (Map.empty (module Int)) env
   | None -> failwith "Could not find name."

--- a/meja/parser_impl.mly
+++ b/meja/parser_impl.mly
@@ -104,7 +104,7 @@ simple_type_expr:
   | UNDERSCORE
     { mktyp ~pos:$loc (Tvar (None, 0)) }
   | x = as_loc(LIDENT)
-    { mktyp ~pos:$loc (Tconstr x) }
+    { mktyp ~pos:$loc (Tctor x) }
   | LBRACKET x = type_expr RBRACKET
     { x }
   | LBRACKET xs = tuple(type_expr) RBRACKET

--- a/meja/parsetypes.ml
+++ b/meja/parsetypes.ml
@@ -9,6 +9,7 @@ and type_desc =
   | Tarrow of type_expr * type_expr
   (* A type name. *)
   | Tctor of str
+  | Tpoly of type_expr list * type_expr
 
 type pattern = {pat_desc: pattern_desc; pat_loc: Location.t}
 

--- a/meja/parsetypes.ml
+++ b/meja/parsetypes.ml
@@ -8,7 +8,7 @@ and type_desc =
   | Ttuple of type_expr list
   | Tarrow of type_expr * type_expr
   (* A type name. *)
-  | Tconstr of str
+  | Tctor of str
 
 type pattern = {pat_desc: pattern_desc; pat_loc: Location.t}
 

--- a/meja/scripts/run-tests.sh
+++ b/meja/scripts/run-tests.sh
@@ -68,7 +68,7 @@ run_test() {
         passes=passes+1
       fi
     fi
-    ocamlformat tests/out/$1.ml > tests/out/$1.ml.reformat
+    ocamlformat tests/out/$1.ml > tests/out/$1.ml.reformat &&
     mv tests/out/$1.ml.reformat tests/out/$1.ml
     check_diff $1.ml
   fi

--- a/meja/to_ocaml.ml
+++ b/meja/to_ocaml.ml
@@ -11,7 +11,7 @@ let rec of_type_desc ?loc typ =
   | Tvar (Some name, _) -> Typ.var ?loc name.txt
   | Tarrow (typ1, typ2) ->
       Typ.arrow ?loc Nolabel (of_type_expr typ1) (of_type_expr typ2)
-  | Tconstr name -> Typ.constr ?loc (mk_lid name) []
+  | Tctor name -> Typ.constr ?loc (mk_lid name) []
   | Ttuple typs -> Typ.tuple ?loc (List.map ~f:of_type_expr typs)
 
 and of_type_expr typ = of_type_desc ~loc:typ.type_loc typ.type_desc

--- a/meja/to_ocaml.ml
+++ b/meja/to_ocaml.ml
@@ -9,6 +9,7 @@ let rec of_type_desc ?loc typ =
   match typ with
   | Tvar (None, _) -> Typ.any ?loc ()
   | Tvar (Some name, _) -> Typ.var ?loc name.txt
+  | Tpoly (_, typ) -> of_type_expr typ
   | Tarrow (typ1, typ2) ->
       Typ.arrow ?loc Nolabel (of_type_expr typ1) (of_type_expr typ2)
   | Tctor name -> Typ.constr ?loc (mk_lid name) []

--- a/meja/typechecker.ml
+++ b/meja/typechecker.ml
@@ -17,6 +17,8 @@ let rec check_type_aux typ ctyp env =
   in
   match (typ.type_desc, ctyp.type_desc) with
   | _, _ when Int.equal typ.type_id ctyp.type_id -> env
+  | Tpoly (_, typ), _ -> check_type_aux typ ctyp env
+  | _, Tpoly (_, ctyp) -> check_type_aux typ ctyp env
   | Tvar (_, depth), Tvar (_, constr_depth) ->
       bind_none
         (without_instance typ env ~f:(fun typ -> check_type_aux typ ctyp))
@@ -49,12 +51,64 @@ let rec check_type_aux typ ctyp env =
     | Unequal_lengths -> failwith "Type doesn't check against constr_typ." )
   | Tarrow (typ1, typ2), Tarrow (ctyp1, ctyp2) ->
       env |> check_type_aux typ1 ctyp1 |> check_type_aux typ2 ctyp2
-  | Tctor name, Tctor constr_name
-    when String.equal name.txt constr_name.txt ->
+  | Tctor name, Tctor constr_name when String.equal name.txt constr_name.txt ->
       env
   | _, _ -> failwith "Type doesn't check against constr_typ."
 
 let check_type env typ constr_typ = check_type_aux typ constr_typ env
+
+let rec type_vars ?depth typ =
+  let deep_enough x =
+    match depth with Some depth -> depth <= x | None -> true
+  in
+  let type_vars' = type_vars in
+  let type_vars = type_vars ?depth in
+  match typ.type_desc with
+  | Tvar (_, var_depth) when deep_enough var_depth ->
+      Set.singleton (module Envi.Type) typ
+  | Tvar _ -> Set.empty (module Envi.Type)
+  | Tpoly (vars, typ) ->
+      let poly_vars =
+        List.fold
+          ~init:(Set.empty (module Envi.Type))
+          vars
+          ~f:(fun set var -> Set.union set (type_vars' var))
+      in
+      Set.diff (type_vars typ) poly_vars
+  | Tctor _ -> Set.empty (module Envi.Type)
+  | Ttuple typs ->
+      Set.union_list (module Envi.Type) (List.map ~f:type_vars typs)
+  | Tarrow (typ1, typ2) -> Set.union (type_vars typ1) (type_vars typ2)
+
+let rec free_type_vars ?depth typ =
+  let free_type_vars = free_type_vars ?depth in
+  match typ.type_desc with
+  | Tvar _ -> Set.empty (module Envi.Type)
+  | Tpoly (vars, typ) ->
+      let poly_vars =
+        List.fold
+          ~init:(Set.empty (module Envi.Type))
+          vars
+          ~f:(fun set var -> Set.union set (type_vars var))
+      in
+      Set.diff (free_type_vars typ) poly_vars
+  | Tctor _ -> Set.empty (module Envi.Type)
+  | Ttuple typs ->
+      Set.union_list (module Envi.Type) (List.map ~f:free_type_vars typs)
+  | Tarrow (typ1, typ2) ->
+      Set.union (type_vars ?depth typ1) (free_type_vars typ2)
+
+let polymorphise typ env =
+  let loc = typ.type_loc in
+  let typ_vars = Set.to_list (free_type_vars ~depth:env.Envi.depth typ) in
+  match typ.type_desc with
+  | Tpoly (vars, typ) -> Envi.Type.mk ~loc (Tpoly (typ_vars @ vars, typ)) env
+  | _ -> Envi.Type.mk ~loc (Tpoly (typ_vars, typ)) env
+
+let add_polymorphised name typ env =
+  let typ, env = Envi.Type.flatten typ env in
+  let typ, env = polymorphise typ env in
+  Envi.add_name name typ env
 
 let rec check_pattern_desc ~loc ~add env typ = function
   | PVariable str -> add str typ env
@@ -96,7 +150,7 @@ let rec get_expression_desc ~loc env = function
       let p_typ, env = Envi.Type.mkvar ~loc None env in
       (* In OCaml, function arguments can't be polymorphic, so each check refines
        them rather than instantiating the parameters. *)
-      let env = check_pattern ~add:Envi.add_in_progress env p_typ p in
+      let env = check_pattern ~add:Envi.add_name env p_typ p in
       let body_typ, env = get_expression env body in
       let env = Envi.close_scope env in
       Envi.Type.mk ~loc (Tarrow (p_typ, body_typ)) env
@@ -125,7 +179,7 @@ and get_expression env exp =
 
 and check_binding (env : Envi.t) p e : 's =
   let e_type, env = get_expression env e in
-  check_pattern ~add:Envi.add_final env e_type p
+  check_pattern ~add:add_polymorphised env e_type p
 
 let check_statement_desc env = function Value (p, e) -> check_binding env p e
 

--- a/meja/typechecker.ml
+++ b/meja/typechecker.ml
@@ -49,7 +49,7 @@ let rec check_type_aux typ ctyp env =
     | Unequal_lengths -> failwith "Type doesn't check against constr_typ." )
   | Tarrow (typ1, typ2), Tarrow (ctyp1, ctyp2) ->
       env |> check_type_aux typ1 ctyp1 |> check_type_aux typ2 ctyp2
-  | Tconstr name, Tconstr constr_name
+  | Tctor name, Tctor constr_name
     when String.equal name.txt constr_name.txt ->
       env
   | _, _ -> failwith "Type doesn't check against constr_typ."
@@ -90,7 +90,7 @@ let rec get_expression_desc ~loc env = function
       in
       apply_typ xs f_typ env
   | Variable name -> Envi.get_name name env
-  | Int _ -> Envi.Type.mk ~loc (Tconstr {txt= "int"; loc= Location.none}) env
+  | Int _ -> Envi.Type.mk ~loc (Tctor {txt= "int"; loc= Location.none}) env
   | Fun (p, body) ->
       let env = Envi.open_scope env in
       let p_typ, env = Envi.Type.mkvar ~loc None env in


### PR DESCRIPTION
This PR
* adds `Tpoly`, for instantiating polymorphic variables within types
* uses `Tpoly` as a marker for which type variables to copy when looking up a variable's type
* flattens variable types, removing instantiated variables, before adding a type to the environment
* renames `Tconstr` to `Tctor` (so that `constr` isn't used to refer to type constraints and constructors)
* tweak to the test script to prevent us from clobbering the output ml file if `ocamlformat` fails

These changes should give us enough sophistication in the typechecker and environment to support polymorphic record fields, variants with type constraints, etc. with minimal changes.