### PR TITLE
Remove continuation trick

### DIFF
--- a/examples/election/election_main.ml
+++ b/examples/election/election_main.ml
@@ -39,4 +39,4 @@ let () =
     )
   in
   let commitments, winner, proof = tally_and_prove received_ballots in
-  assert (verify proof (Keypair.vk keypair) (exposed ()) commitments winner)
+  assert (verify proof (Keypair.vk keypair) (exposed ()) [commitments; winner])

--- a/examples/imperative_test/imperative_test.ml
+++ b/examples/imperative_test/imperative_test.ml
@@ -54,9 +54,9 @@ let prove () =
   let ((module I) as i) = make (module Backends.Mnt4.GM) in
   let open I in
   let exposing = Data_spec.[Field.typ] in
-  let f x () = test2 i x in
+  let f H_list.([x]) = test2 i x |> ignore in
   let keys = generate_keypair ~exposing f in
-  let proof = prove (Keypair.pk keys) exposing f (Field.Constant.of_int 17) in
+  let proof = prove (Keypair.pk keys) exposing f [Field.Constant.of_int 17] in
   (Proof.to_string proof, Verification_key.to_bigstring (Keypair.vk keys))
 
 let verify proof vk =
@@ -65,7 +65,7 @@ let verify proof vk =
   let exposing = Data_spec.[Field.typ] in
   let proof = Proof.of_string proof in
   let vk = Verification_key.of_bigstring vk in
-  verify proof vk exposing (Field.Constant.of_int 17)
+  verify proof vk exposing [Field.Constant.of_int 17]
 
 module Intf = Snark.Run.Make (Backends.Mnt4.GM)
 
@@ -73,16 +73,16 @@ let exposing = Intf.(Data_spec.[Field.typ])
 
 let prove2 () =
   let open Intf in
-  let f x () = test3 (module Intf) x in
+  let f H_list.([x]) = test3 (module Intf) x |> ignore in
   let keys = generate_keypair ~exposing f in
-  let proof = prove (Keypair.pk keys) exposing f (Field.Constant.of_int 39) in
+  let proof = prove (Keypair.pk keys) exposing f [Field.Constant.of_int 39] in
   (Proof.to_string proof, Verification_key.to_bigstring (Keypair.vk keys))
 
 let verify2 proof vk =
   let open Intf in
   let proof = Proof.of_string proof in
   let vk = Verification_key.of_bigstring vk in
-  verify proof vk exposing (Field.Constant.of_int 29)
+  verify proof vk exposing [Field.Constant.of_int 29]
 
 let main () =
   let proof, vk = prove () in

--- a/examples/merkle_update/merkle_update.ml
+++ b/examples/merkle_update/merkle_update.ml
@@ -122,7 +122,8 @@ let update_many root_start
 (* Now that we have specified the computation to produce a snark for, we can actually
    produce the snark. *)
 (* First we generate the keypair. *)
-let keypair = generate_keypair ~exposing:(input ()) update_many
+let keypair =
+  generate_keypair ~exposing:(input ()) (fun [a; us; b] -> update_many a us b)
 
 (* Next, we can generate a proof on some sample inputs. *)
 (* First the inputs. *)
@@ -154,12 +155,13 @@ let proof =
   prove (Keypair.pk keypair) (input ()) (* The input spec *)
                                         tree_start
     (* The initial state for the prover *)
-    update_many (* The computation to create a snark for *)
-                root_start (* The inputs for the snark *)
-                           updates root_end
+      (fun [a; us; b] -> update_many a us b)
+    (* The computation to create a snark for *)
+    (* The inputs for the snark *)
+    [root_start; updates; root_end]
 
 (* Now we can check that the snark verifies as expected. *)
 let verified =
-  verify proof (Keypair.vk keypair) (input ()) root_start updates root_end
+  verify proof (Keypair.vk keypair) (input ()) [root_start; updates; root_end]
 
 let () = printf "Verified: %b\n" verified

--- a/examples/tutorial/tutorial.ml
+++ b/examples/tutorial/tutorial.ml
@@ -100,18 +100,22 @@ let exercise1 () =
   let input () = Data_spec.[Field.typ] in
   (* Now we generate a keypair that we can use produce and verify proofs *)
   let keypair =
-    generate_keypair ~exposing:(input ()) assert_is_cube_root_of_1
+    generate_keypair ~exposing:(input ()) (fun [x] ->
+        assert_is_cube_root_of_1 x )
   in
   (* Now we prove: Here is an input to `assert_is_cube_root_of_1` such that the
      checked computation terminates without failing any assertions. In other
      words, there exists some cube_root_of_1.
    *)
   let proof =
-    prove (Keypair.pk keypair) (input ()) () assert_is_cube_root_of_1
-      cube_root_of_1
+    prove (Keypair.pk keypair) (input ()) ()
+      (fun [x] -> assert_is_cube_root_of_1 x)
+      [cube_root_of_1]
   in
   (* We can verify a proof as follows *)
-  let is_valid = verify proof (Keypair.vk keypair) (input ()) cube_root_of_1 in
+  let is_valid =
+    verify proof (Keypair.vk keypair) (input ()) [cube_root_of_1]
+  in
   printf !"is %{sexp:Field.t} a cube root of 1? %b\n%!" cube_root_of_1 is_valid
 
 (* Exercise 1: Comment this out when you're ready to test it! *)
@@ -248,14 +252,17 @@ module Exercise3 = struct
     let matrix = Typ.array ~length:2 cols in
     Data_spec.[matrix]
 
-  let keypair = generate_keypair ~exposing:(input ()) assert_exists_sqrt
+  let keypair =
+    generate_keypair ~exposing:(input ()) (fun [x] -> assert_exists_sqrt x)
 
   let mat_1245 = Field.[|[|of_int 1; of_int 2|]; [|of_int 4; of_int 5|]|]
 
   let proof =
-    prove (Keypair.pk keypair) (input ()) () assert_exists_sqrt mat_1245
+    prove (Keypair.pk keypair) (input ()) ()
+      (fun [x] -> assert_exists_sqrt x)
+      [mat_1245]
 
-  let is_valid = verify proof (Keypair.vk keypair) (input ()) mat_1245
+  let is_valid = verify proof (Keypair.vk keypair) (input ()) [mat_1245]
 
   let run () =
     printf "Is mat_1245 the sqrt of our 9;12 24;33 matrix: %b?" is_valid

--- a/src/curves.ml
+++ b/src/curves.ml
@@ -735,7 +735,7 @@ module Make_weierstrass_checked
       end
     end
 
-    let create (type shifted) () : ((module S), _) Checked.t =
+    let create () : ((module S), _) Checked.t =
       let%map shift =
         exists typ ~compute:As_prover.(map (return ()) ~f:Curve.random)
       in

--- a/src/h_list.ml
+++ b/src/h_list.ml
@@ -1,4 +1,2 @@
 (** Polymorphic list type. *)
-type (_, _) t =
-  | [] : ('r, 'r) t
-  | ( :: ) : 'a * ('r, 'k) t -> ('r, 'a -> 'k) t
+type _ t = [] : unit t | ( :: ) : 'a * 'xs t -> ('a * 'xs) t

--- a/src/types.ml
+++ b/src/types.ml
@@ -67,3 +67,11 @@ and Checked : sig
     | Next_auxiliary : (int -> ('a, 's, 'f) t) -> ('a, 's, 'f) t
 end =
   Checked
+
+module Data_spec = struct
+  type (_, _, _) t =
+    | [] : (unit, unit, 'f) t
+    | ( :: ) :
+        ('a, 'b, 'f) Typ.t * ('var, 'value, 'f) t
+        -> ('a * 'var, 'b * 'value, 'f) t
+end


### PR DESCRIPTION
This PR removes the use of continuation types in the data_spec gadt and uses h_list instead. There are definitely some downsides to this approach (namely one needs to say `H_list.` occasionally) but I think overall it has made the code simpler and make the implementation of the pretty top level api @mrmr1993 and I discussed easier.