### PR TITLE
Stop needing `open Let_syntax`

### DIFF
--- a/examples/election/election.ml
+++ b/examples/election/election.ml
@@ -2,7 +2,6 @@ open Core
 open Snarky
 open Impl
 open Import
-open Let_syntax
 
 (* First we declare the type of "votes" and call a library functor [Enumerable] to
    make it possible to refer to values of type [Vote.t] in checked computations. *)

--- a/examples/tutorial/tutorial.ml
+++ b/examples/tutorial/tutorial.ml
@@ -11,7 +11,6 @@ open Snarky
 (* 0. First we instantiate Snarky with a 'backend' *)
 module Impl = Snark.Make (Backends.Bn128.Default)
 open Impl
-open Let_syntax
 
 (* 1. There is a monad called 'Checked'. It has an extra type parameter but let's
   ignore that for now *)

--- a/src/as_prover.ml
+++ b/src/as_prover.ml
@@ -5,7 +5,7 @@ type ('a, 'f, 's) t = ('a, 'f, 's) As_prover0.t
 module type S = sig
   type field
 
-  include Monad.S2 with type ('a, 's) t = ('a, field, 's) t
+  include Monad_let.S2 with type ('a, 's) t = ('a, field, 's) t
 
   val run : ('a, 's) t -> (field Cvar.t -> field) -> 's -> 's * 'a
 
@@ -79,12 +79,12 @@ struct
     let return = return
   end
 
-  include Monad.Make2 (T)
+  include Monad_let.Make2 (T)
 end
 
 include T
 
-include Monad.Make3 (struct
+include Monad_let.Make3 (struct
   type nonrec ('a, 'f, 's) t = ('a, 'f, 's) t
 
   let map = `Custom map

--- a/src/as_prover.mli
+++ b/src/as_prover.mli
@@ -1,5 +1,3 @@
-open Core_kernel
-
 (** {!type:t} is the type of functions that the prover can run during the
     course of a checked computation.
     
@@ -7,14 +5,15 @@ open Core_kernel
     over {!type:t} so that we have a simple way to interact with values inside the type
     (the value of type ['a] corresponding to our [('a, 'f, 's) t]).
     *)
-include Monad.S3 with type ('a, 'f, 's) t = ('f Cvar.t -> 'f) -> 's -> 's * 'a
+include
+  Monad_let.S3 with type ('a, 'f, 's) t = ('f Cvar.t -> 'f) -> 's -> 's * 'a
 
 val run : ('a, 'f, 's) t -> ('f Cvar.t -> 'f) -> 's -> 's * 'a
 
 module type S = sig
   type field
 
-  include Monad.S2 with type ('a, 's) t = ('a, field, 's) t
+  include Monad_let.S2 with type ('a, 's) t = ('a, field, 's) t
 
   val run : ('a, 's) t -> (field Cvar.t -> field) -> 's -> 's * 'a
 

--- a/src/as_prover0.ml
+++ b/src/as_prover0.ml
@@ -1,5 +1,3 @@
-open Core_kernel
-
 type ('a, 'f, 's) t = ('f Cvar.t -> 'f) -> 's -> 's * 'a
 
 module T = struct
@@ -33,7 +31,7 @@ end
 
 include T
 
-include Monad.Make3 (struct
+include Monad_let.Make3 (struct
   type nonrec ('a, 'e, 's) t = ('a, 'e, 's) t
 
   let map = `Custom map

--- a/src/curves.ml
+++ b/src/curves.ml
@@ -281,7 +281,6 @@ module Edwards = struct
     (* TODO: Assert quadratic non-residuosity of Params.d *)
 
     let assert_on_curve (x, y) =
-      let open Let_syntax in
       let%bind x2 = Field.Checked.mul x x and y2 = Field.Checked.mul y y in
       let open Field.Checked.Infix in
       assert_r1cs (Params.d * x2) y2 (x2 + y2 - Field.Var.constant Field.one)
@@ -580,7 +579,6 @@ module Make_weierstrass_checked
   type t = Curve.t
 
   let assert_on_curve (x, y) =
-    let open Let_syntax in
     let%bind x2 = Field.Checked.square x in
     let%bind x3 = Field.Checked.mul x2 x in
     assert_square y
@@ -610,7 +608,6 @@ module Make_weierstrass_checked
   end
 
   let%snarkydef_ add' ~div (ax, ay) (bx, by) =
-    let open Let_syntax in
     let%bind lambda = div (Field.Var.sub by ay) (Field.Var.sub bx ax) in
     let%bind cx =
       exists Typ.field
@@ -650,7 +647,6 @@ module Make_weierstrass_checked
    on which it is called are not equal. If it is called on equal points,
    the prover can return almost any curve point they want to from this function. *)
   let add_unsafe =
-    let open Let_syntax in
     let div_unsafe x y =
       let%bind z =
         exists Field.typ
@@ -690,7 +686,6 @@ module Make_weierstrass_checked
       go 0 [] xs ys zs
     in
     fun b ~then_ ~else_ ->
-      let open Let_syntax in
       let%bind r =
         exists typ
           ~compute:
@@ -741,7 +736,6 @@ module Make_weierstrass_checked
     end
 
     let create (type shifted) () : ((module S), _) Checked.t =
-      let open Let_syntax in
       let%map shift =
         exists typ ~compute:As_prover.(map (return ()) ~f:Curve.random)
       in
@@ -752,7 +746,6 @@ module Make_weierstrass_checked
   end
 
   let%snarkydef_ double (ax, ay) =
-    let open Let_syntax in
     let%bind x_squared = Field.Checked.square ax in
     let%bind lambda =
       exists Typ.field
@@ -826,7 +819,6 @@ module Make_weierstrass_checked
    a discussion of this trick.
 *)
   let lookup_point (b0, b1) (t1, t2, t3, t4) =
-    let open Let_syntax in
     let%map b0_and_b1 = Boolean.( && ) b0 b1 in
     let lookup_one (a1, a2, a3, a4) =
       let open Field.Infix in

--- a/src/free_monad.ml
+++ b/src/free_monad.ml
@@ -1,5 +1,3 @@
-open Base
-
 module Functor = struct
   module type S = sig
     type 'a t
@@ -23,7 +21,7 @@ end
 module Make (F : Functor.S) : sig
   type 'a t = Pure of 'a | Free of 'a t F.t
 
-  include Monad.S with type 'a t := 'a t
+  include Monad_let.S with type 'a t := 'a t
 end = struct
   module T = struct
     type 'a t = Pure of 'a | Free of 'a t F.t
@@ -42,13 +40,13 @@ end = struct
   end
 
   include T
-  include Monad.Make (T)
+  include Monad_let.Make (T)
 end
 
 module Make2 (F : Functor.S2) : sig
   type ('a, 'x) t = Pure of 'a | Free of (('a, 'x) t, 'x) F.t
 
-  include Monad.S2 with type ('a, 'x) t := ('a, 'x) t
+  include Monad_let.S2 with type ('a, 'x) t := ('a, 'x) t
 end = struct
   module T = struct
     type ('a, 'x) t = Pure of 'a | Free of (('a, 'x) t, 'x) F.t
@@ -67,13 +65,13 @@ end = struct
   end
 
   include T
-  include Monad.Make2 (T)
+  include Monad_let.Make2 (T)
 end
 
 module Make3 (F : Functor.S3) : sig
   type ('a, 'x, 'y) t = Pure of 'a | Free of (('a, 'x, 'y) t, 'x, 'y) F.t
 
-  include Monad.S3 with type ('a, 'x, 'y) t := ('a, 'x, 'y) t
+  include Monad_let.S3 with type ('a, 'x, 'y) t := ('a, 'x, 'y) t
 end = struct
   module T = struct
     type ('a, 'x, 'y) t = Pure of 'a | Free of (('a, 'x, 'y) t, 'x, 'y) F.t
@@ -92,5 +90,5 @@ end = struct
   end
 
   include T
-  include Monad.Make3 (T)
+  include Monad_let.Make3 (T)
 end

--- a/src/knapsack.ml
+++ b/src/knapsack.ml
@@ -46,7 +46,6 @@ module Make (Impl : Snark_intf.S) = struct
 
     let hash_to_bits (t : t) (vs : Boolean.var list) :
         (Boolean.var list, _) Checked.t =
-      let open Let_syntax in
       let%bind xs = hash_to_field t vs in
       with_label "hash_to_bits"
         (let%map bss =
@@ -77,7 +76,6 @@ module Make (Impl : Snark_intf.S) = struct
      res - xs = b * (ys - xs)
   *)
     let if_ (b : Boolean.var) ~then_:ys ~else_:xs : (var, _) Impl.Checked.t =
-      let open Impl.Let_syntax in
       let%bind res =
         exists typ_unchecked
           ~compute:

--- a/src/merkle_tree.ml
+++ b/src/merkle_tree.ml
@@ -463,7 +463,6 @@ struct
   (* addr0 should have least significant bit first *)
   let%snarkydef_ update ~(depth : int) ~root ~prev ~next addr0 :
       (Hash.var, (Hash.value, Elt.value) merkle_tree) Checked.t =
-    let open Let_syntax in
     let%bind prev_entry_hash = Elt.hash prev
     and next_entry_hash = Elt.hash next
     and prev_path =

--- a/src/monad_let.ml
+++ b/src/monad_let.ml
@@ -1,0 +1,232 @@
+(** The usual Janestreet [Monad] interfaces, with [Let_syntax] included in the
+    monad module. *)
+open Core_kernel
+
+open Monad
+
+module type Let_syntax = sig
+  type 'a t
+
+  val return : 'a -> 'a t
+
+  val bind : 'a t -> f:('a -> 'b t) -> 'b t
+
+  val map : 'a t -> f:('a -> 'b) -> 'b t
+
+  val both : 'a t -> 'b t -> ('a * 'b) t
+
+  module Open_on_rhs : sig end
+end
+
+module type Base_syntax = sig
+  type 'a t
+
+  val return : 'a -> 'a t
+
+  include Infix with type 'a t := 'a t
+end
+
+module type Syntax = sig
+  include Base_syntax
+
+  include Let_syntax with type 'a t := 'a t
+end
+
+module type S = sig
+  type 'a t
+
+  include S_without_syntax with type 'a t := 'a t
+
+  module Let_syntax : sig
+    include Base_syntax with type 'a t := 'a t
+
+    include Let_syntax with type 'a t := 'a t
+
+    module Let_syntax : Let_syntax with type 'a t := 'a t
+  end
+end
+
+module Make (X : Monad.Basic) : S with type 'a t := 'a X.t = struct
+  include X
+  module M = Monad.Make (X)
+  module Let = M.Let_syntax.Let_syntax
+
+  include (M : S_without_syntax with type 'a t := 'a t)
+
+  module Let_syntax = struct
+    include (M.Let_syntax : Base_syntax with type 'a t := 'a t)
+
+    include (Let : Let_syntax with type 'a t := 'a t)
+
+    module Let_syntax = Let
+  end
+end
+
+module type Let_syntax2 = sig
+  type ('a, 'e) t
+
+  val return : 'a -> ('a, 'e) t
+
+  val bind : ('a, 'e) t -> f:('a -> ('b, 'e) t) -> ('b, 'e) t
+
+  val map : ('a, 'e) t -> f:('a -> 'b) -> ('b, 'e) t
+
+  val both : ('a, 'e) t -> ('b, 'e) t -> ('a * 'b, 'e) t
+
+  module Open_on_rhs : sig end
+end
+
+module type Base_syntax2 = sig
+  type ('a, 'e) t
+
+  val return : 'a -> ('a, 'e) t
+
+  include Infix2 with type ('a, 'e) t := ('a, 'e) t
+end
+
+module type Syntax2 = sig
+  include Base_syntax2
+
+  include Let_syntax2 with type ('a, 'e) t := ('a, 'e) t
+end
+
+module type S_without_syntax2 = sig
+  type ('a, 'e) t
+
+  include Infix2 with type ('a, 'e) t := ('a, 'e) t
+
+  module Monad_infix : Infix2 with type ('a, 'e) t := ('a, 'e) t
+
+  val bind : ('a, 'e) t -> f:('a -> ('b, 'e) t) -> ('b, 'e) t
+
+  val return : 'a -> ('a, _) t
+
+  val map : ('a, 'e) t -> f:('a -> 'b) -> ('b, 'e) t
+
+  val join : (('a, 'e) t, 'e) t -> ('a, 'e) t
+
+  val ignore_m : (_, 'e) t -> (unit, 'e) t
+
+  val all : ('a, 'e) t list -> ('a list, 'e) t
+
+  val all_unit : (unit, 'e) t list -> (unit, 'e) t
+
+  val all_ignore : (unit, 'e) t list -> (unit, 'e) t
+    [@@deprecated "[since 2018-02] Use [all_unit]"]
+end
+
+module type S2 = sig
+  type ('a, 'e) t
+
+  include S_without_syntax2 with type ('a, 'e) t := ('a, 'e) t
+
+  module Let_syntax : sig
+    include Base_syntax2 with type ('a, 'e) t := ('a, 'e) t
+
+    include Let_syntax2 with type ('a, 'e) t := ('a, 'e) t
+
+    module Let_syntax : Let_syntax2 with type ('a, 'e) t := ('a, 'e) t
+  end
+end
+
+module Make2 (X : Monad.Basic2) : S2 with type ('a, 'e) t := ('a, 'e) X.t =
+struct
+  include X
+  module M = Monad.Make2 (X)
+  module Let = M.Let_syntax.Let_syntax
+
+  include (M : S_without_syntax2 with type ('a, 'e) t := ('a, 'e) t)
+
+  module Let_syntax = struct
+    include (M.Let_syntax : Base_syntax2 with type ('a, 'e) t := ('a, 'e) t)
+
+    include (Let : Let_syntax2 with type ('a, 'e) t := ('a, 'e) t)
+
+    module Let_syntax = Let
+  end
+end
+
+module type Let_syntax3 = sig
+  type ('a, 'd, 'e) t
+
+  val return : 'a -> ('a, 'd, 'e) t
+
+  val bind : ('a, 'd, 'e) t -> f:('a -> ('b, 'd, 'e) t) -> ('b, 'd, 'e) t
+
+  val map : ('a, 'd, 'e) t -> f:('a -> 'b) -> ('b, 'd, 'e) t
+
+  val both : ('a, 'd, 'e) t -> ('b, 'd, 'e) t -> ('a * 'b, 'd, 'e) t
+
+  module Open_on_rhs : sig end
+end
+
+module type Base_syntax3 = sig
+  type ('a, 'd, 'e) t
+
+  val return : 'a -> ('a, 'd, 'e) t
+
+  include Infix3 with type ('a, 'd, 'e) t := ('a, 'd, 'e) t
+end
+
+module type Syntax3 = sig
+  include Base_syntax3
+
+  include Let_syntax3 with type ('a, 'd, 'e) t := ('a, 'd, 'e) t
+end
+
+module type S_without_syntax3 = sig
+  type ('a, 'd, 'e) t
+
+  include Infix3 with type ('a, 'd, 'e) t := ('a, 'd, 'e) t
+
+  module Monad_infix : Infix3 with type ('a, 'd, 'e) t := ('a, 'd, 'e) t
+
+  val bind : ('a, 'd, 'e) t -> f:('a -> ('b, 'd, 'e) t) -> ('b, 'd, 'e) t
+
+  val return : 'a -> ('a, _, _) t
+
+  val map : ('a, 'd, 'e) t -> f:('a -> 'b) -> ('b, 'd, 'e) t
+
+  val join : (('a, 'd, 'e) t, 'd, 'e) t -> ('a, 'd, 'e) t
+
+  val ignore_m : (_, 'd, 'e) t -> (unit, 'd, 'e) t
+
+  val all : ('a, 'd, 'e) t list -> ('a list, 'd, 'e) t
+
+  val all_unit : (unit, 'd, 'e) t list -> (unit, 'd, 'e) t
+
+  val all_ignore : (unit, 'd, 'e) t list -> (unit, 'd, 'e) t
+    [@@deprecated "[since 2018-02] Use [all_unit]"]
+end
+
+module type S3 = sig
+  type ('a, 'd, 'e) t
+
+  include S_without_syntax3 with type ('a, 'd, 'e) t := ('a, 'd, 'e) t
+
+  module Let_syntax : sig
+    include Base_syntax3 with type ('a, 'd, 'e) t := ('a, 'd, 'e) t
+
+    include Let_syntax3 with type ('a, 'd, 'e) t := ('a, 'd, 'e) t
+
+    module Let_syntax : Let_syntax3 with type ('a, 'd, 'e) t := ('a, 'd, 'e) t
+  end
+end
+
+module Make3 (X : Monad.Basic3) :
+  S3 with type ('a, 'd, 'e) t := ('a, 'd, 'e) X.t = struct
+  include X
+  module M = Monad.Make3 (X)
+  module Let = M.Let_syntax.Let_syntax
+
+  include (M : S_without_syntax3 with type ('a, 'd, 'e) t := ('a, 'd, 'e) t)
+
+  module Let_syntax = struct
+    include (
+      M.Let_syntax : Base_syntax3 with type ('a, 'd, 'e) t := ('a, 'd, 'e) t )
+
+    include (Let : Let_syntax3 with type ('a, 'd, 'e) t := ('a, 'd, 'e) t)
+
+    module Let_syntax = Let
+  end
+end

--- a/src/monad_sequence.ml
+++ b/src/monad_sequence.ml
@@ -45,7 +45,7 @@ module type S = sig
 end
 
 module List
-    (M : Monad.S2) (Bool : sig
+    (M : Monad_let.S2) (Bool : sig
         type t
 
         val any : t list -> (t, _) M.t

--- a/src/pedersen.ml
+++ b/src/pedersen.ml
@@ -113,7 +113,6 @@ end = struct
 
   let lookup ((s0, s1, s2) : Boolean.var Triple.t)
       (q : Weierstrass_curve.t Quadruple.t) =
-    let open Let_syntax in
     let%bind s_and = Boolean.(s0 && s1) in
     let open Field.Checked.Infix in
     let lookup_one (a1, a2, a3, a4) =
@@ -205,7 +204,6 @@ end = struct
     let support t = t.support
 
     let disjoint_union_exn t1 t2 =
-      let open Let_syntax in
       let support = Interval_union.disjoint_union_exn t1.support t2.support in
       let%map acc = Acc.add t1.acc t2.acc in
       {support; acc}

--- a/src/restrict_monad.ml
+++ b/src/restrict_monad.ml
@@ -1,9 +1,7 @@
-open Base
-
 module Make2
-    (M : Monad.S2) (T : sig
+    (M : Monad_let.S2) (T : sig
         type t
-    end) : Monad.S with type 'a t = ('a, T.t) M.t = struct
+    end) : Monad_let.S with type 'a t = ('a, T.t) M.t = struct
   type 'a t = ('a, T.t) M.t
 
   let map = M.map
@@ -28,11 +26,11 @@ module Make2
 end
 
 module Make3
-    (M : Monad.S3) (T : sig
+    (M : Monad_let.S3) (T : sig
         type t1
 
         type t2
-    end) : Monad.S with type 'a t = ('a, T.t1, T.t2) M.t = struct
+    end) : Monad_let.S with type 'a t = ('a, T.t1, T.t2) M.t = struct
   type 'a t = ('a, T.t1, T.t2) M.t
 
   let map = M.map

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -289,7 +289,7 @@ module Make_basic (Backend : Backend_intf.S) = struct
     end
 
     include T
-    include Monad.Make2 (T)
+    include Monad_let.Make2 (T)
   end
 
   module Typ = struct

--- a/src/snark_intf.ml
+++ b/src/snark_intf.ml
@@ -107,19 +107,19 @@ module type Basic = sig
   (** Mappings from OCaml types to R1CS variables and constraints. *)
   and Typ : sig
     module Store : sig
-      include Monad.S with type 'a t = ('a, Field.t) Typ_monads.Store.t
+      include Monad_let.S with type 'a t = ('a, Field.t) Typ_monads.Store.t
 
       val store : field -> Field.Var.t t
     end
 
     module Alloc : sig
-      include Monad.S with type 'a t = ('a, Field.t) Typ_monads.Alloc.t
+      include Monad_let.S with type 'a t = ('a, Field.t) Typ_monads.Alloc.t
 
       val alloc : Field.Var.t t
     end
 
     module Read : sig
-      include Monad.S with type 'a t = ('a, Field.t) Typ_monads.Read.t
+      include Monad_let.S with type 'a t = ('a, Field.t) Typ_monads.Read.t
 
       val read : Field.Var.t -> field t
     end
@@ -302,7 +302,8 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
   Field.Checked.mul x_times_y z
 ]}
     *)
-    include Monad.S2 with type ('a, 's) t = ('a, 's, Field.t) Types.Checked.t
+    include
+      Monad_let.S2 with type ('a, 's) t = ('a, 's, Field.t) Types.Checked.t
 
     module List :
       Monad_sequence.S
@@ -438,7 +439,8 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
     val typ : (Var.t, t) Typ.t
   end
 
-  include Monad.Syntax2 with type ('a, 's) t := ('a, 's) Checked.t
+  module Let_syntax :
+    Monad_let.Syntax2 with type ('a, 's) t := ('a, 's) Checked.t
 
   module Proof : sig
     type t
@@ -486,7 +488,7 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
       val set : 'a t -> 'a -> (unit, _) as_prover
     end
 
-    include Monad.S2 with type ('a, 's) t := ('a, 's) t
+    include Monad_let.S2 with type ('a, 's) t := ('a, 's) t
 
     val map2 : ('a, 's) t -> ('b, 's) t -> f:('a -> 'b -> 'c) -> ('c, 's) t
 

--- a/src/traversable.ml
+++ b/src/traversable.ml
@@ -1,11 +1,9 @@
-open Core_kernel
-
 module type S = sig
   type 'a t
 
   (* TODO-someday: Should be applicative, it's anonying because Applicative.S is not a subsignature
    of Monad.S, but Monad.S is more common so we go with that. *)
-  module Traverse (A : Monad.S) : sig
+  module Traverse (A : Monad_let.S) : sig
     val f : 'a t -> f:('a -> 'b A.t) -> 'b t A.t
   end
 end


### PR DESCRIPTION
This PR
* creates the `Monad_let` module matching the interfaces in `Monad.Base`, but also including the `Let_syntax.Let_syntax` module in the toplevel `Let_syntax`
* uses this wherever we have monads

This should remove the need for the e.g. `As_prover.(Let_syntax.(...))` pattern.