### PR TITLE
[Meja] Add support for prefix/infix operators

### DIFF
--- a/meja/lexer_impl.mll
+++ b/meja/lexer_impl.mll
@@ -22,6 +22,8 @@ let number = ['0'-'9']+
 let lowercase_alpha = ['a'-'z']
 let uppercase_alpha = ['A'-'Z']
 let ident = ['a'-'z' 'A'-'Z' '_' '\'' '0'-'9']
+let symbolchar =
+  ['!' '$' '%' '&' '*' '+' '-' '.' '/' ':' '<' '=' '>' '?' '@' '^' '|' '~']
 
 rule token = parse
     whitespace
@@ -52,6 +54,14 @@ rule token = parse
   | '|' { BAR }
   | ''' { QUOT }
   | '.' { DOT }
+
+  | "!" symbolchar * as op { PREFIXOP op }
+  | ['~' '?'] symbolchar + as op { PREFIXOP op }
+  | ['=' '<' '>' '|' '&' '$'] symbolchar * as op { INFIXOP0 op }
+  | ['@' '^'] symbolchar * as op { INFIXOP1 op }
+  | ['+' '-'] symbolchar * as op { INFIXOP2 op }
+  | "**" symbolchar * as op { INFIXOP4 op }
+  | ['*' '/' '%'] symbolchar * as op { INFIXOP3 op }
   | lowercase_alpha ident* { LIDENT(Lexing.lexeme lexbuf) }
   | uppercase_alpha ident* { UIDENT(Lexing.lexeme lexbuf) }
   | _ { raise (Error (lexeme_loc lexbuf, Unexpected_character (Lexing.lexeme lexbuf))) }

--- a/meja/parser_errors.ml
+++ b/meja/parser_errors.ml
@@ -1,4 +1,8 @@
-type error = Fun_no_fat_arrow | Missing_semi | Unexpected_character of string
+type error =
+  | Fun_no_fat_arrow
+  | Missing_semi
+  | Unexpected_character of string
+  | Expecting of string
 
 exception Error of Location.t * error
 
@@ -10,6 +14,7 @@ let report_error ppf = function
   | Fun_no_fat_arrow -> fprintf ppf "Expected => before {@."
   | Missing_semi -> fprintf ppf "Missing semicolon."
   | Unexpected_character x -> fprintf ppf "Unexpected character '%s'" x
+  | Expecting desc -> fprintf ppf "Syntax error: %s expected" desc
 
 let () =
   Location.register_error_of_exn (function

--- a/meja/tests/operator_names.meja
+++ b/meja/tests/operator_names.meja
@@ -1,0 +1,28 @@
+let (+) = 15;
+
+let (-) = 20;
+
+let (!) = fun (_) => {30;};
+
+let (||) = fun (x, y) => {
+  switch (x) {
+    | true => x
+    | false => y
+  };
+};
+
+let a = (||) (true, false);
+
+let b = true || false;
+
+let c = !a;
+
+let f : (int -> int -> int) -> int = fun (check : 'a -> 'a -> 'a) => {
+  let (+) = fun (l, _) => {l;};
+  let (-) = fun (_, r) => {r;};
+  let (*) = fun (_, r) => {r;};
+  let (/) = fun (l, _) => {l;};
+  let x = () * true - 1 / ((), ()) + (1, 1);
+  let y = (() * true) - (1 / ((), ())) + (1, 1);
+  check (x, y);
+};

--- a/meja/tests/operator_names.ml
+++ b/meja/tests/operator_names.ml
@@ -1,0 +1,23 @@
+let ( + ) = 15
+
+let ( - ) = 20
+
+let ( ! ) _ = 30
+
+let ( || ) x y = match x with true -> x | false -> y
+
+let a = true || false
+
+let b = true || false
+
+let c = !a
+
+let (f : (int -> int -> int) -> int) =
+ fun (check : 'a -> 'a -> 'a) ->
+  let ( + ) l _ = l in
+  let ( - ) _ r = r in
+  let ( * ) _ r = r in
+  let ( / ) l _ = l in
+  let x = (((() * true) - 1) / ((), ())) + (1, 1) in
+  let y = (() * true) - (1 / ((), ())) + (1, 1) in
+  check x y


### PR DESCRIPTION
This PR adds support for prefix/infix operators, which will let us implement the infix `+`, `*` notations for fields, etc.