### PR TITLE
Tweak the opam files, give a better installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,17 +10,9 @@ be used in production systems.
 ## Getting started
 - First install libsnark's dependencies as specified [here](https://github.com/scipr-lab/libsnark#dependencies)
 - Then, make sure you have [opam](https://opam.ocaml.org/doc/Install.html) installed.
-- Next, install snarky's dependencies from the repo
+- Finally, install `snarky` and its dependencies by running
 ```bash
-opam pin add fold_lib git@github.com:o1-labs/snarky.git
-opam pin add tuple_lib git@github.com:o1-labs/snarky.git
-opam pin add bitstring_lib git@github.com:o1-labs/snarky.git
-opam pin add interval_union git@github.com:o1-labs/snarky.git
-opam pin add ppx_snarky git@github.com:o1-labs/snarky.git
-```
-- Finally, install `snarky` by running
-```bash
-opam pin add snarky git@github.com:o1-labs/snarky.git
+opam pin add git@github.com:o1-labs/snarky.git
 ```
 and answering yes to the prompts.
 

--- a/bench.opam
+++ b/bench.opam
@@ -1,7 +1,0 @@
-opam-version: "1.2"
-version: "0.1"
-build: [
-  ["jbuilder" "build" "--only" "interval_union" "-j" jobs "@install"]
-]
-depends: [ "core" "ppx_deriving" "ppx_jane" ]
-

--- a/meja.opam
+++ b/meja.opam
@@ -16,12 +16,5 @@ depends: [
 ]
 available: [ ocaml-version >= "4.04.1" ]
 descr: "
-A Reason-ML style language with baked-in support for Snarky.
+A Reason-ML style language with baked-in support for Snarky
 "
-opam-version: "1.2"
-version: "0.1"
-build: [
-  ["jbuilder" "build" "--only" "interval_union" "--root" "." "-j" jobs "@install"]
-]
-depends: [ "core" "ppx_deriving" "ppx_jane" ]
-

--- a/snarky_bench.opam
+++ b/snarky_bench.opam
@@ -1,5 +1,5 @@
 opam-version: "1.2"
-name: "bitstring_lib"
+name: "snarky_bench"
 maintainer: "opensource@o1labs.org"
 authors: ["O(1) Labs, LLC <opensource@o1labs.org>"]
 homepage: "https://github.com/o1labs/snarky"
@@ -11,12 +11,12 @@ build: [
 ]
 depends: [
   "core"
-  "tuple_lib"
-  "ppx_deriving"
+  "snarky"
   "ppx_jane"
+  "ppx_bench"
   "jbuilder"                {build & >= "1.0+beta12"}
 ]
 available: [ ocaml-version >= "4.04.1" ]
 descr: "
-A helper library for bitstrings in snarky
+Benchmark runner for snarky
 "


### PR DESCRIPTION
This PR
* changes the readme to suggest `opam pin DIR` for installing snarky and deps
* tweaks the opam files so that this works properly