### PR TITLE
Build locally by default when calling `make`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-all : docker googlecloud minikube
+default : build
 
 build :
 	dune build --root=.
@@ -32,5 +32,5 @@ minikube :
 googlecloud :
 	./rebuild-googlecloud.sh ocaml-camlsnark
 
-.PHONY : all build examples docker minikube googlecloud
+.PHONY : default build examples docker minikube googlecloud
 


### PR DESCRIPTION
This PR changes the default make target to the obvious one (`make build`), so new users can just `make` and have the library build.