### PR TITLE
[Meja] Implicit arguments

### DIFF
--- a/meja/envi.ml
+++ b/meja/envi.ml
@@ -800,9 +800,13 @@ module Core = struct
     let loc = Location.none in
     let var, env = Type__.mkvar ~loc None env in
     let testing_show_constr, env =
-      TypeDecl.import (mk_type_decl "testing_show_constr" ~params:[var] TAbstract) env
+      TypeDecl.import
+        (mk_type_decl "testing_show_constr" ~params:[var] TAbstract)
+        env
     in
-    let testing_show_typ, env = TypeDecl.mk_typ testing_show_constr ~params:[var] env in
+    let testing_show_typ, env =
+      TypeDecl.mk_typ testing_show_constr ~params:[var] env
+    in
     let typ, env = Type__.mk ~loc (Tarrow (var, Type.string)) env in
     let typ, env = Type__.mk ~loc (Timplicit (testing_show_typ, typ)) env in
     let typ, env = Type__.mk ~loc (Tpoly ([var], typ)) env in

--- a/meja/envi.ml
+++ b/meja/envi.ml
@@ -534,7 +534,7 @@ module Type = struct
     | typ1 :: typs1, typ2 :: typs2 ->
         or_compare (compare typ1 typ2) ~f:(fun () -> compare_all typs1 typs2)
 
-  let flattened_implicit_vars typ_vars env =
+  let flattened_implicit_vars ~toplevel typ_vars env =
     let {TypeEnvi.implicit_vars; _} = env.type_env in
     let env, implicit_vars =
       List.fold_map ~init:env implicit_vars ~f:(fun env e ->
@@ -551,10 +551,12 @@ module Type = struct
           cmp )
     in
     let local_implicit_vars, implicit_vars =
-      List.partition_tf implicit_vars ~f:(fun {exp_type; _} ->
-          let exp_vars = type_vars exp_type in
-          let instantiated_vars = Set.inter exp_vars typ_vars in
-          not (Set.is_empty instantiated_vars) )
+      if toplevel then implicit_vars, []
+      else
+        List.partition_tf implicit_vars ~f:(fun {exp_type; _} ->
+            let exp_vars = type_vars exp_type in
+            let instantiated_vars = Set.inter exp_vars typ_vars in
+            not (Set.is_empty instantiated_vars) )
     in
     ( local_implicit_vars
     , {env with type_env= {env.type_env with implicit_vars}} )

--- a/meja/envi.ml
+++ b/meja/envi.ml
@@ -553,7 +553,8 @@ module Type = struct
     let local_implicit_vars, implicit_vars =
       List.partition_tf implicit_vars ~f:(fun {exp_type; _} ->
           let exp_vars = type_vars exp_type in
-          Set.is_subset exp_vars ~of_:typ_vars )
+          let instantiated_vars = Set.inter exp_vars typ_vars in
+          not (Set.is_empty instantiated_vars))
     in
     ( local_implicit_vars
     , {env with type_env= {env.type_env with implicit_vars}} )

--- a/meja/envi.ml
+++ b/meja/envi.ml
@@ -746,9 +746,9 @@ let find_name (lid : lid) env =
 module Core = struct
   let mkloc s = Location.(mkloc s none)
 
-  let mk_type_decl name desc =
+  let mk_type_decl ?(params = []) name desc =
     { tdec_ident= mkloc name
-    ; tdec_params= []
+    ; tdec_params= params
     ; tdec_desc= desc
     ; tdec_id= 0
     ; tdec_loc= Location.none }
@@ -778,6 +778,8 @@ module Core = struct
 
   let float, env = TypeDecl.import (mk_type_decl "float" TAbstract) env
 
+  module Type__ = Type
+
   module Type = struct
     let int, env = TypeDecl.mk_typ int ~params:[] env
 
@@ -793,6 +795,18 @@ module Core = struct
   end
 
   let env = Type.env
+
+  let env =
+    let loc = Location.none in
+    let var, env = Type__.mkvar ~loc None env in
+    let testing_show_constr, env =
+      TypeDecl.import (mk_type_decl "testing_show_constr" ~params:[var] TAbstract) env
+    in
+    let testing_show_typ, env = TypeDecl.mk_typ testing_show_constr ~params:[var] env in
+    let typ, env = Type__.mk ~loc (Tarrow (var, Type.string)) env in
+    let typ, env = Type__.mk ~loc (Timplicit (testing_show_typ, typ)) env in
+    let typ, env = Type__.mk ~loc (Tpoly ([var], typ)) env in
+    add_name (mkloc "testing_show") typ env
 end
 
 (* Error handling *)

--- a/meja/envi.ml
+++ b/meja/envi.ml
@@ -554,7 +554,7 @@ module Type = struct
       List.partition_tf implicit_vars ~f:(fun {exp_type; _} ->
           let exp_vars = type_vars exp_type in
           let instantiated_vars = Set.inter exp_vars typ_vars in
-          not (Set.is_empty instantiated_vars))
+          not (Set.is_empty instantiated_vars) )
     in
     ( local_implicit_vars
     , {env with type_env= {env.type_env with implicit_vars}} )

--- a/meja/envi.ml
+++ b/meja/envi.ml
@@ -546,12 +546,13 @@ module Type = struct
           let cmp = compare exp1.exp_type exp2.exp_type in
           ( if Int.equal cmp 0 then
             match (exp1.exp_desc, exp2.exp_desc) with
-            | Unifiable desc1, Unifiable desc2 -> desc1.name <- desc2.name
+            | Unifiable desc1, Unifiable desc2 ->
+                desc1.expression <- desc2.expression
             | _, _ -> raise (Error (exp1.exp_loc, No_unifiable_implicit)) ) ;
           cmp )
     in
     let local_implicit_vars, implicit_vars =
-      if toplevel then implicit_vars, []
+      if toplevel then (implicit_vars, [])
       else
         List.partition_tf implicit_vars ~f:(fun {exp_type; _} ->
             let exp_vars = type_vars exp_type in
@@ -564,8 +565,10 @@ module Type = struct
   let new_implicit_var ~loc typ env =
     let {TypeEnvi.implicit_vars; implicit_id; _} = env.type_env in
     let mk exp_loc exp_desc = {exp_loc; exp_desc; exp_type= typ} in
-    let name = Location.mkloc (sprintf "__implicit%i__" implicit_id) loc in
-    let new_exp = mk loc (Unifiable {name}) in
+    let name =
+      Location.mkloc (Lident (sprintf "__implicit%i__" implicit_id)) loc
+    in
+    let new_exp = mk loc (Unifiable {expression= mk loc (Variable name)}) in
     ( new_exp
     , { env with
         type_env=

--- a/meja/envi.ml
+++ b/meja/envi.ml
@@ -318,7 +318,8 @@ let find_module ~loc (lid : lid) env =
   | Some m -> m
   | None -> raise (Error (loc, Unbound_module lid.txt))
 
-let add_implicit_instance path typ env =
+let add_implicit_instance name typ env =
+  let path = Lident name in
   let id, type_env = TypeEnvi.next_instance_id env.type_env in
   let env =
     map_current_scope env ~f:(fun scope ->

--- a/meja/envi.ml
+++ b/meja/envi.ml
@@ -898,24 +898,6 @@ module Core = struct
   end
 
   let env = Type.env
-
-  let env =
-    let loc = Location.none in
-    let var, env = Type__.mkvar ~loc None env in
-    let testing_show_constr, env =
-      TypeDecl.import
-        (mk_type_decl "testing_show_constr" ~params:[var] TAbstract)
-        env
-    in
-    let testing_show_typ, env =
-      TypeDecl.mk_typ testing_show_constr ~params:[var] env
-    in
-    let typ, env = Type__.mk ~loc (Tarrow (var, Type.string, Explicit)) env in
-    let typ, env =
-      Type__.mk ~loc (Tarrow (testing_show_typ, typ, Implicit)) env
-    in
-    let typ, env = Type__.mk ~loc (Tpoly ([var], typ)) env in
-    add_name (mkloc "testing_show") typ env
 end
 
 (* Error handling *)

--- a/meja/lexer_impl.mll
+++ b/meja/lexer_impl.mll
@@ -34,6 +34,7 @@ rule token = parse
     { INT (int_of_string (Lexing.lexeme lexbuf)) }
   | "fun" { FUN }
   | "let" { LET }
+  | "instance" { INSTANCE }
   | "type" { TYPE }
   | "true" { TRUE }
   | "false" { FALSE }

--- a/meja/parser_impl.mly
+++ b/meja/parser_impl.mly
@@ -256,7 +256,7 @@ function_from_args:
     { mkexp ~pos:$loc (Fun (p, body, Explicit)) }
   | pat RBRACKET err = err
     { raise (Error (err, Fun_no_fat_arrow)) }
-  | p = pat RBRACKET typ = type_expr EQUALGT LBRACE body = block RBRACE
+  | p = pat RBRACKET COLON typ = type_expr EQUALGT LBRACE body = block RBRACE
     { mkexp ~pos:$loc (Fun (p, mkexp ~pos:$loc(typ) (Constraint (body, typ)), Explicit)) }
   | p = pat COMMA f = function_from_args
     { mkexp ~pos:$loc (Fun (p, f, Explicit)) }
@@ -266,10 +266,12 @@ function_from_implicit_args:
     { mkexp ~pos:$loc (Fun (p, f, Implicit)) }
   | p = pat RBRACE EQUALGT LBRACE body = block RBRACE
     { mkexp ~pos:$loc (Fun (p, body, Implicit)) }
-  | p = pat RBRACE typ = type_expr EQUALGT LBRACE body = block RBRACE
+  | p = pat RBRACE COLON typ = type_expr EQUALGT LBRACE body = block RBRACE
     { mkexp ~pos:$loc (Fun (p, mkexp ~pos:$loc(typ) (Constraint (body, typ)), Implicit)) }
   | p = pat COMMA f = function_from_implicit_args
     { mkexp ~pos:$loc (Fun (p, f, Implicit)) }
+  | pat RBRACE err = err
+    { raise (Error (err, Fun_no_fat_arrow)) }
 
 block:
   | e = expr SEMI
@@ -341,7 +343,9 @@ type_expr:
   | x = simple_type_expr
     { x }
   | x = simple_type_expr DASHGT y = type_expr
-    { mktyp ~pos:$loc (Tarrow (x, y)) }
+    { mktyp ~pos:$loc (Tarrow (x, y, Explicit)) }
+  | LBRACE x = simple_type_expr RBRACE DASHGT y = type_expr
+    { mktyp ~pos:$loc (Tarrow (x, y, Implicit)) }
 
 list(X, SEP):
   | xs = list(X, SEP) SEP x = X

--- a/meja/parsetypes.ml
+++ b/meja/parsetypes.ml
@@ -102,6 +102,8 @@ and pattern_desc =
   | PRecord of (lid * pattern) list
   | PCtor of lid * pattern option
 
+type explicitness = Implicit | Explicit
+
 type expression =
   {exp_desc: expression_desc; exp_loc: Location.t; exp_type: type_expr}
 
@@ -109,7 +111,7 @@ and expression_desc =
   | Apply of expression * expression list
   | Variable of lid
   | Int of int
-  | Fun of pattern * expression
+  | Fun of pattern * expression * explicitness
   | Seq of expression * expression
   | Let of pattern * expression * expression
   | Constraint of expression * type_expr
@@ -123,6 +125,7 @@ type statement = {stmt_desc: statement_desc; stmt_loc: Location.t}
 
 and statement_desc =
   | Value of pattern * expression
+  | Instance of str * expression
   | TypeDecl of type_decl
   | Module of str * module_expr
   | Open of lid

--- a/meja/parsetypes.ml
+++ b/meja/parsetypes.ml
@@ -111,7 +111,7 @@ and expression_desc =
   | Match of expression * (pattern * expression) list
   | Record of (lid * expression) list * expression option
   | Ctor of lid * expression option
-  | Unifiable of {mutable expression: expression}
+  | Unifiable of {mutable expression: expression option; name: str; id: int}
 
 type statement = {stmt_desc: statement_desc; stmt_loc: Location.t}
 

--- a/meja/parsetypes.ml
+++ b/meja/parsetypes.ml
@@ -36,6 +36,12 @@ module Longident = struct
     | Lident name -> pp_print_string ppf name
     | Ldot (lid, name) -> fprintf ppf "%a.%s" pp lid name
     | Lapply (lid1, lid2) -> fprintf ppf "%a(%a)" pp lid1 pp lid2
+
+  let rec add_outer_module name lid =
+    match lid with
+    | Lident name2 -> Ldot (Lident name, name2)
+    | Ldot (lid, name2) -> Ldot (add_outer_module name lid, name2)
+    | Lapply _ -> failwith "Unhandled Lapply in add_outer_module"
 end
 
 type str = string Location.loc

--- a/meja/parsetypes.ml
+++ b/meja/parsetypes.ml
@@ -51,6 +51,7 @@ and type_desc =
   | Tvar of str option * (* depth *) int
   | Ttuple of type_expr list
   | Tarrow of type_expr * type_expr
+  | Timplicit of type_expr * type_expr
   (* A type name. *)
   | Tctor of variant
   | Tpoly of type_expr list * type_expr
@@ -110,6 +111,7 @@ and expression_desc =
   | Match of expression * (pattern * expression) list
   | Record of (lid * expression) list * expression option
   | Ctor of lid * expression option
+  | Unifiable of {mutable name: str}
 
 type statement = {stmt_desc: statement_desc; stmt_loc: Location.t}
 

--- a/meja/parsetypes.ml
+++ b/meja/parsetypes.ml
@@ -48,6 +48,8 @@ type str = string Location.loc
 
 type lid = Longident.t Location.loc
 
+type explicitness = Implicit | Explicit
+
 let mk_lid (str : str) = Location.mkloc (Longident.Lident str.txt) str.loc
 
 type type_expr = {type_desc: type_desc; type_id: int; type_loc: Location.t}
@@ -56,8 +58,7 @@ and type_desc =
   (* A type variable. Name is None when not yet chosen. *)
   | Tvar of str option * (* depth *) int
   | Ttuple of type_expr list
-  | Tarrow of type_expr * type_expr
-  | Timplicit of type_expr * type_expr
+  | Tarrow of type_expr * type_expr * explicitness
   (* A type name. *)
   | Tctor of variant
   | Tpoly of type_expr list * type_expr
@@ -102,8 +103,6 @@ and pattern_desc =
   | PRecord of (lid * pattern) list
   | PCtor of lid * pattern option
 
-type explicitness = Implicit | Explicit
-
 type expression =
   {exp_desc: expression_desc; exp_loc: Location.t; exp_type: type_expr}
 
@@ -147,9 +146,9 @@ let rec typ_debug_print fmt typ =
       print "poly [%a] %a"
         (print_list typ_debug_print)
         typs typ_debug_print typ
-  | Tarrow (typ1, typ2) ->
+  | Tarrow (typ1, typ2, Explicit) ->
       print "%a -> %a" typ_debug_print typ1 typ_debug_print typ2
-  | Timplicit (typ1, typ2) ->
+  | Tarrow (typ1, typ2, Implicit) ->
       print "{%a} -> %a" typ_debug_print typ1 typ_debug_print typ2
   | Tctor {var_ident= name; var_params= params; _} ->
       print "%a (%a)" Longident.pp name.txt (print_list typ_debug_print) params

--- a/meja/parsetypes.ml
+++ b/meja/parsetypes.ml
@@ -111,7 +111,7 @@ and expression_desc =
   | Match of expression * (pattern * expression) list
   | Record of (lid * expression) list * expression option
   | Ctor of lid * expression option
-  | Unifiable of {mutable name: str}
+  | Unifiable of {mutable expression: expression}
 
 type statement = {stmt_desc: statement_desc; stmt_loc: Location.t}
 

--- a/meja/parsetypes.ml
+++ b/meja/parsetypes.ml
@@ -140,6 +140,8 @@ let rec typ_debug_print fmt typ =
         typs typ_debug_print typ
   | Tarrow (typ1, typ2) ->
       print "%a -> %a" typ_debug_print typ1 typ_debug_print typ2
+  | Timplicit (typ1, typ2) ->
+      print "{%a} -> %a" typ_debug_print typ1 typ_debug_print typ2
   | Tctor {var_ident= name; var_params= params; _} ->
       print "%a (%a)" Longident.pp name.txt (print_list typ_debug_print) params
   | Ttuple typs -> print "(%a)" (print_list typ_debug_print) typs ) ;

--- a/meja/tests/implicits-fail.meja
+++ b/meja/tests/implicits-fail.meja
@@ -1,0 +1,1 @@
+let (i, j) = (testing_show (18), testing_show (true));

--- a/meja/tests/implicits-fail.meja
+++ b/meja/tests/implicits-fail.meja
@@ -1,1 +1,5 @@
-let (i, j) = (testing_show (18), testing_show (true));
+type showable('a) = {show : 'a -> string};
+
+let show = fun {{show}} => { show; };
+
+let (i, j) = (show (18), show (true));

--- a/meja/tests/implicits-fail.stderr
+++ b/meja/tests/implicits-fail.stderr
@@ -1,0 +1,3 @@
+File "tests/implicits-fail.meja", line 1, characters 14-52:
+Error: Could not find an instance for an implicit variable of type int
+                                                                    testing_show_constr.

--- a/meja/tests/implicits-fail.stderr
+++ b/meja/tests/implicits-fail.stderr
@@ -1,3 +1,3 @@
-File "tests/implicits-fail.meja", line 1, characters 14-52:
+File "tests/implicits-fail.meja", line 5, characters 14-36:
 Error: Could not find an instance for an implicit variable of type int
-                                                                    testing_show_constr.
+                                                                    showable.

--- a/meja/tests/implicits.meja
+++ b/meja/tests/implicits.meja
@@ -1,15 +1,19 @@
+type showable('a) = {show : 'a -> string};
+
+let show = fun {{show}} => { show; };
+
 let f = fun (x : 'a) => {
-  let f = fun (x) => { testing_show (x); };
+  let f = fun (x) => { show (x); };
   f (x);
 };
 
 let g = fun (x : 'a, y : 'a) => {
-  let a = testing_show (x);
-  let b = testing_show (y);
-  let c = testing_show (15);
-  let d = testing_show (18);
-  let e = testing_show (true);
-  let f = testing_show (false);
+  let a = show (x);
+  let b = show (y);
+  let c = show (15);
+  let d = show (18);
+  let e = show (true);
+  let f = show (false);
   (a, b, c, d, e, f);
 };
 
@@ -21,14 +25,26 @@ type conv ('a, 'b) = {conv: 'a -> 'b};
 
 let conv = fun {{conv}} => { conv; };
 
-instance conv_bool_int = {conv: fun (x) => {switch (x) { | true => 1 | false => 0 };}};
+instance conv_bool_int =
+  {conv: fun (x) => {
+      switch (x) {
+        | true => 1
+        | false => 0
+      };
+    }};
 
 let i = fun (b : bool, f : int -> 'a) => {
   f (conv (b));
 };
 
 module T = {
-  instance conv_int_bool = {conv: fun (x) => {switch (x) { | 0 => false | _ => true };}};
+  instance conv_int_bool =
+    {conv: fun (x) => {
+        switch (x) {
+          | 0 => false
+          | _ => true
+        };
+      }};
 };
 
 let j = fun (i : int, f : bool -> 'a) => {
@@ -39,7 +55,7 @@ type equiv ('a, 'b) = Equiv('a -> 'b, 'b -> 'a);
 
 instance equiv_eq = Equiv(fun (x) => {x;}, fun (x) => {x;});
 
-instance conv_equiv = fun {Equiv(conv, _)} => {{conv};};
+instance conv_equiv = fun {Equiv(conv, _)} => { {conv}; };
 
 let k = fun (i : int, f : 'a -> 'a -> 'a) => {
   f (i, conv(i));

--- a/meja/tests/implicits.meja
+++ b/meja/tests/implicits.meja
@@ -16,3 +16,31 @@ let g = fun (x : 'a, y : 'a) => {
 let h = fun (x : int, y : bool, z : float) => {
   (g (x, x), g (y, y), g (z, z));
 };
+
+type conv ('a, 'b) = {conv: 'a -> 'b};
+
+let conv = fun {{conv}} => { conv; };
+
+instance conv_bool_int = {conv: fun (x) => {switch (x) { | true => 1 | false => 0 };}};
+
+let i = fun (b : bool, f : int -> 'a) => {
+  f (conv (b));
+};
+
+module T = {
+  instance conv_int_bool = {conv: fun (x) => {switch (x) { | 0 => false | _ => true };}};
+};
+
+let j = fun (i : int, f : bool -> 'a) => {
+  f (conv (i));
+};
+
+type equiv ('a, 'b) = Equiv('a -> 'b, 'b -> 'a);
+
+instance equiv_eq = Equiv(fun (x) => {x;}, fun (x) => {x;});
+
+instance conv_equiv = fun {Equiv(conv, _)} => {{conv};};
+
+let k = fun (i : int, f : 'a -> 'a -> 'a) => {
+  f (i, conv(i));
+};

--- a/meja/tests/implicits.meja
+++ b/meja/tests/implicits.meja
@@ -1,9 +1,9 @@
-let x = fun (x : 'a) => {
+let f = fun (x : 'a) => {
   let f = fun (x) => { testing_show (x); };
   f (x);
 };
 
-let y = fun (x : 'a, y : 'a) => {
+let g = fun (x : 'a, y : 'a) => {
   let a = testing_show (x);
   let b = testing_show (y);
   let c = testing_show (15);
@@ -11,4 +11,8 @@ let y = fun (x : 'a, y : 'a) => {
   let e = testing_show (true);
   let f = testing_show (false);
   (a, b, c, d, e, f);
+};
+
+let h = fun (x : int, y : bool, z : float) => {
+  (g (x, x), g (y, y), g (z, z));
 };

--- a/meja/tests/implicits.ml
+++ b/meja/tests/implicits.ml
@@ -1,14 +1,18 @@
+type 'a showable = {show: 'a -> string}
+
+let show {show; _} = show
+
 let f __implicit2__ (x : 'a) =
-  let f __implicit1__ x = (testing_show __implicit1__) x in
+  let f __implicit1__ x = (show __implicit1__) x in
   (f __implicit2__) x
 
 let g __implicit7__ __implicit5__ __implicit3__ (x : 'a) (y : 'a) =
-  let a = (testing_show __implicit3__) x in
-  let b = (testing_show __implicit3__) y in
-  let c = (testing_show __implicit5__) 15 in
-  let d = (testing_show __implicit5__) 18 in
-  let e = (testing_show __implicit7__) true in
-  let f = (testing_show __implicit7__) false in
+  let a = (show __implicit3__) x in
+  let b = (show __implicit3__) y in
+  let c = (show __implicit5__) 15 in
+  let d = (show __implicit5__) 18 in
+  let e = (show __implicit7__) true in
+  let f = (show __implicit7__) false in
   (a, b, c, d, e, f)
 
 let h __implicit15__ __implicit11__ __implicit9__ (x : int) (y : bool)

--- a/meja/tests/implicits.ml
+++ b/meja/tests/implicits.ml
@@ -11,8 +11,8 @@ let g __implicit7__ __implicit5__ __implicit3__ (x : 'a) (y : 'a) =
   let f = (testing_show __implicit7__) false in
   (a, b, c, d, e, f)
 
-let h __implicit17__ __implicit14__ __implicit10__ (x : int) (y : bool)
+let h __implicit15__ __implicit14__ __implicit9__ (x : int) (y : bool)
     (z : float) =
-  ( (g __implicit14__ __implicit10__ __implicit10__) x x
-  , (g __implicit14__ __implicit10__ __implicit14__) y y
-  , (g __implicit14__ __implicit10__ __implicit17__) z z )
+  ( (g __implicit14__ __implicit9__ __implicit9__) x x
+  , (g __implicit14__ __implicit9__ __implicit14__) y y
+  , (g __implicit14__ __implicit9__ __implicit15__) z z )

--- a/meja/tests/implicits.ml
+++ b/meja/tests/implicits.ml
@@ -16,3 +16,25 @@ let h __implicit15__ __implicit11__ __implicit9__ (x : int) (y : bool)
   ( (g __implicit11__ __implicit9__ __implicit9__) x x
   , (g __implicit11__ __implicit9__ __implicit11__) y y
   , (g __implicit11__ __implicit9__ __implicit15__) z z )
+
+type ('a, 'b) conv = {conv: 'a -> 'b}
+
+let conv {conv; _} = conv
+
+let conv_bool_int = {conv= (fun x -> match x with true -> 1 | false -> 0)}
+
+let i (b : bool) (f : int -> 'a) = f ((conv conv_bool_int) b)
+
+module T = struct
+  let conv_int_bool = {conv= (fun x -> match x with 0 -> false | _ -> true)}
+end
+
+let j (i : int) (f : bool -> 'a) = f ((conv T.conv_int_bool) i)
+
+type ('a, 'b) equiv = Equiv of ('a -> 'b) * ('b -> 'a)
+
+let equiv_eq = Equiv ((fun x -> x), fun x -> x)
+
+let conv_equiv (Equiv (conv, _)) = {conv}
+
+let k (i : int) (f : 'a -> 'a -> 'a) = f i ((conv (conv_equiv equiv_eq)) i)

--- a/meja/tests/implicits.ml
+++ b/meja/tests/implicits.ml
@@ -1,8 +1,8 @@
-let x __implicit2__ (x : 'a) =
+let f __implicit2__ (x : 'a) =
   let f __implicit1__ x = (testing_show __implicit1__) x in
   (f __implicit2__) x
 
-let y __implicit3__ (x : 'a) (y : 'a) =
+let g __implicit3__ (x : 'a) (y : 'a) =
   let a = (testing_show __implicit3__) x in
   let b = (testing_show __implicit3__) y in
   let c = (testing_show __implicit5__) 15 in
@@ -10,3 +10,6 @@ let y __implicit3__ (x : 'a) (y : 'a) =
   let e = (testing_show __implicit7__) true in
   let f = (testing_show __implicit7__) false in
   (a, b, c, d, e, f)
+
+let h (x : int) (y : bool) (z : float) =
+  ((g __implicit5__) x x, (g __implicit7__) y y, (g __implicit11__) z z)

--- a/meja/tests/implicits.ml
+++ b/meja/tests/implicits.ml
@@ -11,8 +11,8 @@ let g __implicit7__ __implicit5__ __implicit3__ (x : 'a) (y : 'a) =
   let f = (testing_show __implicit7__) false in
   (a, b, c, d, e, f)
 
-let h __implicit15__ __implicit14__ __implicit9__ (x : int) (y : bool)
+let h __implicit15__ __implicit11__ __implicit9__ (x : int) (y : bool)
     (z : float) =
-  ( (g __implicit14__ __implicit9__ __implicit9__) x x
-  , (g __implicit14__ __implicit9__ __implicit14__) y y
-  , (g __implicit14__ __implicit9__ __implicit15__) z z )
+  ( (g __implicit11__ __implicit9__ __implicit9__) x x
+  , (g __implicit11__ __implicit9__ __implicit11__) y y
+  , (g __implicit11__ __implicit9__ __implicit15__) z z )

--- a/meja/tests/implicits.ml
+++ b/meja/tests/implicits.ml
@@ -2,7 +2,7 @@ let f __implicit2__ (x : 'a) =
   let f __implicit1__ x = (testing_show __implicit1__) x in
   (f __implicit2__) x
 
-let g __implicit3__ (x : 'a) (y : 'a) =
+let g __implicit7__ __implicit5__ __implicit3__ (x : 'a) (y : 'a) =
   let a = (testing_show __implicit3__) x in
   let b = (testing_show __implicit3__) y in
   let c = (testing_show __implicit5__) 15 in
@@ -11,5 +11,8 @@ let g __implicit3__ (x : 'a) (y : 'a) =
   let f = (testing_show __implicit7__) false in
   (a, b, c, d, e, f)
 
-let h (x : int) (y : bool) (z : float) =
-  ((g __implicit5__) x x, (g __implicit7__) y y, (g __implicit11__) z z)
+let h __implicit17__ __implicit14__ __implicit10__ (x : int) (y : bool)
+    (z : float) =
+  ( (g __implicit14__ __implicit10__ __implicit10__) x x
+  , (g __implicit14__ __implicit10__ __implicit14__) y y
+  , (g __implicit14__ __implicit10__ __implicit17__) z z )

--- a/meja/tests/test_implicits.meja
+++ b/meja/tests/test_implicits.meja
@@ -1,0 +1,14 @@
+let x = fun (x : 'a) => {
+  let f = fun (x) => { testing_show (x); };
+  f (x);
+};
+
+let y = fun (x : 'a, y : 'a) => {
+  let a = testing_show (x);
+  let b = testing_show (y);
+  let c = testing_show (15);
+  let d = testing_show (18);
+  let e = testing_show (true);
+  let f = testing_show (false);
+  (a, b, c, d, e, f);
+};

--- a/meja/tests/test_implicits.ml
+++ b/meja/tests/test_implicits.ml
@@ -2,11 +2,11 @@ let x __implicit2__ (x : 'a) =
   let f __implicit1__ x = (testing_show __implicit1__) x in
   (f __implicit2__) x
 
-let y __implicit11__ __implicit9__ __implicit3__ (x : 'a) (y : 'a) =
+let y __implicit3__ (x : 'a) (y : 'a) =
   let a = (testing_show __implicit3__) x in
   let b = (testing_show __implicit3__) y in
-  let c __implicit5__ = (testing_show __implicit5__) 15 in
-  let d __implicit6__ = (testing_show __implicit6__) 18 in
-  let e __implicit7__ = (testing_show __implicit7__) true in
-  let f __implicit8__ = (testing_show __implicit8__) false in
-  (a, b, c __implicit9__, d __implicit9__, e __implicit11__, f __implicit11__)
+  let c = (testing_show __implicit5__) 15 in
+  let d = (testing_show __implicit5__) 18 in
+  let e = (testing_show __implicit7__) true in
+  let f = (testing_show __implicit7__) false in
+  (a, b, c, d, e, f)

--- a/meja/tests/test_implicits.ml
+++ b/meja/tests/test_implicits.ml
@@ -1,0 +1,12 @@
+let x __implicit2__ (x : 'a) =
+  let f __implicit1__ x = (testing_show __implicit1__) x in
+  (f __implicit2__) x
+
+let y __implicit11__ __implicit9__ __implicit3__ (x : 'a) (y : 'a) =
+  let a = (testing_show __implicit3__) x in
+  let b = (testing_show __implicit3__) y in
+  let c __implicit5__ = (testing_show __implicit5__) 15 in
+  let d __implicit6__ = (testing_show __implicit6__) 18 in
+  let e __implicit7__ = (testing_show __implicit7__) true in
+  let f __implicit8__ = (testing_show __implicit8__) false in
+  (a, b, c __implicit9__, d __implicit9__, e __implicit11__, f __implicit11__)

--- a/meja/to_ocaml.ml
+++ b/meja/to_ocaml.ml
@@ -8,7 +8,7 @@ let rec of_type_desc ?loc typ =
   | Tvar (None, _) -> Typ.any ?loc ()
   | Tvar (Some name, _) -> Typ.var ?loc name.txt
   | Tpoly (_, typ) -> of_type_expr typ
-  | Tarrow (typ1, typ2) ->
+  | Tarrow (typ1, typ2) | Timplicit (typ1, typ2) ->
       Typ.arrow ?loc Nolabel (of_type_expr typ1) (of_type_expr typ2)
   | Tctor {var_ident= name; var_params= params; _} ->
       Typ.constr ?loc name (List.map ~f:of_type_expr params)
@@ -87,6 +87,7 @@ let rec of_expression_desc ?loc = function
         (Option.map ~f:of_expression ext)
   | Ctor (name, arg) ->
       Exp.construct ?loc name (Option.map ~f:of_expression arg)
+  | Unifiable {name} -> Exp.ident ?loc (mk_lid name)
 
 and of_expression exp = of_expression_desc ~loc:exp.exp_loc exp.exp_desc
 

--- a/meja/to_ocaml.ml
+++ b/meja/to_ocaml.ml
@@ -67,7 +67,7 @@ let rec of_expression_desc ?loc = function
         (List.map ~f:(fun x -> (Nolabel, of_expression x)) es)
   | Variable name -> Exp.ident ?loc name
   | Int i -> Exp.constant ?loc (Const.int i)
-  | Fun (p, body) ->
+  | Fun (p, body, _) ->
       Exp.fun_ ?loc Nolabel None (of_pattern p) (of_expression body)
   | Constraint (e, typ) ->
       Exp.constraint_ ?loc (of_expression e) (of_type_expr typ)
@@ -95,6 +95,8 @@ and of_expression exp = of_expression_desc ~loc:exp.exp_loc exp.exp_desc
 let rec of_statement_desc ?loc = function
   | Value (p, e) ->
       Str.value ?loc Nonrecursive [Vb.mk (of_pattern p) (of_expression e)]
+  | Instance (name, e) ->
+      Str.value ?loc Nonrecursive [Vb.mk (Pat.var ?loc name) (of_expression e)]
   | TypeDecl decl -> Str.type_ ?loc Recursive [of_type_decl decl]
   | Module (name, m) -> Str.module_ ?loc (Mb.mk ?loc name (of_module_expr m))
   | Open name -> Str.open_ ?loc (Opn.mk ?loc name)

--- a/meja/to_ocaml.ml
+++ b/meja/to_ocaml.ml
@@ -8,7 +8,7 @@ let rec of_type_desc ?loc typ =
   | Tvar (None, _) -> Typ.any ?loc ()
   | Tvar (Some name, _) -> Typ.var ?loc name.txt
   | Tpoly (_, typ) -> of_type_expr typ
-  | Tarrow (typ1, typ2) | Timplicit (typ1, typ2) ->
+  | Tarrow (typ1, typ2, _) ->
       Typ.arrow ?loc Nolabel (of_type_expr typ1) (of_type_expr typ2)
   | Tctor {var_ident= name; var_params= params; _} ->
       Typ.constr ?loc name (List.map ~f:of_type_expr params)

--- a/meja/to_ocaml.ml
+++ b/meja/to_ocaml.ml
@@ -87,7 +87,8 @@ let rec of_expression_desc ?loc = function
         (Option.map ~f:of_expression ext)
   | Ctor (name, arg) ->
       Exp.construct ?loc name (Option.map ~f:of_expression arg)
-  | Unifiable {expression} -> of_expression expression
+  | Unifiable {expression= Some e; _} -> of_expression e
+  | Unifiable {name; _} -> Exp.ident ?loc (mk_lid name)
 
 and of_expression exp = of_expression_desc ~loc:exp.exp_loc exp.exp_desc
 

--- a/meja/to_ocaml.ml
+++ b/meja/to_ocaml.ml
@@ -87,7 +87,7 @@ let rec of_expression_desc ?loc = function
         (Option.map ~f:of_expression ext)
   | Ctor (name, arg) ->
       Exp.construct ?loc name (Option.map ~f:of_expression arg)
-  | Unifiable {name} -> Exp.ident ?loc (mk_lid name)
+  | Unifiable {expression} -> of_expression expression
 
 and of_expression exp = of_expression_desc ~loc:exp.exp_loc exp.exp_desc
 

--- a/meja/typechecker.ml
+++ b/meja/typechecker.ml
@@ -13,6 +13,7 @@ type error =
   | Wrong_type_description of string * str
   | Unifiable_expr
   | No_unifiable_expr
+  | No_instance of type_expr
 
 exception Error of Location.t * error
 
@@ -138,7 +139,9 @@ let rec free_type_vars ?depth typ =
 let polymorphise typ env =
   let loc = typ.type_loc in
   let typ_vars = Set.to_list (free_type_vars ~depth:env.Envi.depth typ) in
-  Envi.Type.mk ~loc (Tpoly (typ_vars, typ)) env
+  match typ_vars with
+  | [] -> (typ, env)
+  | _ -> Envi.Type.mk ~loc (Tpoly (typ_vars, typ)) env
 
 let add_polymorphised name typ env =
   let typ, env = Envi.Type.flatten typ env in
@@ -440,35 +443,38 @@ let rec get_expression env exp =
 
 and check_binding ?(toplevel = false) (env : Envi.t) p e : 's =
   let e, env = get_expression env e in
-  match p.pat_desc with
-  | PVariable str ->
-      let exp_type, env = Envi.Type.flatten e.exp_type env in
-      let e = {e with exp_type} in
-      let typ_vars = free_type_vars ~depth:env.Envi.depth exp_type in
-      let implicit_vars, env =
-        Envi.Type.flattened_implicit_vars ~toplevel typ_vars env
-      in
-      let loc = e.exp_loc in
-      let e, env =
-        List.fold ~init:(e, env) implicit_vars ~f:(fun (e, env) var ->
-            match var.exp_desc with
-            | Unifiable {expression= None; name; _} ->
-                let exp_type, env =
-                  Envi.Type.mk ~loc (Timplicit (var.exp_type, e.exp_type)) env
-                in
-                let p = {pat_desc= PVariable name; pat_loc= loc} in
-                ({exp_desc= Fun (p, e); exp_type; exp_loc= loc}, env)
-            | _ -> raise (Error (var.exp_loc, No_unifiable_expr)) )
-      in
-      let loc = p.pat_loc in
+  let exp_type, env = Envi.Type.flatten e.exp_type env in
+  let e = {e with exp_type} in
+  let typ_vars = free_type_vars ~depth:env.Envi.depth exp_type in
+  let implicit_vars, env =
+    Envi.Type.flattened_implicit_vars ~toplevel typ_vars env
+  in
+  let loc = e.exp_loc in
+  let e, env =
+    List.fold ~init:(e, env) implicit_vars ~f:(fun (e, env) var ->
+        match var.exp_desc with
+        | Unifiable {expression= None; name; _} ->
+            let exp_type, env =
+              Envi.Type.mk ~loc (Timplicit (var.exp_type, e.exp_type)) env
+            in
+            let p = {pat_desc= PVariable name; pat_loc= loc} in
+            ({exp_desc= Fun (p, e); exp_type; exp_loc= loc}, env)
+        | _ -> raise (Error (var.exp_loc, No_unifiable_expr)) )
+  in
+  let loc = p.pat_loc in
+  match (p.pat_desc, implicit_vars) with
+  | PVariable str, _ ->
       let typ, env =
-        Envi.Type.mk ~loc (Tpoly (Set.to_list typ_vars, e.exp_type)) env
+        if Set.is_empty typ_vars then (e.exp_type, env)
+        else Envi.Type.mk ~loc (Tpoly (Set.to_list typ_vars, e.exp_type)) env
       in
       let env = Envi.add_name str typ env in
       (p, e, env)
-  | _ ->
+  | _, [] ->
       let env = check_pattern ~add:add_polymorphised env e.exp_type p in
       (p, e, env)
+  | _, implicit :: _ ->
+      raise (Error (e.exp_loc, No_instance implicit.exp_type))
 
 let rec check_statement env stmt =
   let loc = stmt.stmt_loc in
@@ -535,8 +541,13 @@ let rec report_error ppf = function
          got %s"
         kind name.txt
   | Unifiable_expr ->
-      fprintf ppf "Internal error: Unexpected an unresolved implicit variable."
-  | No_unifiable_expr -> fprintf ppf "Internal error: Expected a Unifiable."
+      fprintf ppf "Internal error: Unexpected implicit variable."
+  | No_unifiable_expr ->
+      fprintf ppf "Internal error: Expected an unresolved implicit variable."
+  | No_instance typ ->
+      fprintf ppf
+        "Could not find an instance for an implicit variable of type @[%a@]."
+        pp_typ typ
 
 let () =
   Location.register_error_of_exn (function

--- a/meja/typechecker.ml
+++ b/meja/typechecker.ml
@@ -279,6 +279,7 @@ let rec check_pattern_desc ~loc ~add env typ = function
             raise (Error (loc, Pattern_declaration ("constructor", name))) )
           ~modules:(fun ~key:name ~data:_ _ ->
             raise (Error (loc, Pattern_declaration ("module", name))) )
+          ~instances:(fun ~key:_ ~data:_ env -> env)
       in
       Envi.push_scope scope2 env
   | PInt _ -> check_type env typ Envi.Core.Type.int
@@ -447,7 +448,7 @@ and check_binding ?(toplevel = false) (env : Envi.t) p e : 's =
   let e = {e with exp_type} in
   let typ_vars = free_type_vars ~depth:env.Envi.depth exp_type in
   let implicit_vars, env =
-    Envi.Type.flattened_implicit_vars ~toplevel typ_vars env
+    Envi.Type.flattened_implicit_vars ~toplevel ~unify:check_type typ_vars env
   in
   let loc = e.exp_loc in
   let e, env =

--- a/meja/typechecker.ml
+++ b/meja/typechecker.ml
@@ -471,7 +471,12 @@ and check_binding ?(toplevel = false) (env : Envi.t) p e : 's =
       let e, env =
         List.fold ~init:(e, env) implicit_vars ~f:(fun (e, env) var ->
             match var with
-            | {exp_desc= Unifiable {name}; exp_type= typ; _} ->
+            | { exp_desc=
+                  Unifiable
+                    { expression=
+                        {exp_desc= Variable {txt= Lident name; loc}; _} }
+              ; exp_type= typ; _ } ->
+                let name = Location.mkloc name loc in
                 let exp_type, env =
                   Envi.Type.mk ~loc (Timplicit (typ, e.exp_type)) env
                 in

--- a/meja/typechecker.ml
+++ b/meja/typechecker.ml
@@ -457,7 +457,7 @@ let rec get_expression env exp =
       ({exp_loc= loc; exp_type= typ; exp_desc= Ctor (name, arg)}, env)
   | Unifiable _ -> raise (Error (loc, Unifiable_expr))
 
-and check_binding (env : Envi.t) p e : 's =
+and check_binding ?(toplevel = false) (env : Envi.t) p e : 's =
   let e, env = get_expression env e in
   match p.pat_desc with
   | PVariable str ->
@@ -465,7 +465,7 @@ and check_binding (env : Envi.t) p e : 's =
       let e = {e with exp_type} in
       let typ_vars = free_type_vars ~depth:env.Envi.depth exp_type in
       let implicit_vars, env =
-        Envi.Type.flattened_implicit_vars typ_vars env
+        Envi.Type.flattened_implicit_vars ~toplevel typ_vars env
       in
       let loc = e.exp_loc in
       let e, env =
@@ -493,7 +493,7 @@ let rec check_statement env stmt =
   let loc = stmt.stmt_loc in
   match stmt.stmt_desc with
   | Value (p, e) ->
-      let p, e, env = check_binding env p e in
+      let p, e, env = check_binding ~toplevel:true env p e in
       (env, {stmt with stmt_desc= Value (p, e)})
   | TypeDecl decl ->
       let decl, env = Envi.TypeDecl.import decl env in

--- a/meja/typechecker.ml
+++ b/meja/typechecker.ml
@@ -82,8 +82,8 @@ let rec check_type_aux typ ctyp env =
     | Ok env -> env
     | Unequal_lengths ->
         raise (Error (ctyp.type_loc, Cannot_unify (typ, ctyp))) )
-  | Tarrow (typ1, typ2), Tarrow (ctyp1, ctyp2)
-   |Timplicit (typ1, typ2), Timplicit (ctyp1, ctyp2) ->
+  | Tarrow (typ1, typ2, Explicit), Tarrow (ctyp1, ctyp2, Explicit)
+   |Tarrow (typ1, typ2, Implicit), Tarrow (ctyp1, ctyp2, Implicit) ->
       env |> check_type_aux typ1 ctyp1 |> check_type_aux typ2 ctyp2
   | Tctor variant, Tctor constr_variant ->
       if Int.equal variant.var_decl_id constr_variant.var_decl_id then
@@ -115,7 +115,7 @@ let rec add_implicits ~loc implicits typ env =
   | [] -> (typ, env)
   | typ' :: implicits ->
       let typ, env = add_implicits ~loc implicits typ env in
-      Envi.Type.mk ~loc (Timplicit (typ', typ)) env
+      Envi.Type.mk ~loc (Tarrow (typ', typ, Implicit)) env
 
 let rec free_type_vars ?depth typ =
   let free_type_vars = free_type_vars ?depth in
@@ -133,7 +133,7 @@ let rec free_type_vars ?depth typ =
       Set.union_list (module Envi.Type) (List.map ~f:free_type_vars var_params)
   | Ttuple typs ->
       Set.union_list (module Envi.Type) (List.map ~f:free_type_vars typs)
-  | Tarrow (typ1, typ2) | Timplicit (typ1, typ2) ->
+  | Tarrow (typ1, typ2, _) ->
       Set.union (Envi.Type.type_vars ?depth typ1) (free_type_vars typ2)
 
 let polymorphise typ env =
@@ -168,7 +168,9 @@ let get_field (field : lid) env =
         Envi.TypeDecl.mk_typ ~loc ~params:vars ~ident:name decl env
       in
       let {fld_type; _} = List.nth_exn field_decls i in
-      let typ, env = Envi.Type.mk ~loc (Tarrow (rcd_type, fld_type)) env in
+      let typ, env =
+        Envi.Type.mk ~loc (Tarrow (rcd_type, fld_type, Explicit)) env
+      in
       Envi.Type.copy typ bound_vars env
   | _ -> raise (Error (loc, Unbound ("record field", field)))
 
@@ -180,7 +182,9 @@ let get_field_of_decl typ bound_vars field_decls (field : lid) env =
           String.equal fld_ident.txt name )
     with
     | Some {fld_type; _} ->
-        let typ, env = Envi.Type.mk ~loc (Tarrow (typ, fld_type)) env in
+        let typ, env =
+          Envi.Type.mk ~loc (Tarrow (typ, fld_type, Explicit)) env
+        in
         Envi.Type.copy typ bound_vars env
     | None -> get_field field env )
   | _ -> get_field field env
@@ -219,7 +223,9 @@ let get_ctor (name : lid) env =
         | Ctor_tuple [typ] -> (typ, env)
         | Ctor_tuple typs -> Envi.Type.mk ~loc (Ttuple typs) env
       in
-      let typ, env = Envi.Type.mk ~loc (Tarrow (args_typ, typ)) env in
+      let typ, env =
+        Envi.Type.mk ~loc (Tarrow (args_typ, typ, Explicit)) env
+      in
       let _, bound_vars, env =
         Envi.Type.refresh_vars params (Map.empty (module Int)) env
       in
@@ -296,7 +302,9 @@ let rec check_pattern_desc ~loc ~add env typ = function
       List.fold ~init:env fields ~f:(fun env (field, p) ->
           let loc = {field.loc with Location.loc_end= p.pat_loc.loc_end} in
           let typ', env = Envi.Type.mkvar ~loc None env in
-          let arrow_type, env = Envi.Type.mk ~loc (Tarrow (typ, typ')) env in
+          let arrow_type, env =
+            Envi.Type.mk ~loc (Tarrow (typ, typ', Explicit)) env
+          in
           let field_typ, env =
             match field_decls with
             | Some (field_decls, bound_vars) ->
@@ -311,7 +319,9 @@ let rec check_pattern_desc ~loc ~add env typ = function
         if Option.is_some arg then Envi.Type.mkvar ~loc None env
         else Envi.Type.mk ~loc (Ttuple []) env
       in
-      let arrow_typ, env = Envi.Type.mk ~loc (Tarrow (arg_typ, typ)) env in
+      let arrow_typ, env =
+        Envi.Type.mk ~loc (Tarrow (arg_typ, typ, Explicit)) env
+      in
       let ctor_typ, env = get_ctor name env in
       let ctor_typ = {ctor_typ with type_loc= name.loc} in
       let env = check_type env arrow_typ ctor_typ in
@@ -332,7 +342,7 @@ let rec get_expression env exp =
             let e, env = get_expression env e in
             let retvar, env = Envi.Type.mkvar ~loc None env in
             let arrow, env =
-              Envi.Type.mk ~loc (Tarrow (e.exp_type, retvar)) env
+              Envi.Type.mk ~loc (Tarrow (e.exp_type, retvar, Explicit)) env
             in
             let env = check_type env f_typ arrow in
             ((retvar, env), e) )
@@ -353,12 +363,9 @@ let rec get_expression env exp =
       let env = check_pattern ~add:Envi.add_name env p_typ p in
       let body, env = get_expression env body in
       let env = Envi.close_expr_scope env in
-      let typ_desc =
-        match explicit with
-        | Explicit -> Tarrow (p_typ, body.exp_type)
-        | Implicit -> Timplicit (p_typ, body.exp_type)
+      let typ, env =
+        Envi.Type.mk ~loc (Tarrow (p_typ, body.exp_type, explicit)) env
       in
-      let typ, env = Envi.Type.mk ~loc typ_desc env in
       ({exp_loc= loc; exp_type= typ; exp_desc= Fun (p, body, explicit)}, env)
   | Seq (e1, e2) ->
       let e1, env = get_expression env e1 in
@@ -422,7 +429,7 @@ let rec get_expression env exp =
             let loc = {field.loc with Location.loc_end= e.exp_loc.loc_end} in
             let e, env = get_expression env e in
             let arrow_type, env =
-              Envi.Type.mk ~loc (Tarrow (typ, e.exp_type)) env
+              Envi.Type.mk ~loc (Tarrow (typ, e.exp_type, Explicit)) env
             in
             let field_typ, env =
               match field_decls with
@@ -444,7 +451,9 @@ let rec get_expression env exp =
             (typ, None, env)
       in
       let typ, env = Envi.Type.mkvar ~loc None env in
-      let arrow_typ, env = Envi.Type.mk ~loc (Tarrow (arg_typ, typ)) env in
+      let arrow_typ, env =
+        Envi.Type.mk ~loc (Tarrow (arg_typ, typ, Explicit)) env
+      in
       let ctor_typ, env = get_ctor name env in
       let env = check_type env arrow_typ ctor_typ in
       ({exp_loc= loc; exp_type= typ; exp_desc= Ctor (name, arg)}, env)
@@ -464,7 +473,9 @@ and check_binding ?(toplevel = false) (env : Envi.t) p e : 's =
         match var.exp_desc with
         | Unifiable {expression= None; name; _} ->
             let exp_type, env =
-              Envi.Type.mk ~loc (Timplicit (var.exp_type, e.exp_type)) env
+              Envi.Type.mk ~loc
+                (Tarrow (var.exp_type, e.exp_type, Implicit))
+                env
             in
             let p = {pat_desc= PVariable name; pat_loc= loc} in
             ({exp_desc= Fun (p, e, Implicit); exp_type; exp_loc= loc}, env)

--- a/meja/typechecker.ml
+++ b/meja/typechecker.ml
@@ -220,7 +220,10 @@ let get_ctor (name : lid) env =
         | Ctor_tuple typs -> Envi.Type.mk ~loc (Ttuple typs) env
       in
       let typ, env = Envi.Type.mk ~loc (Tarrow (args_typ, typ)) env in
-      Envi.Type.copy typ (Map.empty (module Int)) env
+      let _, bound_vars, env =
+        Envi.Type.refresh_vars params (Map.empty (module Int)) env
+      in
+      Envi.Type.copy typ bound_vars env
   | _ -> raise (Error (loc, Unbound ("constructor", name)))
 
 let rec check_pattern_desc ~loc ~add env typ = function


### PR DESCRIPTION
This PR
- adds the `Timplicit` type for implicit arguments (analogous to `Tarrow`)
- adds the `Unifiable` expression to hold implicit arguments, so that we can unify them
  * this uses mutability, so that we don't have to do extra passes over the AST to update it when unifying these variables
- inserts implicit arguments into bindings when the type variables it introduces are contained in those arguments

There is currently no search implemented, so implicit arguments with no type variables (e.g. `testing_show (18) : {testing_show_constr(int)} -> int` in the examples) just get the argument passed through each scope for now.

This depends on #98; without it the test will fail.