### PR TITLE
[Meja] Handle Tctor parameters everywhere

### DIFF
--- a/meja/envi.ml
+++ b/meja/envi.ml
@@ -467,7 +467,13 @@ module Type = struct
         in
         let typ, env = flatten typ env in
         mk ~loc (Tpoly (Set.to_list var_set, typ)) env
-    | Tctor _ -> mk ~loc typ.type_desc env
+    | Tctor variant ->
+        let env, var_params = List.fold_map ~init:env variant.var_params
+          ~f:(fun env typ ->
+            let typ, env = flatten typ env in
+            (env, typ))
+        in
+        mk ~loc (Tctor {variant with var_params}) env
     | Ttuple typs ->
         let env, typs =
           List.fold_map typs ~init:env ~f:(fun e t ->

--- a/meja/envi.ml
+++ b/meja/envi.ml
@@ -386,9 +386,8 @@ module Type = struct
       | Some var -> (var, env)
       | None -> (typ, env) )
     | Tpoly (vars, typ) ->
-        let vars, new_vars_map, env = refresh_vars vars new_vars_map env in
-        let typ, env = copy typ new_vars_map env in
-        mk ~loc (Tpoly (vars, typ)) env
+        let _vars, new_vars_map, env = refresh_vars vars new_vars_map env in
+        copy typ new_vars_map env
     | Tctor _ -> mk ~loc typ.type_desc env
     | Ttuple typs ->
         let env, typs =

--- a/meja/envi.ml
+++ b/meja/envi.ml
@@ -388,7 +388,12 @@ module Type = struct
     | Tpoly (vars, typ) ->
         let _vars, new_vars_map, env = refresh_vars vars new_vars_map env in
         copy typ new_vars_map env
-    | Tctor _ -> mk ~loc typ.type_desc env
+    | Tctor ({var_params; _} as variant) ->
+        let env, var_params = List.fold_map ~init:env var_params ~f:(fun e t ->
+          let t, e = copy t new_vars_map e in
+          (e, t))
+        in
+      mk ~loc (Tctor {variant with var_params}) env
     | Ttuple typs ->
         let env, typs =
           List.fold_map typs ~init:env ~f:(fun e t ->

--- a/meja/envi.ml
+++ b/meja/envi.ml
@@ -439,7 +439,10 @@ module Type = struct
             ~f:(fun set var -> Set.union set (type_vars' var))
         in
         Set.diff (type_vars typ) poly_vars
-    | Tctor _ -> Set.empty (module Comparator)
+    | Tctor {var_params; _} ->
+        List.fold ~init:(Set.empty (module Comparator))
+          var_params
+          ~f:(fun set var -> Set.union set (type_vars' var))
     | Ttuple typs ->
         Set.union_list (module Comparator) (List.map ~f:type_vars typs)
     | Tarrow (typ1, typ2) -> Set.union (type_vars typ1) (type_vars typ2)

--- a/meja/envi.ml
+++ b/meja/envi.ml
@@ -231,7 +231,7 @@ let pop_scope env =
   match env.scope_stack with
   | [] -> raise (Error (Location.none, No_open_scopes))
   | scope :: scope_stack ->
-      (scope, {env with scope_stack; depth= env.depth + 1})
+      (scope, {env with scope_stack; depth= env.depth - 1})
 
 let pop_expr_scope env =
   let scope, env = pop_scope env in

--- a/meja/envi.ml
+++ b/meja/envi.ml
@@ -432,17 +432,12 @@ module Type = struct
         Set.singleton (module Comparator) typ
     | Tvar _ -> Set.empty (module Comparator)
     | Tpoly (vars, typ) ->
-        let poly_vars =
-          List.fold
-            ~init:(Set.empty (module Comparator))
-            vars
-            ~f:(fun set var -> Set.union set (type_vars' var))
+        let poly_vars = Set.union_list (module Comparator)
+          (List.map ~f:type_vars' vars)
         in
         Set.diff (type_vars typ) poly_vars
     | Tctor {var_params; _} ->
-        List.fold ~init:(Set.empty (module Comparator))
-          var_params
-          ~f:(fun set var -> Set.union set (type_vars' var))
+        Set.union_list (module Comparator) (List.map ~f:type_vars var_params)
     | Ttuple typs ->
         Set.union_list (module Comparator) (List.map ~f:type_vars typs)
     | Tarrow (typ1, typ2) -> Set.union (type_vars typ1) (type_vars typ2)

--- a/meja/envi.ml
+++ b/meja/envi.ml
@@ -389,11 +389,12 @@ module Type = struct
         let _vars, new_vars_map, env = refresh_vars vars new_vars_map env in
         copy typ new_vars_map env
     | Tctor ({var_params; _} as variant) ->
-        let env, var_params = List.fold_map ~init:env var_params ~f:(fun e t ->
-          let t, e = copy t new_vars_map e in
-          (e, t))
+        let env, var_params =
+          List.fold_map ~init:env var_params ~f:(fun e t ->
+              let t, e = copy t new_vars_map e in
+              (e, t) )
         in
-      mk ~loc (Tctor {variant with var_params}) env
+        mk ~loc (Tctor {variant with var_params}) env
     | Ttuple typs ->
         let env, typs =
           List.fold_map typs ~init:env ~f:(fun e t ->
@@ -432,8 +433,8 @@ module Type = struct
         Set.singleton (module Comparator) typ
     | Tvar _ -> Set.empty (module Comparator)
     | Tpoly (vars, typ) ->
-        let poly_vars = Set.union_list (module Comparator)
-          (List.map ~f:type_vars' vars)
+        let poly_vars =
+          Set.union_list (module Comparator) (List.map ~f:type_vars' vars)
         in
         Set.diff (type_vars typ) poly_vars
     | Tctor {var_params; _} ->
@@ -463,10 +464,10 @@ module Type = struct
         let typ, env = flatten typ env in
         mk ~loc (Tpoly (Set.to_list var_set, typ)) env
     | Tctor variant ->
-        let env, var_params = List.fold_map ~init:env variant.var_params
-          ~f:(fun env typ ->
-            let typ, env = flatten typ env in
-            (env, typ))
+        let env, var_params =
+          List.fold_map ~init:env variant.var_params ~f:(fun env typ ->
+              let typ, env = flatten typ env in
+              (env, typ) )
         in
         mk ~loc (Tctor {variant with var_params}) env
     | Ttuple typs ->

--- a/meja/typechecker.ml
+++ b/meja/typechecker.ml
@@ -118,7 +118,8 @@ let rec free_type_vars ?depth typ =
           ~f:(fun set var -> Set.union set (Envi.Type.type_vars var))
       in
       Set.diff (free_type_vars typ) poly_vars
-  | Tctor _ -> Set.empty (module Envi.Type)
+  | Tctor {var_params; _} ->
+      Set.union_list (module Envi.Type) (List.map ~f:free_type_vars var_params)
   | Ttuple typs ->
       Set.union_list (module Envi.Type) (List.map ~f:free_type_vars typs)
   | Tarrow (typ1, typ2) ->


### PR DESCRIPTION
This PR
- adds `Tctor` parameter handling for some cases I'd forgotten to port over
- fixes a nasty typo where both opening *and* closing the scope caused the depth to increase.