### PR TITLE
Pull 'field_var out of type parameters

### DIFF
--- a/src/as_prover.ml
+++ b/src/as_prover.ml
@@ -19,8 +19,7 @@ module type S = sig
 
   val read_var : field Cvar.t -> (field, 's) t
 
-  val read :
-    ('var, 'value, field) Typ.t -> 'var -> ('value, 'prover_state) t
+  val read : ('var, 'value, field) Typ.t -> 'var -> ('value, 'prover_state) t
 
   module Ref : sig
     type 'a t

--- a/src/as_prover.mli
+++ b/src/as_prover.mli
@@ -12,11 +12,9 @@ include Monad.S3 with type ('a, 'e, 's) t = 'e -> 's -> 's * 'a
 val run : ('a, 'e, 's) t -> 'e -> 's -> 's * 'a
 
 module type S = sig
-  type var
-
   type field
 
-  type env = var -> field
+  type env = field Cvar.t -> field
 
   include Monad.S2 with type ('a, 's) t = ('a, env, 's) t
 
@@ -30,17 +28,17 @@ module type S = sig
 
   val map2 : ('a, 's) t -> ('b, 's) t -> f:('a -> 'b -> 'c) -> ('c, 's) t
 
-  val read_var : var -> (field, 's) t
+  val read_var : field Cvar.t -> (field, 's) t
 
   val read :
-    ('var, 'value, field, var) Typ.t -> 'var -> ('value, 'prover_state) t
+    ('var, 'value, field) Typ.t -> 'var -> ('value, 'prover_state) t
 
   module Ref : sig
     type 'a t
 
     val create :
          ('a, env, 'prover_state) As_prover0.t
-      -> ('a t, 'prover_state, field, var) Checked.t
+      -> ('a t, 'prover_state, field) Checked.t
 
     val get : 'a t -> ('a, env, _) As_prover0.t
 
@@ -49,7 +47,5 @@ module type S = sig
 end
 
 module Make (Env : sig
-  type var
-
   type field
-end) : S with type var := Env.var with type field := Env.field
+end) : S with type field := Env.field

--- a/src/as_prover.mli
+++ b/src/as_prover.mli
@@ -28,8 +28,7 @@ module type S = sig
 
   val read_var : field Cvar.t -> (field, 's) t
 
-  val read :
-    ('var, 'value, field) Typ.t -> 'var -> ('value, 'prover_state) t
+  val read : ('var, 'value, field) Typ.t -> 'var -> ('value, 'prover_state) t
 
   module Ref : sig
     type 'a t

--- a/src/as_prover.mli
+++ b/src/as_prover.mli
@@ -5,20 +5,18 @@ open Core_kernel
     
     We form a {{: https://en.wikipedia.org/wiki/Monad_(functional_programming)}monad}
     over {!type:t} so that we have a simple way to interact with values inside the type
-    (the value of type ['a] corresponding to our [('a, 'e, 's) t]).
+    (the value of type ['a] corresponding to our [('a, 'f, 's) t]).
     *)
-include Monad.S3 with type ('a, 'e, 's) t = 'e -> 's -> 's * 'a
+include Monad.S3 with type ('a, 'f, 's) t = ('f Cvar.t -> 'f) -> 's -> 's * 'a
 
-val run : ('a, 'e, 's) t -> 'e -> 's -> 's * 'a
+val run : ('a, 'f, 's) t -> ('f Cvar.t -> 'f) -> 's -> 's * 'a
 
 module type S = sig
   type field
 
-  type env = field Cvar.t -> field
+  include Monad.S2 with type ('a, 's) t = ('a, field, 's) t
 
-  include Monad.S2 with type ('a, 's) t = ('a, env, 's) t
-
-  val run : ('a, 's) t -> env -> 's -> 's * 'a
+  val run : ('a, 's) t -> (field Cvar.t -> field) -> 's -> 's * 'a
 
   val get_state : ('s, 's) t
 
@@ -37,12 +35,12 @@ module type S = sig
     type 'a t
 
     val create :
-         ('a, env, 'prover_state) As_prover0.t
+         ('a, field, 'prover_state) As_prover0.t
       -> ('a t, 'prover_state, field) Checked.t
 
-    val get : 'a t -> ('a, env, _) As_prover0.t
+    val get : 'a t -> ('a, field, _) As_prover0.t
 
-    val set : 'a t -> 'a -> (unit, env, _) As_prover0.t
+    val set : 'a t -> 'a -> (unit, field, _) As_prover0.t
   end
 end
 

--- a/src/as_prover0.ml
+++ b/src/as_prover0.ml
@@ -1,6 +1,6 @@
 open Core_kernel
 
-type ('a, 'e, 's) t = 'e -> 's -> 's * 'a
+type ('a, 'f, 's) t = ('f Cvar.t -> 'f) -> 's -> 's * 'a
 
 module T = struct
   let map t ~f tbl s =
@@ -28,7 +28,7 @@ module T = struct
     let s, y = y tbl s in
     (s, f x y)
 
-  let read_var (v : 'var) : ('field, 'var -> 'field, 's) t =
+  let read_var (v : 'var) : ('field, 'field, 's) t =
    fun tbl s -> (s, tbl v)
 end
 

--- a/src/as_prover0.ml
+++ b/src/as_prover0.ml
@@ -28,8 +28,7 @@ module T = struct
     let s, y = y tbl s in
     (s, f x y)
 
-  let read_var (v : 'var) : ('field, 'field, 's) t =
-   fun tbl s -> (s, tbl v)
+  let read_var (v : 'var) : ('field, 'field, 's) t = fun tbl s -> (s, tbl v)
 end
 
 include T

--- a/src/checked.ml
+++ b/src/checked.ml
@@ -1,15 +1,15 @@
 open Core_kernel
 open Types.Checked
 
-type ('a, 's, 'field, 'var) t = ('a, 's, 'field, 'var) Types.Checked.t
+type ('a, 's, 'field) t = ('a, 's, 'field) Types.Checked.t
 
 module T0 = struct
   let return x = Pure x
 
   let as_prover x = As_prover (x, return ())
 
-  let rec map : type s a b field var sys.
-      (a, s, field, var) t -> f:(a -> b) -> (b, s, field, var) t =
+  let rec map : type s a b field.
+      (a, s, field) t -> f:(a -> b) -> (b, s, field) t =
    fun t ~f ->
     match t with
     | Pure x -> Pure (f x)
@@ -25,10 +25,10 @@ module T0 = struct
 
   let map = `Custom map
 
-  let rec bind : type s a b field var sys.
-         (a, s, field, var) t
-      -> f:(a -> (b, s, field, var) t)
-      -> (b, s, field, var) t =
+  let rec bind : type s a b field.
+         (a, s, field) t
+      -> f:(a -> (b, s, field) t)
+      -> (b, s, field) t =
    fun t ~f ->
     match t with
     | Pure x -> f x
@@ -80,8 +80,8 @@ end
 module T = struct
   include T0
 
-  let request_witness (typ : ('var, 'value, 'field, 'cvar) Types.Typ.t)
-      (r : ('value Request.t, 'cvar -> 'field, 's) As_prover0.t) =
+  let request_witness (typ : ('var, 'value, 'field) Types.Typ.t)
+      (r : ('value Request.t, 'field Cvar.t -> 'field, 's) As_prover0.t) =
     Exists (typ, Request r, fun h -> return (Handle.var h))
 
   let request ?such_that typ r =

--- a/src/checked.ml
+++ b/src/checked.ml
@@ -81,7 +81,7 @@ module T = struct
   include T0
 
   let request_witness (typ : ('var, 'value, 'field) Types.Typ.t)
-      (r : ('value Request.t, 'field Cvar.t -> 'field, 's) As_prover0.t) =
+      (r : ('value Request.t, 'field, 's) As_prover0.t) =
     Exists (typ, Request r, fun h -> return (Handle.var h))
 
   let request ?such_that typ r =

--- a/src/checked.ml
+++ b/src/checked.ml
@@ -26,9 +26,7 @@ module T0 = struct
   let map = `Custom map
 
   let rec bind : type s a b field.
-         (a, s, field) t
-      -> f:(a -> (b, s, field) t)
-      -> (b, s, field) t =
+      (a, s, field) t -> f:(a -> (b, s, field) t) -> (b, s, field) t =
    fun t ~f ->
     match t with
     | Pure x -> f x

--- a/src/handle.ml
+++ b/src/handle.ml
@@ -2,7 +2,7 @@ open Core_kernel
 
 type ('var, 'value) t = {var: 'var; value: 'value option}
 
-let value (t : ('var, 'value) t) : ('value, 'cvar -> 'field, 's) As_prover0.t =
+let value (t : ('var, 'value) t) : ('value, 'field, 's) As_prover0.t =
  fun _ s -> (s, Option.value_exn t.value)
 
 let var {var; _} = var

--- a/src/provider.ml
+++ b/src/provider.ml
@@ -1,7 +1,7 @@
-type ('a, 'e, 's) t =
-  | Request of ('a Request.t, 'e, 's) As_prover0.t
-  | Compute of ('a, 'e, 's) As_prover0.t
-  | Both of ('a Request.t, 'e, 's) As_prover0.t * ('a, 'e, 's) As_prover0.t
+type ('a, 'f, 's) t =
+  | Request of ('a Request.t, 'f, 's) As_prover0.t
+  | Compute of ('a, 'f, 's) As_prover0.t
+  | Both of ('a Request.t, 'f, 's) As_prover0.t * ('a, 'f, 's) As_prover0.t
 
 let run t stack tbl s (handler : Request.Handler.t) =
   match t with

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -261,7 +261,6 @@ module Make_basic (Backend : Backend_intf.S) = struct
 
     module Alloc = struct
       open Alloc
-
       include Restrict_monad.Make2 (Alloc) (Field)
 
       let alloc = alloc

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -457,8 +457,6 @@ module Make_basic (Backend : Backend_intf.S) = struct
 
   module As_prover = struct
     include As_prover.Make (struct
-      type var = Cvar.t
-
       type field = Field.t
     end)
 

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -243,14 +243,8 @@ module Make_basic (Backend : Backend_intf.S) = struct
   module Typ_monads = struct
     open Typ_monads
 
-    module A = struct
-      type t1 = Field.t
-
-      type t2 = Cvar.t
-    end
-
     module Store = struct
-      include Restrict_monad.Make3 (Store) (A)
+      include Restrict_monad.Make2 (Store) (Field)
 
       let store = Store.store
 
@@ -258,7 +252,7 @@ module Make_basic (Backend : Backend_intf.S) = struct
     end
 
     module Read = struct
-      include Restrict_monad.Make3 (Read) (A)
+      include Restrict_monad.Make2 (Read) (Field)
 
       let read = Read.read
 
@@ -268,11 +262,7 @@ module Make_basic (Backend : Backend_intf.S) = struct
     module Alloc = struct
       open Alloc
 
-      include Restrict_monad.Make2
-                (Alloc)
-                (struct
-                  type t = Cvar.t
-                end)
+      include Restrict_monad.Make2 (Alloc) (Field)
 
       let alloc = alloc
 

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -294,7 +294,7 @@ module Make_basic (Backend : Backend_intf.S) = struct
 
   module Checked0 = struct
     module T = struct
-      type ('a, 's) t = ('a, 's, Field.t, Cvar.t) Checked.t
+      type ('a, 's) t = ('a, 's, Field.t) Checked.t
 
       include Checked.T
     end
@@ -308,7 +308,7 @@ module Make_basic (Backend : Backend_intf.S) = struct
     include Typ_monads
     include Typ.T
 
-    type ('var, 'value) t = ('var, 'value, Field.t, Cvar.t) Types.Typ.t
+    type ('var, 'value) t = ('var, 'value, Field.t) Types.Typ.t
 
     type ('var, 'value) typ = ('var, 'value) t
 

--- a/src/snark_intf.ml
+++ b/src/snark_intf.ml
@@ -108,20 +108,20 @@ module type Basic = sig
   and Typ : sig
     module Store : sig
       include
-        Monad.S with type 'a t = ('a, Field.t, Field.Var.t) Typ_monads.Store.t
+        Monad.S with type 'a t = ('a, Field.t) Typ_monads.Store.t
 
       val store : field -> Field.Var.t t
     end
 
     module Alloc : sig
-      include Monad.S with type 'a t = ('a, Field.Var.t) Typ_monads.Alloc.t
+      include Monad.S with type 'a t = ('a, Field.t) Typ_monads.Alloc.t
 
       val alloc : Field.Var.t t
     end
 
     module Read : sig
       include
-        Monad.S with type 'a t = ('a, Field.t, Field.Var.t) Typ_monads.Read.t
+        Monad.S with type 'a t = ('a, Field.t) Typ_monads.Read.t
 
       val read : Field.Var.t -> field t
     end

--- a/src/snark_intf.ml
+++ b/src/snark_intf.ml
@@ -107,8 +107,7 @@ module type Basic = sig
   (** Mappings from OCaml types to R1CS variables and constraints. *)
   and Typ : sig
     module Store : sig
-      include
-        Monad.S with type 'a t = ('a, Field.t) Typ_monads.Store.t
+      include Monad.S with type 'a t = ('a, Field.t) Typ_monads.Store.t
 
       val store : field -> Field.Var.t t
     end
@@ -120,8 +119,7 @@ module type Basic = sig
     end
 
     module Read : sig
-      include
-        Monad.S with type 'a t = ('a, Field.t) Typ_monads.Read.t
+      include Monad.S with type 'a t = ('a, Field.t) Typ_monads.Read.t
 
       val read : Field.Var.t -> field t
     end

--- a/src/snark_intf.ml
+++ b/src/snark_intf.ml
@@ -304,9 +304,7 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
   Field.Checked.mul x_times_y z
 ]}
     *)
-    include
-      Monad.S2
-      with type ('a, 's) t = ('a, 's, Field.t) Types.Checked.t
+    include Monad.S2 with type ('a, 's) t = ('a, 's, Field.t) Types.Checked.t
 
     module List :
       Monad_sequence.S

--- a/src/snark_intf.ml
+++ b/src/snark_intf.ml
@@ -126,7 +126,7 @@ module type Basic = sig
       val read : Field.Var.t -> field t
     end
 
-    type ('var, 'value) t = ('var, 'value, Field.t, Field.Var.t) Types.Typ.t
+    type ('var, 'value) t = ('var, 'value, Field.t) Types.Typ.t
 
     (** Accessors for {!type:Types.Typ.t} fields: *)
 
@@ -306,7 +306,7 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
     *)
     include
       Monad.S2
-      with type ('a, 's) t = ('a, 's, Field.t, Field.Var.t) Types.Checked.t
+      with type ('a, 's) t = ('a, 's, Field.t) Types.Checked.t
 
     module List :
       Monad_sequence.S

--- a/src/typ.ml
+++ b/src/typ.ml
@@ -16,8 +16,7 @@ module T = struct
       ('value, 'field) Read.t =
     read v
 
-  let alloc ({alloc; _} : ('var, 'value, 'field) t) :
-      ('var, 'field) Alloc.t =
+  let alloc ({alloc; _} : ('var, 'value, 'field) t) : ('var, 'field) Alloc.t =
     alloc
 
   let check (type field) ({check; _} : ('var, 'value, field) t) (v : 'var) :

--- a/src/typ.ml
+++ b/src/typ.ml
@@ -1,7 +1,6 @@
 open Core_kernel
 
-type ('var, 'value, 'field) t =
-  ('var, 'value, 'field) Types.Typ.t
+type ('var, 'value, 'field) t = ('var, 'value, 'field) Types.Typ.t
 
 type ('var, 'value, 'field) typ = ('var, 'value, 'field) t
 
@@ -21,11 +20,9 @@ module T = struct
       ('var, 'field Cvar.t) Alloc.t =
     alloc
 
-  let check (type field) ({check; _} : ('var, 'value, field) t)
-      (v : 'var) : (unit, 's, field) Types.Checked.t =
-    let do_nothing : (unit, field, _) As_prover0.t =
-     fun _ s -> (s, ())
-    in
+  let check (type field) ({check; _} : ('var, 'value, field) t) (v : 'var) :
+      (unit, 's, field) Types.Checked.t =
+    let do_nothing : (unit, field, _) As_prover0.t = fun _ s -> (s, ()) in
     With_state (do_nothing, (fun () -> do_nothing), check v, Checked.return)
 
   let unit () : (unit, unit, 'field) t =
@@ -43,8 +40,7 @@ module T = struct
     ; alloc= Alloc.alloc
     ; check= (fun _ -> Checked.return ()) }
 
-  let transport
-      ({read; store; alloc; check} : ('var1, 'value1, 'field) t)
+  let transport ({read; store; alloc; check} : ('var1, 'value1, 'field) t)
       ~(there : 'value2 -> 'value1) ~(back : 'value1 -> 'value2) :
       ('var1, 'value2, 'field) t =
     { alloc
@@ -52,8 +48,7 @@ module T = struct
     ; read= (fun v -> Read.map ~f:back (read v))
     ; check }
 
-  let transport_var
-      ({read; store; alloc; check} : ('var1, 'value, 'field) t)
+  let transport_var ({read; store; alloc; check} : ('var1, 'value, 'field) t)
       ~(there : 'var2 -> 'var1) ~(back : 'var1 -> 'var2) :
       ('var2, 'value, 'field) t =
     { alloc= Alloc.map alloc ~f:back
@@ -135,8 +130,7 @@ module T = struct
   let ( * ) = tuple2
 
   let tuple3 (typ1 : ('var1, 'value1, 'field) t)
-      (typ2 : ('var2, 'value2, 'field) t)
-      (typ3 : ('var3, 'value3, 'field) t) :
+      (typ2 : ('var2, 'value2, 'field) t) (typ3 : ('var3, 'value3, 'field) t) :
       ('var1 * 'var2 * 'var3, 'value1 * 'value2 * 'value3, 'field) t =
     let alloc =
       let open Alloc.Let_syntax in

--- a/src/typ.ml
+++ b/src/typ.ml
@@ -23,7 +23,7 @@ module T = struct
 
   let check (type field) ({check; _} : ('var, 'value, field) t)
       (v : 'var) : (unit, 's, field) Types.Checked.t =
-    let do_nothing : (unit, field Cvar.t -> field, _) As_prover0.t =
+    let do_nothing : (unit, field, _) As_prover0.t =
      fun _ s -> (s, ())
     in
     With_state (do_nothing, (fun () -> do_nothing), check v, Checked.return)

--- a/src/typ.ml
+++ b/src/typ.ml
@@ -9,15 +9,15 @@ module T = struct
   open Typ_monads
 
   let store ({store; _} : ('var, 'value, 'field) t) (x : 'value) :
-      ('var, 'field, 'field Cvar.t) Store.t =
+      ('var, 'field) Store.t =
     store x
 
   let read ({read; _} : ('var, 'value, 'field) t) (v : 'var) :
-      ('value, 'field, 'field Cvar.t) Read.t =
+      ('value, 'field) Read.t =
     read v
 
   let alloc ({alloc; _} : ('var, 'value, 'field) t) :
-      ('var, 'field Cvar.t) Alloc.t =
+      ('var, 'field) Alloc.t =
     alloc
 
   let check (type field) ({check; _} : ('var, 'value, field) t) (v : 'var) :

--- a/src/typ_monads.ml
+++ b/src/typ_monads.ml
@@ -1,11 +1,11 @@
 module Store = struct
   module T = struct
-    type ('k, 'field, 'var) t = Store of 'field * ('var -> 'k)
+    type ('k, 'field) t = Store of 'field * ('field Cvar.t -> 'k)
 
     let map t ~f = match t with Store (x, k) -> Store (x, fun v -> f (k v))
   end
 
-  include Free_monad.Make3 (T)
+  include Free_monad.Make2 (T)
 
   let store x = Free (T.Store (x, fun v -> Pure v))
 
@@ -15,12 +15,12 @@ end
 
 module Read = struct
   module T = struct
-    type ('k, 'field, 'cvar) t = Read of 'cvar * ('field -> 'k)
+    type ('k, 'field) t = Read of 'field Cvar.t * ('field -> 'k)
 
     let map t ~f = match t with Read (v, k) -> Read (v, fun x -> f (k x))
   end
 
-  include Free_monad.Make3 (T)
+  include Free_monad.Make2 (T)
 
   let read v = Free (T.Read (v, return))
 
@@ -30,7 +30,7 @@ end
 
 module Alloc = struct
   module T = struct
-    type ('k, 'var) t = Alloc of ('var -> 'k)
+    type ('k, 'field) t = Alloc of ('field Cvar.t -> 'k)
 
     let map t ~f = match t with Alloc k -> Alloc (fun v -> f (k v))
   end

--- a/src/types.ml
+++ b/src/types.ml
@@ -1,12 +1,11 @@
 module rec Typ : sig
   open Typ_monads
 
-  (** The type [('var, 'value, 'field, 'field_var) t] describes a mapping
-      from OCaml types to the variables and constraints they represent:
+  (** The type [('var, 'value, 'field) t] describes a mapping from OCaml types
+      to the variables and constraints they represent:
       - ['value] is the OCaml type
       - ['field] is the type of the field elements
-      - ['field_var] is the type of variables within the R1CS
-      - ['var] is some other type that contains some ['field_var] values.
+      - ['var] is some other type that contains some R1CS variables.
 
       For convenience and readability, it is usually best to have the ['var]
       type mirror the ['value] type in structure, for example:
@@ -21,11 +20,11 @@ module rec Typ : sig
     let or (x : t) = Snark.Boolean.(x.b1 || x.b2)
   end
 ]}*)
-  type ('var, 'value, 'field, 'field_var) t =
-    { store: 'value -> ('var, 'field, 'field_var) Store.t
-    ; read: 'var -> ('value, 'field, 'field_var) Read.t
-    ; alloc: ('var, 'field_var) Alloc.t
-    ; check: 'var -> (unit, unit, 'field, 'field_var) Checked.t }
+  type ('var, 'value, 'field) t =
+    { store: 'value -> ('var, 'field, 'field Cvar.t) Store.t
+    ; read: 'var -> ('value, 'field, 'field Cvar.t) Read.t
+    ; alloc: ('var, 'field Cvar.t) Alloc.t
+    ; check: 'var -> (unit, unit, 'field) Checked.t }
 end =
   Typ
 
@@ -33,42 +32,42 @@ and Checked : sig
   (* TODO-someday: Consider having an "Assembly" type with only a store constructor for straight up Var.t's
     that this gets compiled into. *)
 
-  (** The type [('ret, 'state, 'field, 'field_var') t] represents a
-      checked computation, where
-      - ['state] is the type that holds the state used by [As_prover] computations
+  (** The type [('ret, 'state, 'field) t] represents a checked computation,
+      where
+      - ['state] is the type that holds the state used by [As_prover]
+        computations
       - ['state -> 'ret] is the type of the computation
-      - ['field] is the type of the field elements
-      - ['field_var] is the type of variables within the R1CS. *)
-  type ('a, 's, 'f, 'v) t =
-    | Pure : 'a -> ('a, 's, 'f, 'v) t
+      - ['field] is the type of the field elements . *)
+  type ('a, 's, 'f) t =
+    | Pure : 'a -> ('a, 's, 'f) t
     | Add_constraint :
-        'v Constraint.t * ('a, 's, 'f, 'v) t
-        -> ('a, 's, 'f, 'v) t
+        'f Cvar.t Constraint.t * ('a, 's, 'f) t
+        -> ('a, 's, 'f) t
     | As_prover :
-        (unit, 'v -> 'f, 's) As_prover0.t * ('a, 's, 'f, 'v) t
-        -> ('a, 's, 'f, 'v) t
+        (unit, 'f Cvar.t -> 'f, 's) As_prover0.t * ('a, 's, 'f) t
+        -> ('a, 's, 'f) t
     | With_label :
-        string * ('a, 's, 'f, 'v) t * ('a -> ('b, 's, 'f, 'v) t)
-        -> ('b, 's, 'f, 'v) t
+        string * ('a, 's, 'f) t * ('a -> ('b, 's, 'f) t)
+        -> ('b, 's, 'f) t
     | With_state :
-        ('s1, 'v -> 'f, 's) As_prover0.t
-        * ('s1 -> (unit, 'v -> 'f, 's) As_prover0.t)
-        * ('b, 's1, 'f, 'v) t
-        * ('b -> ('a, 's, 'f, 'v) t)
-        -> ('a, 's, 'f, 'v) t
+        ('s1, 'f Cvar.t -> 'f, 's) As_prover0.t
+        * ('s1 -> (unit, 'f Cvar.t -> 'f, 's) As_prover0.t)
+        * ('b, 's1, 'f) t
+        * ('b -> ('a, 's, 'f) t)
+        -> ('a, 's, 'f) t
     | With_handler :
         Request.Handler.single
-        * ('a, 's, 'f, 'v) t
-        * ('a -> ('b, 's, 'f, 'v) t)
-        -> ('b, 's, 'f, 'v) t
+        * ('a, 's, 'f) t
+        * ('a -> ('b, 's, 'f) t)
+        -> ('b, 's, 'f) t
     | Clear_handler :
-        ('a, 's, 'f, 'v) t * ('a -> ('b, 's, 'f, 'v) t)
-        -> ('b, 's, 'f, 'v) t
+        ('a, 's, 'f) t * ('a -> ('b, 's, 'f) t)
+        -> ('b, 's, 'f) t
     | Exists :
-        ('var, 'value, 'f, 'v) Typ.t
-        * ('value, 'v -> 'f, 's) Provider.t
-        * (('var, 'value) Handle.t -> ('a, 's, 'f, 'v) t)
-        -> ('a, 's, 'f, 'v) t
-    | Next_auxiliary : (int -> ('a, 's, 'f, 'v) t) -> ('a, 's, 'f, 'v) t
+        ('var, 'value, 'f) Typ.t
+        * ('value, 'f Cvar.t -> 'f, 's) Provider.t
+        * (('var, 'value) Handle.t -> ('a, 's, 'f) t)
+        -> ('a, 's, 'f) t
+    | Next_auxiliary : (int -> ('a, 's, 'f) t) -> ('a, 's, 'f) t
 end =
   Checked

--- a/src/types.ml
+++ b/src/types.ml
@@ -44,14 +44,14 @@ and Checked : sig
         'f Cvar.t Constraint.t * ('a, 's, 'f) t
         -> ('a, 's, 'f) t
     | As_prover :
-        (unit, 'f Cvar.t -> 'f, 's) As_prover0.t * ('a, 's, 'f) t
+        (unit, 'f, 's) As_prover0.t * ('a, 's, 'f) t
         -> ('a, 's, 'f) t
     | With_label :
         string * ('a, 's, 'f) t * ('a -> ('b, 's, 'f) t)
         -> ('b, 's, 'f) t
     | With_state :
-        ('s1, 'f Cvar.t -> 'f, 's) As_prover0.t
-        * ('s1 -> (unit, 'f Cvar.t -> 'f, 's) As_prover0.t)
+        ('s1, 'f, 's) As_prover0.t
+        * ('s1 -> (unit, 'f, 's) As_prover0.t)
         * ('b, 's1, 'f) t
         * ('b -> ('a, 's, 'f) t)
         -> ('a, 's, 'f) t
@@ -65,7 +65,7 @@ and Checked : sig
         -> ('b, 's, 'f) t
     | Exists :
         ('var, 'value, 'f) Typ.t
-        * ('value, 'f Cvar.t -> 'f, 's) Provider.t
+        * ('value, 'f, 's) Provider.t
         * (('var, 'value) Handle.t -> ('a, 's, 'f) t)
         -> ('a, 's, 'f) t
     | Next_auxiliary : (int -> ('a, 's, 'f) t) -> ('a, 's, 'f) t

--- a/src/types.ml
+++ b/src/types.ml
@@ -56,13 +56,9 @@ and Checked : sig
         * ('b -> ('a, 's, 'f) t)
         -> ('a, 's, 'f) t
     | With_handler :
-        Request.Handler.single
-        * ('a, 's, 'f) t
-        * ('a -> ('b, 's, 'f) t)
+        Request.Handler.single * ('a, 's, 'f) t * ('a -> ('b, 's, 'f) t)
         -> ('b, 's, 'f) t
-    | Clear_handler :
-        ('a, 's, 'f) t * ('a -> ('b, 's, 'f) t)
-        -> ('b, 's, 'f) t
+    | Clear_handler : ('a, 's, 'f) t * ('a -> ('b, 's, 'f) t) -> ('b, 's, 'f) t
     | Exists :
         ('var, 'value, 'f) Typ.t
         * ('value, 'f, 's) Provider.t

--- a/src/types.ml
+++ b/src/types.ml
@@ -21,9 +21,9 @@ module rec Typ : sig
   end
 ]}*)
   type ('var, 'value, 'field) t =
-    { store: 'value -> ('var, 'field, 'field Cvar.t) Store.t
-    ; read: 'var -> ('value, 'field, 'field Cvar.t) Read.t
-    ; alloc: ('var, 'field Cvar.t) Alloc.t
+    { store: 'value -> ('var, 'field) Store.t
+    ; read: 'var -> ('value, 'field) Read.t
+    ; alloc: ('var, 'field) Alloc.t
     ; check: 'var -> (unit, unit, 'field) Checked.t }
 end =
   Typ


### PR DESCRIPTION
This PR updates the base types so that they no longer refer to `'field_var`/`'cvar`, since we can now just derive that from `'field`.

This affects types `Typ.t`, `Checked.t`, `As_prover.t`, `Typ_monads.Store.t`, `Typ_monads.Read.t` and `Typ_monads.Alloc.t`.