### PR TITLE
Imperative interface

### DIFF
--- a/src/checked_intf.ml
+++ b/src/checked_intf.ml
@@ -50,8 +50,7 @@ module Runner_state (M : Backend_types) = struct
 
     val initial_state : unit t ref
 
-    val run :
-      (unit, 's, M.Field.t, M.Field.Var.t) Checked.t -> 's t -> 's t * unit
+    val run : ('a, 's, M.Field.t, M.Field.Var.t) Checked.t -> 's t -> 's t * 'a
   end
 end
 

--- a/src/checked_intf.ml
+++ b/src/checked_intf.ml
@@ -44,6 +44,15 @@ module Runner_state (M : Backend_types) = struct
 
     val set_handler : Request.Handler.t -> 's t -> 's t
   end
+
+  module type S_imperative = sig
+    include S with type 'a prover_state = 'a
+
+    val initial_state : unit t ref
+
+    val run :
+      (unit, 's, M.Field.t, M.Field.Var.t) Checked.t -> 's t -> 's t * unit
+  end
 end
 
 module type S = sig

--- a/src/checked_intf.ml
+++ b/src/checked_intf.ml
@@ -1,0 +1,136 @@
+module type Backend_types = sig
+  module Field : sig
+    type t
+
+    module Var : sig
+      type t
+    end
+  end
+end
+
+module Runner_state (M : Backend_types) = struct
+  module type S = sig
+    type 's t
+
+    type 's prover_state
+
+    val to_prover_state : 's -> 's prover_state
+
+    val get_value : 's t -> M.Field.Var.t -> M.Field.t
+
+    val store_field_elt : 's t -> M.Field.t -> M.Field.Var.t
+
+    val alloc_var : 's t -> unit -> M.Field.Var.t
+
+    module Constraint : sig
+      val add : stack:string list -> M.Field.Var.t Constraint.t -> 'a t -> unit
+
+      val eval : M.Field.Var.t Constraint.t -> 's t -> bool
+    end
+
+    val eval_constraints : 's t -> bool
+
+    val next_auxiliary : 's t -> int ref
+
+    val prover_state : 's t -> 's prover_state option
+
+    val set_prover_state : 's prover_state option -> 's1 t -> 's t
+
+    val stack : 's t -> string list
+
+    val set_stack : string list -> 's t -> 's t
+
+    val handler : 's t -> Request.Handler.t
+
+    val set_handler : Request.Handler.t -> 's t -> 's t
+  end
+end
+
+module type S = sig
+  type ('a, 's, 'field, 'field_var) t
+
+  type 's prover_state
+
+  val assert_ :
+       ?label:string
+    -> 'field_var Constraint.t
+    -> (unit, 's, 'field, 'field_var) t
+
+  val assert_all :
+       ?label:string
+    -> 'field_var Constraint.t list
+    -> (unit, 's, 'field, 'field_var) t
+
+  val assert_r1cs :
+       ?label:string
+    -> 'field_var
+    -> 'field_var
+    -> 'field_var
+    -> (unit, _, 'field, 'field_var) t
+
+  val assert_square :
+       ?label:string
+    -> 'field_var
+    -> 'field_var
+    -> (unit, _, 'field, 'field_var) t
+
+  val as_prover :
+       (unit, 'field_var -> 'field, 's prover_state) As_prover0.t
+    -> (unit, 's, 'field, 'field_var) t
+
+  val with_state :
+       ?and_then:(   's1
+                  -> (unit, 'field_var -> 'field, 's prover_state) As_prover0.t)
+    -> ('s1, 'field_var -> 'field, 's prover_state) As_prover0.t
+    -> ('a, 's1, 'field, 'field_var) t
+    -> ('a, 's, 'field, 'field_var) t
+
+  val next_auxiliary : (int, 's, 'field, 'field_var) t
+
+  val request_witness :
+       ('var, 'value, 'field, 'field_var) Typ.t
+    -> ('value Request.t, 'field_var -> 'field, 's prover_state) As_prover0.t
+    -> ('var, 's, 'field, 'field_var) t
+
+  val perform :
+       (unit Request.t, 'field_var -> 'field, 's prover_state) As_prover0.t
+    -> (unit, 's, 'field, 'field_var) t
+
+  val request :
+       ?such_that:('var -> (unit, 's, 'field, 'field_var) t)
+    -> ('var, 'value, 'field, 'field_var) Typ.t
+    -> 'value Request.t
+    -> ('var, 's, 'field, 'field_var) t
+  (** TODO: Come up with a better name for this in relation to the above *)
+
+  val exists :
+       ?request:( 'value Request.t
+                , 'field_var -> 'field
+                , 's prover_state )
+                As_prover0.t
+    -> ?compute:('value, 'field_var -> 'field, 's prover_state) As_prover0.t
+    -> ('var, 'value, 'field, 'field_var) Typ.t
+    -> ('var, 's, 'field, 'field_var) t
+
+  type response = Request.response
+
+  val unhandled : response
+
+  type request = Request.request =
+    | With :
+        { request: 'a Request.t
+        ; respond: 'a Request.Response.t -> response }
+        -> request
+
+  module Handler : sig
+    type t = request -> response
+  end
+
+  val handle :
+       ('a, 's, 'field, 'field_var) t
+    -> Handler.t
+    -> ('a, 's, 'field, 'field_var) t
+
+  val with_label :
+    string -> ('a, 's, 'field, 'field_var) t -> ('a, 's, 'field, 'field_var) t
+end

--- a/src/constraint.ml
+++ b/src/constraint.ml
@@ -29,6 +29,8 @@ module T = struct
   let annotation (t : 'a t) =
     String.concat ~sep:"; "
       (List.filter_map t ~f:(fun {annotation; _} -> annotation))
+
+  let stack_to_string = String.concat ~sep:"\n"
 end
 
 include T

--- a/src/run.ml
+++ b/src/run.ml
@@ -20,6 +20,8 @@ module type S = sig
   val assert_square :
     ?label:string -> Field.Var.t -> Field.Var.t -> (unit, _) t
 
+  val assert_equal : ?label:string -> Field.Var.t -> Field.Var.t -> (unit, _) t
+
   val run_as_prover :
        ('a, Field.Var.t -> Field.t, 's prover_state) As_prover0.t option
     -> ('a option, 's) t
@@ -267,12 +269,14 @@ module Make
   let next_auxiliary () state = (state, !(next_auxiliary state))
 end
 
+module type S_imperative = S with type ('a, _) t = 'a and type 'a prover_state = unit
+
 module Make_imperative
     (M : Checked_intf.Backend_types) (State : sig
         include Checked_intf.Runner_state(M).S with type 'a prover_state = 'a
 
         val initial_state : unit t
-    end) : S with type ('a, _) t = 'a and type 'a prover_state = unit = struct
+    end) : S_imperative = struct
   module Stateful = Make (M) (State)
   module Field = Stateful.Field
   open Stateful
@@ -305,6 +309,8 @@ module Make_imperative
   let assert_r1cs ?label c1 c2 c3 = unwrap @@ assert_r1cs ?label c1 c2 c3
 
   let assert_square ?label c1 c2 = unwrap @@ assert_square ?label c1 c2
+
+  let assert_equal ?label c1 c2 = unwrap @@ assert_equal ?label c1 c2
 
   let run_as_prover f =
     unwrap @@ run_as_prover (Option.map ~f:wrap_as_prover f)

--- a/src/run.ml
+++ b/src/run.ml
@@ -1,0 +1,257 @@
+open Core_kernel
+
+module type S = sig
+  include Checked_intf.Backend_types
+
+  type ('a, 's) t
+
+  type 's prover_state
+
+  val assert_ : ?label:string -> Field.Var.t Constraint.t -> (unit, 's) t
+
+  val assert_all :
+    ?label:string -> Field.Var.t Constraint.t list -> (unit, 's) t
+
+  val assert_r1cs :
+    ?label:string -> Field.Var.t -> Field.Var.t -> Field.Var.t -> (unit, _) t
+
+  val assert_square :
+    ?label:string -> Field.Var.t -> Field.Var.t -> (unit, _) t
+
+  val as_prover :
+       (unit, Field.Var.t -> Field.t, 's prover_state) As_prover0.t
+    -> (unit, 's) t
+
+  val with_state :
+       ?and_then:(   's1 prover_state
+                  -> ( unit
+                     , Field.Var.t -> Field.t
+                     , 's prover_state )
+                     As_prover0.t)
+    -> ('s1 prover_state, Field.Var.t -> Field.t, 's prover_state) As_prover0.t
+    -> ('a, 's1) t
+    -> ('a, 's) t
+
+  val next_auxiliary : (int, 's) t
+
+  val request_witness :
+       run:((unit, unit, Field.t, Field.Var.t) Checked.t -> (unit, unit) t)
+    -> ('var, 'value, Field.t, Field.Var.t) Typ.t
+    -> ('value Request.t, Field.Var.t -> Field.t, 's prover_state) As_prover0.t
+    -> ('var, 's) t
+
+  val perform :
+       run:((unit, unit, Field.t, Field.Var.t) Checked.t -> (unit, unit) t)
+    -> (unit Request.t, Field.Var.t -> Field.t, 's prover_state) As_prover0.t
+    -> (unit, 's) t
+
+  val request :
+       run:((unit, unit, Field.t, Field.Var.t) Checked.t -> (unit, unit) t)
+    -> ?such_that:('var -> (unit, 's) t)
+    -> ('var, 'value, Field.t, Field.Var.t) Typ.t
+    -> 'value Request.t
+    -> ('var, 's) t
+  (** TODO: Come up with a better name for this in relation to the above *)
+
+  val exists :
+       run:((unit, unit, Field.t, Field.Var.t) Checked.t -> (unit, unit) t)
+    -> ?request:( 'value Request.t
+                , Field.Var.t -> Field.t
+                , 's prover_state )
+                As_prover0.t
+    -> ?compute:('value, Field.Var.t -> Field.t, 's prover_state) As_prover0.t
+    -> ('var, 'value, Field.t, Field.Var.t) Typ.t
+    -> ('var, 's) t
+
+  val exists_provider :
+       run:((unit, unit, Field.t, Field.Var.t) Checked.t -> (unit, unit) t)
+    -> ('var, 'value, Field.t, Field.Var.t) Typ.t
+    -> ('value, Field.Var.t -> Field.t, 's prover_state) Provider.t
+    -> (('var, 'value) Handle.t, 's) t
+
+  type response = Request.response
+
+  val unhandled : response
+
+  type request = Request.request =
+    | With :
+        { request: 'a Request.t
+        ; respond: 'a Request.Response.t -> response }
+        -> request
+
+  module Handler : sig
+    type t = request -> response
+  end
+
+  val handle : ('a, 's) t -> Handler.t -> ('a, 's) t
+
+  val with_label : string -> ('a, 's) t -> ('a, 's) t
+end
+
+module Make
+    (M : Checked_intf.Backend_types)
+    (State : Checked_intf.Runner_state(M).S) :
+  S
+  with type ('a, 's) t = 's State.t -> 's State.t * 'a
+   and type 'a prover_state = 'a State.prover_state
+   and type Field.t = M.Field.t
+   and type Field.Var.t = M.Field.Var.t = struct
+  module Constraint0 = Constraint
+  include M
+  open State
+
+  type ('a, 's) t = 's State.t -> 's State.t * 'a
+
+  module Let_syntax = struct
+    module Let_syntax = struct
+      let map ~(f : 'a -> 'b) (a : ('a, 's) t) : ('b, 's) t =
+       fun s ->
+        let s, a = a s in
+        (s, f a)
+
+      let bind ~(f : 'a -> ('b, 's) t) (a : ('a, 's) t) : ('b, 's) t =
+       fun s ->
+        let s, a = a s in
+        f a s
+
+      let return (a : 'a) : ('a, 's) t = fun s -> (s, a)
+    end
+  end
+
+  include Let_syntax.Let_syntax
+
+  type 'a prover_state = 'a State.prover_state
+
+  let run_as_prover x state =
+    match (x, prover_state state) with
+    | Some x, Some s ->
+        let s', y = As_prover.run x (get_value state) s in
+        (set_prover_state (Some s') state, Some y)
+    | _, _ -> (state, None)
+
+  let as_prover x state =
+    let state, (_ : unit option) = run_as_prover (Some x) state in
+    (state, ())
+
+  let with_label label f state =
+    let stack = stack state in
+    let state, b = f (set_stack (label :: stack) state) in
+    (set_stack stack state, b)
+
+  let add_constraint c state =
+    if eval_constraints state && not (Constraint.eval c state) then
+      failwithf "Constraint unsatisfied:\n%s\n%s\n" (Constraint0.annotation c)
+        (Constraint0.stack_to_string (stack state))
+        () ;
+    Constraint.add ~stack:(stack state) c state ;
+    (state, ())
+
+  let assert_ ?label c =
+    add_constraint
+      (List.map c ~f:(fun c -> Constraint0.override_label c label))
+
+  let assert_r1cs ?label a b c = assert_ (Constraint0.r1cs ?label a b c)
+
+  let assert_square ?label a c = assert_ (Constraint0.square ?label a c)
+
+  let assert_all =
+    let map_concat_rev xss ~f =
+      let rec go acc xs xss =
+        match (xs, xss) with
+        | [], [] -> acc
+        | [], xs :: xss -> go acc xs xss
+        | x :: xs, _ -> go (f x :: acc) xs xss
+      in
+      go [] [] xss
+    in
+    fun ?label cs ->
+      add_constraint
+        (map_concat_rev ~f:(fun c -> Constraint0.override_label c label) cs)
+
+  let assert_equal ?label x y = assert_ (Constraint0.equal ?label x y)
+
+  let do_nothing _ = As_prover0.return ()
+
+  let with_state ?(and_then = do_nothing) as_prover f state =
+    let state, s_sub = run_as_prover (Some as_prover) state in
+    let sub_state, y = f (set_prover_state s_sub state) in
+    let sub_prover_state = Option.map ~f:and_then (prover_state sub_state) in
+    let state, (_ : unit option) = run_as_prover sub_prover_state state in
+    (state, y)
+
+  type response = Request.response
+
+  let unhandled = Request.unhandled
+
+  type request = Request.request =
+    | With :
+        { request: 'a Request.t
+        ; respond: 'a Request.Response.t -> response }
+        -> request
+
+  module Handler = struct
+    type t = request -> response
+  end
+
+  let with_handler ~f h state =
+    let handler = handler state in
+    let state, y = f (set_handler (Request.Handler.push handler h) state) in
+    (set_handler handler state, y)
+
+  let handle f k = with_handler ~f (Request.Handler.create_single k)
+
+  let clear_handler ~f state =
+    let handler = handler state in
+    let state, y = f (set_handler Request.Handler.fail state) in
+    (set_handler handler state, y)
+
+  let exists_provider
+      ~(run : (unit, unit, Field.t, Field.Var.t) Checked.t -> (unit, unit) t)
+      {Types.Typ.store; alloc; check; _} provider state =
+    match prover_state state with
+    | Some s ->
+        let s', value =
+          Provider.run provider (stack state) (get_value state) s
+            (handler state)
+        in
+        let var = Typ_monads.Store.run (store value) (store_field_elt state) in
+        let state = set_prover_state (Some (to_prover_state ())) state in
+        let state, () = run (check var) state in
+        let state = set_prover_state (Some s') state in
+        (state, {Handle.var; value= Some value})
+    | None ->
+        let var = Typ_monads.Alloc.run alloc (alloc_var state) in
+        let state = set_prover_state None state in
+        let state, () = run (check var) state in
+        let state = set_prover_state None state in
+        (state, {Handle.var; value= None})
+
+  let exists ~run ?request ?compute typ =
+    let provider =
+      let request =
+        Option.value request ~default:(As_prover0.return Request.Fail)
+      in
+      match compute with
+      | None -> Provider.Request request
+      | Some c -> Provider.Both (request, c)
+    in
+    bind (exists_provider ~run typ provider) ~f:(fun h -> return (Handle.var h))
+
+  let request_witness ~run
+      (typ : ('var, 'value, Field.t, Field.Var.t) Types.Typ.t)
+      (r : ('value Request.t, Field.Var.t -> Field.t, 's) As_prover0.t) =
+    bind (exists_provider ~run typ (Request r)) ~f:(fun h -> return (Handle.var h))
+
+  let request ~run ?such_that typ r =
+    match such_that with
+    | None -> request_witness ~run typ (As_prover0.return r)
+    | Some such_that ->
+        let open Let_syntax in
+        let%bind x = request_witness ~run typ (As_prover0.return r) in
+        let%map () = such_that x in
+        x
+
+  let perform ~run req = request_witness ~run (Typ.unit ()) req
+
+  let next_auxiliary state = (state, !(next_auxiliary state))
+end

--- a/src/run.ml
+++ b/src/run.ml
@@ -301,6 +301,9 @@ module type S_imperative = sig
        ('var, 'value, Field.t, Field.Var.t) Typ.t
     -> ('value, Field.Var.t -> Field.t, 's prover_state) Provider.t
     -> (('var, 'value) Handle.t, 's) t
+
+  val of_checked :
+    ('a, 's prover_state, Field.t, Field.Var.t) Checked.t -> ('a, 's) t
 end
 
 module Make_imperative
@@ -322,7 +325,7 @@ module Make_imperative
 
   let wrap x state = (state, x)
 
-  let unwrap (x : ('a, unit) t) =
+  let unwrap (x : ('a, unit) Stateful.t) =
     let state', x = x !state in
     state := state' ;
     x
@@ -390,6 +393,8 @@ module Make_imperative
   let handle t handler = unwrap @@ handle (wrap t) handler
 
   let with_label label t = unwrap @@ with_label label (wrap t)
+
+  let of_checked k = unwrap (run k)
 end
 
 type ('field, 'field_var) impl =
@@ -486,3 +491,7 @@ let handle (type f v) ~(impl : (f, v) impl) =
 let with_label (type f v) ~(impl : (f, v) impl) =
   let (module I) = impl in
   I.with_label
+
+let of_checked (type f v) ~(impl : (f, v) impl) =
+  let (module I) = impl in
+  I.of_checked

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -556,7 +556,7 @@ module Make_basic (Backend : Backend_intf.S) = struct
         Field.Vector.emplace_back aux x ;
         Cvar.Unsafe.of_var v
 
-      let alloc_var {next_auxiliary; _} =
+      let alloc_var {next_auxiliary; _} () =
         let v = Backend.Var.create !next_auxiliary in
         incr next_auxiliary ; Cvar.Unsafe.of_var v
 
@@ -616,7 +616,7 @@ module Make_basic (Backend : Backend_intf.S) = struct
             let state = update_prover_state ~f:(fun _ -> Some s') state in
             (state, {Handle.var; value= Some value})
         | None ->
-            let var = Typ.Alloc.run alloc (fun () -> alloc_var state) in
+            let var = Typ.Alloc.run alloc (alloc_var state) in
             let state = update_prover_state ~f:(fun _ -> None) state in
             let state = run (check var) state in
             let state = update_prover_state ~f:(fun _ -> None) state in

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -213,8 +213,6 @@ module Make_basic (Backend : Backend_intf.S) = struct
           R1CS_constraint.set_is_square constr false ;
           constr
 
-    let stack_to_string = String.concat ~sep:"\n"
-
     let add ~stack (t : t) system =
       List.iter t ~f:(fun {basic; annotation} ->
           let label = Option.value annotation ~default:"<unknown>" in
@@ -673,14 +671,16 @@ module Make_basic (Backend : Backend_intf.S) = struct
             go (k y) state
         | Exists (typ, p, k) ->
             let state, handle =
-              Run_helper.exists ~run:(fun t state -> fst (go t state)) typ p state
+              Run_helper.exists
+                ~run:(fun t state -> fst (go t state))
+                typ p state
             in
             go (k handle) state
         | Next_auxiliary k ->
             let state, i = Run_helper.next_auxiliary state in
             go (k i) state
       in
-      let (state, value) = go t0 state in
+      let state, value = go t0 state in
       Option.iter system ~f:(fun system ->
           let auxiliary_input_size = !next_auxiliary - (1 + num_inputs) in
           R1CS_constraint_system.set_auxiliary_input_size system

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -523,6 +523,7 @@ module Make_basic (Backend : Backend_intf.S) = struct
       module Backend_types = struct
         module Field = struct
           type t = Field0.t
+
           module Var = struct
             type t = Cvar.t
           end
@@ -595,7 +596,7 @@ module Make_basic (Backend : Backend_intf.S) = struct
         let set_handler handler state = {state with handler}
       end
 
-      include Run.Make(Backend_types)(Runner_state)
+      include Run.Make (Backend_types) (Runner_state)
     end
 
     let run (type a s) ~num_inputs ~input ~next_auxiliary ~aux ?system
@@ -650,7 +651,7 @@ module Make_basic (Backend : Backend_intf.S) = struct
             in
             go (k handle) state
         | Next_auxiliary k ->
-            let state, i = Run_helper.next_auxiliary state in
+            let state, i = Run_helper.next_auxiliary () state in
             go (k i) state
       in
       let state, value = go t0 state in

--- a/src/snark_intf.ml
+++ b/src/snark_intf.ml
@@ -615,6 +615,36 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
   val constraint_count :
     ?log:(?start:bool -> string -> int -> unit) -> (_, _) Checked.t -> int
 
+  module Run : sig
+    type 'a t = impl:(Field.t, Field.Var.t) Run.impl -> 'a
+
+    val constraint_system :
+         exposing:(unit t, _, 'k_var, _) Data_spec.t
+      -> 'k_var
+      -> R1CS_constraint_system.t
+
+    val generate_keypair :
+      exposing:(unit t, _, 'k_var, _) Data_spec.t -> 'k_var -> Keypair.t
+
+    val prove :
+         Proving_key.t
+      -> (unit t, Proof.t, 'k_var, 'k_value) Data_spec.t
+      -> 'k_var
+      -> 'k_value
+
+    val verify :
+         Proof.t
+      -> Verification_key.t
+      -> (_, bool, _, 'k_value) Data_spec.t
+      -> 'k_value
+
+    val run_unchecked : 'a t -> 'a
+
+    val run_and_check : ('a, unit) As_prover.t t -> 'a Or_error.t
+
+    val check : 'a t -> bool
+  end
+
   val set_eval_constraints : bool -> unit
   (** Sets the [eval_constraints] state. If [true], {!val:run_unchecked} and
       {!val:prove} will check that the constraint system is satisfied while


### PR DESCRIPTION
This PR creates a bare-minimum interface for running checked computations imperatively. At the moment, the interface (in `Run`) is roughly the constructors of `Checked.t`, plus a converter `of_checked` that takes an actual `Checked.t` and runs it.

This PR:
* moves the moving parts of the implementation of `Snark0.Checked.run` out into `Run`, functored over the types and utility functions it would normally have in `Snark0`.
* creates an imperative-ish API which works in a state monad containing the current `run_state`
* wraps the state-monad API in a module expression with a `run_state ref`, so that it can be passed around as an argument (of type `Run.impl`)
* adds the true imperative API, using this type of module expression as its argument (labelled `~impl`)
* exposes a `Run` module from `Snark0.Make`, which gives versions of `prove`, `verify`, etc. that operate on these imperative calls (of type `impl:('field, 'field_var) impl -> 'a`, analogous to `('a, unit, 'field, 'field_var) Checked.t`).

Quirks:
* there are some `'s prover_state` types lurking around, which decide whether the prover can have state (`type 's prover_state = 's`) in the normal case, or not (`type _ prover_state = unit`) otherwise. These prevent us from writing out the signatures even more times.
* most of the core code is now generalised over `Checked.t`, except for `Typ.t`s and a few other pain points