### PR TITLE
Turn on errors for all warnings

### DIFF
--- a/src/as_prover0.ml
+++ b/src/as_prover0.ml
@@ -17,8 +17,6 @@ module T = struct
 
   let get_state _tbl s = (s, s)
 
-  let read_var v tbl s = (s, tbl v)
-
   let set_state s _tbl _ = (s, ())
 
   let modify_state f _tbl s = (f s, ())

--- a/src/as_prover0.ml
+++ b/src/as_prover0.ml
@@ -19,7 +19,7 @@ module T = struct
 
   let read_var v tbl s = (s, tbl v)
 
-  let set_state s tbl _ = (s, ())
+  let set_state s _tbl _ = (s, ())
 
   let modify_state f _tbl s = (f s, ())
 

--- a/src/checked.ml
+++ b/src/checked.ml
@@ -8,7 +8,7 @@ module T0 = struct
 
   let as_prover x = As_prover (x, return ())
 
-  let rec map : type s a b field var sys.
+  let rec map : type s a b field var.
       (a, s, field, var) t -> f:(a -> b) -> (b, s, field, var) t =
    fun t ~f ->
     match t with
@@ -25,7 +25,7 @@ module T0 = struct
 
   let map = `Custom map
 
-  let rec bind : type s a b field var sys.
+  let rec bind : type s a b field var.
          (a, s, field, var) t
       -> f:(a -> (b, s, field, var) t)
       -> (b, s, field, var) t =

--- a/src/curves.ml
+++ b/src/curves.ml
@@ -740,7 +740,7 @@ module Make_weierstrass_checked
       end
     end
 
-    let create (type shifted) () : ((module S), _) Checked.t =
+    let create () : ((module S), _) Checked.t =
       let open Let_syntax in
       let%map shift =
         exists typ ~compute:As_prover.(map (return ()) ~f:Curve.random)

--- a/src/dune
+++ b/src/dune
@@ -1,7 +1,7 @@
 (library
  (name snarky)
  (public_name snarky)
- (flags :standard -short-paths -safe-string -warn-error -27-32-9-39-6-34)
+ (flags :standard -short-paths -safe-string -warn-error -27-32-39-6-34)
  (inline_tests)
  (libraries core_kernel fold_lib tuple_lib bitstring_lib interval_union
    bignum camlsnark_c)

--- a/src/dune
+++ b/src/dune
@@ -1,7 +1,7 @@
 (library
  (name snarky)
  (public_name snarky)
- (flags :standard -short-paths -safe-string -warn-error -27-32-39-6-34)
+ (flags :standard -short-paths -safe-string -warn-error -32-39-6-34)
  (inline_tests)
  (libraries core_kernel fold_lib tuple_lib bitstring_lib interval_union
    bignum camlsnark_c)

--- a/src/dune
+++ b/src/dune
@@ -1,7 +1,7 @@
 (library
  (name snarky)
  (public_name snarky)
- (flags :standard -short-paths -safe-string -warn-error -32)
+ (flags :standard -short-paths -safe-string)
  (inline_tests)
  (libraries core_kernel fold_lib tuple_lib bitstring_lib interval_union
    bignum camlsnark_c)

--- a/src/dune
+++ b/src/dune
@@ -1,7 +1,7 @@
 (library
  (name snarky)
  (public_name snarky)
- (flags :standard -short-paths -safe-string -warn-error -32-39)
+ (flags :standard -short-paths -safe-string -warn-error -32)
  (inline_tests)
  (libraries core_kernel fold_lib tuple_lib bitstring_lib interval_union
    bignum camlsnark_c)

--- a/src/dune
+++ b/src/dune
@@ -1,7 +1,7 @@
 (library
  (name snarky)
  (public_name snarky)
- (flags :standard -short-paths -safe-string -warn-error -32-39-6-34)
+ (flags :standard -short-paths -safe-string -warn-error -32-39)
  (inline_tests)
  (libraries core_kernel fold_lib tuple_lib bitstring_lib interval_union
    bignum camlsnark_c)

--- a/src/enumerable.ml
+++ b/src/enumerable.ml
@@ -7,11 +7,7 @@ let int_to_bits ~length n =
 let int_of_bits bs =
   List.foldi bs ~init:0 ~f:(fun i acc b -> if b then acc + (1 lsl i) else acc)
 
-module Make
-    (Impl : Snark_intf.Basic) (M : sig
-        type t [@@deriving enum]
-    end) =
-struct
+module Make (Impl : Snark_intf.Basic) (M : Enumerable_intf.Enum) = struct
   open Impl
 
   (* TODO: Make this throw when the elt is too big *)

--- a/src/enumerable.mli
+++ b/src/enumerable.mli
@@ -1,7 +1,4 @@
-module Make
-    (Impl : Snark_intf.Basic) (M : sig
-        type t [@@deriving enum]
-    end) :
+module Make (Impl : Snark_intf.Basic) (M : Enumerable_intf.Enum) :
   Enumerable_intf.S
   with type ('a, 'b) checked := ('a, 'b) Impl.Checked.t
    and type ('a, 'b) typ := ('a, 'b) Impl.Typ.t

--- a/src/enumerable_intf.ml
+++ b/src/enumerable_intf.ml
@@ -1,3 +1,7 @@
+module type Enum = sig
+  type t [@@deriving enum]
+end
+
 module type S = sig
   type (_, _) checked
 

--- a/src/knapsack.ml
+++ b/src/knapsack.ml
@@ -21,7 +21,7 @@ module Make (Impl : Snark_intf.S) = struct
     in
     go [] xs ys
 
-  let hash_to_field {dimension; max_input_length; coefficients} xs =
+  let hash_to_field {coefficients; _} xs =
     let sum = List.fold ~init:Field.zero ~f:Field.add in
     List.map coefficients ~f:(fun cs ->
         sum (map2_lax cs xs ~f:(fun c b -> if b then c else Field.zero)) )
@@ -33,7 +33,7 @@ module Make (Impl : Snark_intf.S) = struct
         List.init Field.size_in_bits ~f:(fun i -> Bigint.test_bit n i) )
 
   module Checked = struct
-    let hash_to_field ({dimension; max_input_length; coefficients} : t)
+    let hash_to_field ({max_input_length; coefficients; _} : t)
         (vs : Boolean.var list) : (Field.Var.t list, _) Checked.t =
       let vs = (vs :> Field.Var.t list) in
       let input_len = List.length vs in

--- a/src/knapsack.ml
+++ b/src/knapsack.ml
@@ -103,15 +103,6 @@ module Make (Impl : Snark_intf.S) = struct
     let hash (h1 : var) (h2 : var) =
       with_label "Knapsack.hash" (Checked.hash_to_bits knapsack (h1 @ h2))
 
-    let map2i_exn xs ys ~f =
-      let rec go acc i xs ys =
-        match (xs, ys) with
-        | [], [] -> List.rev acc
-        | x :: xs, y :: ys -> go (f i x y :: acc) (i + 1) xs ys
-        | _, _ -> failwith "mapi_exn: Invalid lengths"
-      in
-      go [] 0 xs ys
-
     let assert_equal = Impl.Bitstring_checked.Assert.equal
   end
 end

--- a/src/merkle_tree.ml
+++ b/src/merkle_tree.ml
@@ -54,7 +54,7 @@ type ('hash, 'a) t =
   ; compress: 'hash -> 'hash -> 'hash }
 [@@deriving sexp]
 
-let check_exn {tree; depth; count; hash; compress} =
+let check_exn {tree; depth; count; hash; compress; _} =
   let default = hash None in
   let rec check_hash = function
     | Non_empty t -> check_hash_non_empty t
@@ -137,7 +137,7 @@ let insert hash compress t0 mask0 address x =
 
 let ith_bit n i = (n lsr i) land 1 = 1
 
-let update ({hash; compress; tree= tree0; depth} as t) addr0 x =
+let update ({hash; compress; tree= tree0; depth; _} as t) addr0 x =
   let tree_hash = tree_hash ~default:(hash None) in
   let rec go_non_empty tree i =
     match tree with

--- a/src/merkle_tree.ml
+++ b/src/merkle_tree.ml
@@ -54,7 +54,7 @@ type ('hash, 'a) t =
   ; compress: 'hash -> 'hash -> 'hash }
 [@@deriving sexp]
 
-let check_exn {tree; depth; count; hash; compress; _} =
+let check_exn {tree; hash; compress; _} =
   let default = hash None in
   let rec check_hash = function
     | Non_empty t -> check_hash_non_empty t
@@ -82,8 +82,8 @@ let tree_hash ~default = function
 let to_list : ('hash, 'a) t -> 'a list =
   let rec go acc = function
     | Empty -> acc
-    | Non_empty (Leaf (_, x)) -> x :: acc
-    | Non_empty (Node (h, l, r)) ->
+    | Non_empty (Leaf (_hash, x)) -> x :: acc
+    | Non_empty (Node (_hash, l, r)) ->
         let acc' = go acc r in
         go acc' l
   in
@@ -118,7 +118,7 @@ let insert hash compress t0 mask0 address x =
           else
             let t_r' = go mask' Empty in
             Node (compress default (non_empty_hash t_r'), Empty, Non_empty t_r')
-      | Non_empty (Node (h, t_l, t_r)) ->
+      | Non_empty (Node (_hash, t_l, t_r)) ->
           if go_left then
             let t_l' = go mask' t_l in
             Node
@@ -192,7 +192,7 @@ let set_dirty default tree addr x =
   in
   go_non_empty tree (List.rev addr)
 
-let recompute_hashes {tree; depth; count; hash; compress} =
+let recompute_hashes {tree; hash; compress; _} =
   let h =
     let default = hash None in
     fun t -> tree_hash ~default t

--- a/src/merkle_tree.ml
+++ b/src/merkle_tree.ml
@@ -73,8 +73,6 @@ let non_empty_hash = function Node (h, _, _) -> h | Leaf (h, _) -> h
 
 let depth {depth; _} = depth
 
-let hash {tree; _} = non_empty_hash tree
-
 let tree_hash ~default = function
   | Empty -> default
   | Non_empty t -> non_empty_hash t

--- a/src/merkle_tree.mli
+++ b/src/merkle_tree.mli
@@ -19,8 +19,6 @@ module Free_hash : sig
     -> 'hash
 end
 
-val root : ('hash, _) t -> 'hash
-
 val depth : (_, _) t -> int
 
 val create :

--- a/src/pedersen.ml
+++ b/src/pedersen.ml
@@ -13,10 +13,6 @@ module Make
 
         val to_affine_coordinates : t -> Impl.Field.t * Impl.Field.t
 
-        val typ : (var, t) Impl.Typ.t
-
-        val negate : t -> t
-
         val add : t -> t -> t
 
         val zero : t

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -475,7 +475,7 @@ module Make_basic (Backend : Backend_intf.S) = struct
 
     let perform req = request_witness Typ.unit req
 
-    let constraint_count ?(log = fun ?start _ _ -> ()) (t : (_, _) t) : int =
+    let constraint_count ?(log = fun ?start:_ _ _ -> ()) (t : (_, _) t) : int =
       let next_auxiliary = ref 1 in
       let alloc_var () =
         let v = Backend.Var.create !next_auxiliary in

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -261,8 +261,6 @@ module Make_basic (Backend : Backend_intf.S) = struct
       include Restrict_monad.Make3 (Read) (A)
 
       let read = Read.read
-
-      let run = Read.run
     end
 
     module Alloc = struct

--- a/src/snark_intf.ml
+++ b/src/snark_intf.ml
@@ -325,7 +325,7 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
   
   and Field : sig
     (** The finite field over which the R1CS operates. *)
-    type t = field [@@deriving bin_io, sexp, hash, compare, eq]
+    type t = field [@@deriving bin_io, sexp, hash, compare]
 
     val gen : t Core_kernel.Quickcheck.Generator.t
     (** A generator for Quickcheck tests. *)


### PR DESCRIPTION
This PR turns on errors for warnings:
* ` 6 Label omitted in function application`
* `9 Missing fields in arecord pattern`
* `27 Innocuous unused variable: unused variable that is not bound with `**`let`**` nor `**`as`**`, and doesn't start with an underscore (_) character.`
* `32 Unused value declaration`
* `34 Unused type declaration`
* `39 Unused rec flag`

Notes:
* it's okay to remove the `deriving equal` in `Snark_intf.Basic.Field` it includes `Field_intf.S`, which has an `equal` of its own.
* `map2i_exn` in `knapsack.ml` has been unused since the `camlsnark` days and was never exposed in the interface
* packaging up `Enumerable_intf.Enum` stops a warning 32 for the the `min` it derives in `enumerable.ml`