### PR TITLE
add boolean xor and improve equal by one constaint

### DIFF
--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -896,7 +896,7 @@ module Make_basic (Backend : Backend_intf.S) = struct
                 ~compute:
                   As_prover.(
                     map2 ~f:( <> ) (read typ_unchecked b1)
-                      (read typ_unchecked b1))
+                      (read typ_unchecked b2))
             in
             let%map () =
               let a = (b1 :> Cvar.t) in

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -152,6 +152,10 @@ module Make_basic (Backend : Backend_intf.S) = struct
     let var_indices t =
       let _, terms = to_constant_and_terms t in
       List.map ~f:(fun (_, v) -> Var.index v) terms
+
+    let to_constant : t -> Field0.t option = function
+      | Constant x -> Some x
+      | _ -> None
   end
 
   module Linear_combination = struct
@@ -846,18 +850,10 @@ module Make_basic (Backend : Backend_intf.S) = struct
               (Cvar.constant (Field.of_int (List.length bs)))
               (Cvar.sum (bs :> Cvar.t list))
 
-      let equal (x : var) (y : var) = equal (x :> Cvar.t) (y :> Cvar.t)
-
-      let of_field x =
-        let open Let_syntax in
-        let%map () = assert_ (Constraint.boolean x) in
-        create x
+      let to_constant (b : var) =
+        Option.map (Cvar.to_constant (b :> Cvar.t)) ~f:Field.(equal one)
 
       let var_of_value b = if b then true_ else false_
-
-      module Unsafe = struct
-        let of_cvar (t : Cvar.t) : var = create t
-      end
 
       let typ : (var, value) Typ.t =
         let open Typ in
@@ -879,6 +875,48 @@ module Make_basic (Backend : Backend_intf.S) = struct
 
       let typ_unchecked : (var, value) Typ.t =
         {typ with check= (fun _ -> return ())}
+
+      let ( lxor ) b1 b2 =
+        match (to_constant b1, to_constant b2) with
+        | Some b1, Some b2 -> return (var_of_value (b1 <> b2))
+        | Some true, None -> return (not b2)
+        | None, Some true -> return (not b1)
+        | Some false, None -> return b2
+        | None, Some false -> return b1
+        | None, None ->
+            (* (1 - 2 a) (1 - 2 b) = 1 - 2 c
+              1 - 2 (a + b) + 4 a b = 1 - 2 c
+              - 2 (a + b) + 4 a b = - 2 c
+              (a + b) - 2 a b = c
+              2 a b = a + b - c
+            *)
+            let open Let_syntax in
+            let%bind res =
+              exists typ_unchecked
+                ~compute:
+                  As_prover.(
+                    map2 ~f:( <> ) (read typ_unchecked b1)
+                      (read typ_unchecked b1))
+            in
+            let%map () =
+              let a = (b1 :> Cvar.t) in
+              let b = (b2 :> Cvar.t) in
+              let c = (res :> Cvar.t) in
+              let open Cvar.Infix in
+              assert_r1cs (a + a) b (a + b - c)
+            in
+            res
+
+      let equal (a : var) (b : var) = a lxor b >>| not
+
+      let of_field x =
+        let open Let_syntax in
+        let%map () = assert_ (Constraint.boolean x) in
+        create x
+
+      module Unsafe = struct
+        let of_cvar (t : Cvar.t) : var = create t
+      end
 
       module Assert = struct
         let ( = ) (x : var) (y : var) = assert_equal (x :> Cvar.t) (y :> Cvar.t)
@@ -1132,13 +1170,7 @@ module Make_basic (Backend : Backend_intf.S) = struct
 
     type var' = Var.t
 
-    module Var = struct
-      include Cvar1
-
-      let to_constant : t -> Field0.t option = function
-        | Constant x -> Some x
-        | _ -> None
-    end
+    module Var = Cvar1
 
     module Checked = struct
       include Cvar1

--- a/src/snark_intf.ml
+++ b/src/snark_intf.ml
@@ -230,6 +230,8 @@ module type Basic = sig
 
     val ( || ) : var -> var -> (var, _) Checked.t
 
+    val ( lxor ) : var -> var -> (var, _) Checked.t
+
     val any : var list -> (var, _) Checked.t
 
     val all : var list -> (var, _) Checked.t


### PR DESCRIPTION
This adds 'xor' for booleans. It's based on the idea of converting a boolean to a sign (0 -> 1, 1 -> -1), multiplying, and then converting back. It costs just one constraint for the multiplication. I replaced 'equal' using 'xor' by the relation `equal x y = not (xor x y)`. It previously cost 2 constraints and now costs 1 since not is free.