### PR TITLE
Fix opam installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,15 @@ be used in production systems.
 ## Getting started
 - First install libsnark's dependencies as specified [here](https://github.com/scipr-lab/libsnark#dependencies)
 - Then, make sure you have [opam](https://opam.ocaml.org/doc/Install.html) installed.
-- Then, install `snarky` by running
+- Next, install snarky's dependencies from the repo
+```bash
+opam pin add fold_lib git@github.com:o1-labs/snarky.git
+opam pin add tuple_lib git@github.com:o1-labs/snarky.git
+opam pin add bitstring_lib git@github.com:o1-labs/snarky.git
+opam pin add interval_union git@github.com:o1-labs/snarky.git
+opam pin add ppx_snarky git@github.com:o1-labs/snarky.git
+```
+- Finally, install `snarky` by running
 ```bash
 opam pin add snarky git@github.com:o1-labs/snarky.git
 ```

--- a/bench.opam
+++ b/bench.opam
@@ -1,7 +1,7 @@
 opam-version: "1.2"
 version: "0.1"
 build: [
-  ["jbuilder" "build" "--only" "interval_union" "--root" "." "-j" jobs "@install"]
+  ["jbuilder" "build" "--only" "interval_union" "-j" jobs "@install"]
 ]
 depends: [ "core" "ppx_deriving" "ppx_jane" ]
 

--- a/bitstring_lib.opam
+++ b/bitstring_lib.opam
@@ -1,7 +1,21 @@
 opam-version: "1.2"
-version: "0.1"
+name: "bitstring_lib"
+maintainer: "opensource@o1labs.org"
+authors: ["O(1) Labs, LLC <opensource@o1labs.org>"]
+homepage: "https://github.com/o1labs/snarky"
+bug-reports: "https://github.com/o1labs/snarky/issues"
+dev-repo: "git+https://github.com/o1labs/snarky.git"
+license: "MIT"
 build: [
-  ["jbuilder" "build" "--only" "bitstring_lib" "--root" "." "-j" jobs "@install"]
+  ["jbuilder" "build" "--root" "." "-p" name "-j" jobs]
 ]
-depends: [ "core" "ppx_deriving" "ppx_jane" ]
-
+depends: [
+  "core"
+  "ppx_deriving"
+  "ppx_jane"
+  "jbuilder"                {build & >= "1.0+beta12"}
+]
+available: [ ocaml-version >= "4.04.1" ]
+descr: "
+A helper library for bitstrings in snarky
+"

--- a/bitstring_lib.opam
+++ b/bitstring_lib.opam
@@ -7,7 +7,7 @@ bug-reports: "https://github.com/o1labs/snarky/issues"
 dev-repo: "git+https://github.com/o1labs/snarky.git"
 license: "MIT"
 build: [
-  ["jbuilder" "build" "--root" "." "-p" name "-j" jobs]
+  ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [
   "core"

--- a/fold_lib.opam
+++ b/fold_lib.opam
@@ -7,7 +7,7 @@ bug-reports: "https://github.com/o1labs/snarky/issues"
 dev-repo: "git+https://github.com/o1labs/snarky.git"
 license: "MIT"
 build: [
-  ["jbuilder" "build" "--root" "." "-p" name "-j" jobs]
+  ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [
   "core"

--- a/fold_lib.opam
+++ b/fold_lib.opam
@@ -1,7 +1,21 @@
 opam-version: "1.2"
-version: "0.1"
+name: "fold_lib"
+maintainer: "opensource@o1labs.org"
+authors: ["O(1) Labs, LLC <opensource@o1labs.org>"]
+homepage: "https://github.com/o1labs/snarky"
+bug-reports: "https://github.com/o1labs/snarky/issues"
+dev-repo: "git+https://github.com/o1labs/snarky.git"
+license: "MIT"
 build: [
-  ["jbuilder" "build" "--only" "interval_union" "--root" "." "-j" jobs "@install"]
+  ["jbuilder" "build" "--root" "." "-p" name "-j" jobs]
 ]
-depends: [ "core" "ppx_deriving" "ppx_jane" ]
-
+depends: [
+  "core"
+  "ppx_deriving"
+  "ppx_jane"
+  "jbuilder"                {build & >= "1.0+beta12"}
+]
+available: [ ocaml-version >= "4.04.1" ]
+descr: "
+A library for treating folds as a first-class data structure and a monad
+"

--- a/interval_union.opam
+++ b/interval_union.opam
@@ -1,7 +1,21 @@
 opam-version: "1.2"
-version: "0.1"
+name: "interval_union"
+maintainer: "opensource@o1labs.org"
+authors: ["O(1) Labs, LLC <opensource@o1labs.org>"]
+homepage: "https://github.com/o1labs/snarky"
+bug-reports: "https://github.com/o1labs/snarky/issues"
+dev-repo: "git+https://github.com/o1labs/snarky.git"
+license: "MIT"
 build: [
-  ["jbuilder" "build" "--only" "interval_union" "--root" "." "-j" jobs "@install"]
+  ["jbuilder" "build" "--root" "." "-p" name "-j" jobs]
 ]
-depends: [ "core" "ppx_deriving" "ppx_jane" ]
-
+depends: [
+  "core_kernel"
+  "ppx_deriving"
+  "ppx_jane"
+  "jbuilder"                {build & >= "1.0+beta12"}
+]
+available: [ ocaml-version >= "4.04.1" ]
+descr: "
+A helper library for manipulating intervals -- pairs of integers -- in snarky
+"

--- a/interval_union.opam
+++ b/interval_union.opam
@@ -7,7 +7,7 @@ bug-reports: "https://github.com/o1labs/snarky/issues"
 dev-repo: "git+https://github.com/o1labs/snarky.git"
 license: "MIT"
 build: [
-  ["jbuilder" "build" "--root" "." "-p" name "-j" jobs]
+  ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [
   "core_kernel"

--- a/meja.opam
+++ b/meja.opam
@@ -1,6 +1,27 @@
 opam-version: "1.2"
+name: "meja"
+maintainer: "opensource@o1labs.org"
+authors: ["O(1) Labs, LLC <opensource@o1labs.org>"]
+homepage: "https://github.com/o1labs/snarky"
+bug-reports: "https://github.com/o1labs/snarky/issues"
+dev-repo: "git+https://github.com/o1labs/snarky.git"
+license: "MIT"
+build: [
+  ["jbuilder" "build" "--root" "." "-p" name "-j" jobs]
+]
+depends: [
+  "core_kernel"
+  "ocaml-compiler-libs"
+  "dune"                {build & >= "1.0+beta12"}
+]
+available: [ ocaml-version >= "4.04.1" ]
+descr: "
+A Reason-ML style language with baked-in support for Snarky.
+"
+opam-version: "1.2"
 version: "0.1"
 build: [
-  ["dune" "build" "--only" "src" "--root" "." "-j" jobs "@install"]
+  ["jbuilder" "build" "--only" "interval_union" "--root" "." "-j" jobs "@install"]
 ]
+depends: [ "core" "ppx_deriving" "ppx_jane" ]
 

--- a/meja.opam
+++ b/meja.opam
@@ -7,7 +7,7 @@ bug-reports: "https://github.com/o1labs/snarky/issues"
 dev-repo: "git+https://github.com/o1labs/snarky.git"
 license: "MIT"
 build: [
-  ["jbuilder" "build" "--root" "." "-p" name "-j" jobs]
+  ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [
   "core_kernel"

--- a/ppx_snarky.opam
+++ b/ppx_snarky.opam
@@ -1,4 +1,5 @@
 opam-version: "1.2"
+name: "ppx_snarky"
 maintainer: "opensource@o1labs.org"
 authors: ["O(1) Labs, LLC <opensource@o1labs.org>"]
 homepage: "https://github.com/o1labs/snarky"
@@ -9,17 +10,9 @@ build: [
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [
+  "core_kernel"
   "ppxlib"
-  "ppxlib.metaquot"
-  "core"
-  "ctypes"
-  "ctypes-foreign"
-  "ppx_deriving"
-  "ppx_driver"
-  "ppx_jane"
-  "bignum"
-  "bitstring_lib"
-  "interval_union"
+  "ppx_sexp_conv"
   "jbuilder"                {build & >= "1.0+beta12"}
 ]
 available: [ ocaml-version >= "4.04.1" ]

--- a/snarky.opam
+++ b/snarky.opam
@@ -10,15 +10,17 @@ build: [
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "core"
-  "ctypes"
-  "ctypes-foreign"
-  "ppx_deriving"
-  "ppx_driver"
-  "ppx_jane"
-  "bignum"
+  "core_kernel"
+  "fold_lib"
+  "tuple_lib"
   "bitstring_lib"
   "interval_union"
+  "bignum"
+  "ctypes"
+  "ctypes-foreign"
+  "ppx_snarky"
+  "ppx_jane"
+  "ppx_deriving"
   "jbuilder"                {build & >= "1.0+beta12"}
 ]
 available: [ ocaml-version >= "4.04.1" ]

--- a/snarky.opam
+++ b/snarky.opam
@@ -1,4 +1,5 @@
 opam-version: "1.2"
+name: "snarky"
 maintainer: "opensource@o1labs.org"
 authors: ["O(1) Labs, LLC <opensource@o1labs.org>"]
 homepage: "https://github.com/o1labs/snarky"

--- a/tuple_lib.opam
+++ b/tuple_lib.opam
@@ -1,7 +1,21 @@
 opam-version: "1.2"
-version: "0.1"
+name: "tuple_lib"
+maintainer: "opensource@o1labs.org"
+authors: ["O(1) Labs, LLC <opensource@o1labs.org>"]
+homepage: "https://github.com/o1labs/snarky"
+bug-reports: "https://github.com/o1labs/snarky/issues"
+dev-repo: "git+https://github.com/o1labs/snarky.git"
+license: "MIT"
 build: [
-  ["jbuilder" "build" "--only" "interval_union" "--root" "." "-j" jobs "@install"]
+  ["jbuilder" "build" "-p" name "-j" jobs]
 ]
-depends: [ "core" "ppx_deriving" "ppx_jane" ]
-
+depends: [
+  "core_kernel"
+  "ppx_deriving"
+  "ppx_jane"
+  "jbuilder"                {build & >= "1.0+beta12"}
+]
+available: [ ocaml-version >= "4.04.1" ]
+descr: "
+A tiny library with names and a useful getter for tuples
+"


### PR DESCRIPTION
This PR updates the `*.opam` files so that they have the right dependencies and build commands.

Fixes  #78.