### PR TITLE
Add field accessors

### DIFF
--- a/meja/lexer_impl.mll
+++ b/meja/lexer_impl.mll
@@ -55,6 +55,7 @@ rule token = parse
   | '_' { UNDERSCORE }
   | '|' { BAR }
   | ''' { QUOT }
+  | "..." { DOTDOTDOT }
   | '.' { DOT }
 
   | "!" symbolchar * as op { PREFIXOP op }

--- a/meja/parser_impl.mly
+++ b/meja/parser_impl.mly
@@ -39,6 +39,7 @@ let mkmod ~pos d = {mod_desc= d; mod_loc= mklocation pos}
 %token UNDERSCORE
 %token BAR
 %token QUOT
+%token DOTDOTDOT
 %token DOT
 %token <string> PREFIXOP
 %token <string> INFIXOP0
@@ -232,6 +233,8 @@ expr:
 expr_record:
   | LBRACE fields = list(expr_field, COMMA) RBRACE
     { mkexp ~pos:$loc (Record(List.rev fields, None)) }
+  | LBRACE DOTDOTDOT e = expr COMMA fields = list(expr_field, COMMA) RBRACE
+    { mkexp ~pos:$loc (Record(List.rev fields, Some e)) }
 
 expr_or_bare_tuple:
   | x = expr

--- a/meja/parsetypes.ml
+++ b/meja/parsetypes.ml
@@ -116,6 +116,7 @@ and expression_desc =
   | Constraint of expression * type_expr
   | Tuple of expression list
   | Match of expression * (pattern * expression) list
+  | Field of expression * lid
   | Record of (lid * expression) list * expression option
   | Ctor of lid * expression option
   | Unifiable of {mutable expression: expression option; name: str; id: int}

--- a/meja/tests/apply-fail.stderr
+++ b/meja/tests/apply-fail.stderr
@@ -1,4 +1,4 @@
-File "tests/apply-fail.meja", line 3, characters 2-7:
-Error: Incompatable types '_ -> _' and 'unit -> _':
+File "tests/apply-fail.meja", line 1, characters 33-37:
+Error: Incompatable types '_' and 'unit':
 Cannot unify 'int' and 'unit'.
 

--- a/meja/tests/record_wrong_accessor.meja
+++ b/meja/tests/record_wrong_accessor.meja
@@ -1,0 +1,9 @@
+type t('a, 'b, 'c) = {a : 'a, b : 'b, c : 'c};
+
+let x = {a: 15, b: 20, c: 25};
+
+module X = {
+  type t('a) = {a : 'a, b : 'a, c : 'a};
+};
+
+let y = x.X.a;

--- a/meja/tests/record_wrong_accessor.stderr
+++ b/meja/tests/record_wrong_accessor.stderr
@@ -1,0 +1,4 @@
+File "tests/record_wrong_accessor.meja", line 3, characters 8-29:
+Error: Incompatable types ''a X.t' and '(int, int, int) t':
+Cannot unify ''a X.t' and '(int, int, int) t'.
+

--- a/meja/tests/records.meja
+++ b/meja/tests/records.meja
@@ -1,0 +1,15 @@
+type t('a, 'b, 'c) = {a : 'a, b : 'b, c : 'c};
+
+let x = {a: 15, b: 20, c: 25};
+
+let y = {a: true, b: false, c: true};
+
+let z = {a: x.a, b: y.b, c: ()};
+
+module X = {
+  type t('a) = {a : 'a, b : 'a, c : 'a};
+
+  let x = {a: 1, b: 1, c: 1};
+};
+
+let b = {X.a: 1, b: 1, c: 1};

--- a/meja/tests/records.meja
+++ b/meja/tests/records.meja
@@ -21,3 +21,9 @@ let c = {...x, a: 35};
 let d = (a.b, b.b);
 
 let e = a.X.a;
+
+let f = {a: true, b: (), c: 15}.a;
+
+let g = {X.a: (), b: (), c: ()}.a;
+
+let h = {X.a: (), b: (), c: ()}.X.a;

--- a/meja/tests/records.meja
+++ b/meja/tests/records.meja
@@ -12,4 +12,12 @@ module X = {
   let x = {a: 1, b: 1, c: 1};
 };
 
+let a = {...X.x, b: 12};
+
 let b = {X.a: 1, b: 1, c: 1};
+
+let c = {...x, a: 35};
+
+let d = (a.b, b.b);
+
+let e = a.X.a;

--- a/meja/tests/records.ml
+++ b/meja/tests/records.ml
@@ -1,0 +1,15 @@
+type ('a, 'b, 'c) t = {a: 'a; b: 'b; c: 'c}
+
+let x = {a= 15; b= 20; c= 25}
+
+let y = {a= true; b= false; c= true}
+
+let z = {a= x.a; b= y.b; c= ()}
+
+module X = struct
+  type 'a t = {a: 'a; b: 'a; c: 'a}
+
+  let x = {a= 1; b= 1; c= 1}
+end
+
+let b = {X.a= 1; b= 1; c= 1}

--- a/meja/tests/records.ml
+++ b/meja/tests/records.ml
@@ -12,4 +12,12 @@ module X = struct
   let x = {a= 1; b= 1; c= 1}
 end
 
+let a = {X.x with b= 12}
+
 let b = {X.a= 1; b= 1; c= 1}
+
+let c = {x with a= 35}
+
+let d = (a.b, b.b)
+
+let e = a.X.a

--- a/meja/tests/records.ml
+++ b/meja/tests/records.ml
@@ -21,3 +21,9 @@ let c = {x with a= 35}
 let d = (a.b, b.b)
 
 let e = a.X.a
+
+let f = {a= true; b= (); c= 15}.a
+
+let g = {X.a= (); b= (); c= ()}.a
+
+let h = {X.a= (); b= (); c= ()}.X.a

--- a/meja/tests/test.meja
+++ b/meja/tests/test.meja
@@ -8,7 +8,10 @@ let a = (15);
 
 let b = (let y = x; y);
 
-let c = {x; y;};
+let c = fun (ignore : int -> unit) => {
+  ignore(x);
+  y;
+};
 
 let d = fun (x) => { x; };
 

--- a/meja/tests/test.ml
+++ b/meja/tests/test.ml
@@ -10,7 +10,7 @@ let b =
   let y = x in
   y
 
-let c = x ; y
+let c (ignore : int -> unit) = ignore x ; y
 
 let d x = x
 

--- a/meja/to_ocaml.ml
+++ b/meja/to_ocaml.ml
@@ -81,6 +81,7 @@ let rec of_expression_desc ?loc = function
       Exp.match_ ?loc (of_expression e)
         (List.map cases ~f:(fun (p, e) ->
              Exp.case (of_pattern p) (of_expression e) ))
+  | Field (e, field) -> Exp.field ?loc (of_expression e) field
   | Record (fields, ext) ->
       Exp.record ?loc
         (List.map fields ~f:(fun (f, e) -> (f, of_expression e)))

--- a/meja/typechecker.ml
+++ b/meja/typechecker.ml
@@ -443,52 +443,10 @@ let rec get_expression env expected exp =
       in
       ({exp_loc= loc; exp_type= expected; exp_desc= Match (e, cases)}, env)
   | Field (e, field) ->
-    let field_info =
-      match field.txt with
-      | Lident _ -> None
-      | Ldot (path, _) -> (
-        match Envi.TypeDecl.find_of_field field env with
-        | Some (({tdec_desc= TRecord field_decls; tdec_params; _} as decl), i)
-          ->
-            let vars, bound_vars, env =
-              Envi.Type.refresh_vars tdec_params (Map.empty (module Int)) env
-            in
-            let ident = Location.mkloc (Longident.Ldot (path, decl.tdec_ident.txt)) loc in
-            let decl_type, env =
-              Envi.TypeDecl.mk_typ ~loc ~params:vars ~ident decl env
-            in
-            let {fld_type; _} = List.nth_exn field_decls i in
-            let fld_type, env = Envi.Type.copy fld_type bound_vars env in
-            let env = check_type env expected fld_type in
-            Some (fld_type, decl_type, env)
-        | _ -> None)
-      | Lapply _ -> failwith "Unhandled Lapply in field name"
-    in
-    let (typ, decl_type, env, resolved) = match field_info with
-    | Some (fld_type, decl_type, env) -> (fld_type, decl_type, env, true)
-    | None ->
-      let fld_type = expected in
-      let decl_type, env = Envi.Type.mkvar ~loc None env in
-      (fld_type, decl_type, env, false)
-    in
-    let e, env = get_expression env decl_type e in
-    let typ, env =
-      if resolved then typ, env
-      else
-        match Envi.TypeDecl.find_unaliased_of_type e.exp_type env with
-        | Some ({tdec_desc= TRecord field_decls; _}, bound_vars, env) -> (
-            match List.find field_decls ~f:(fun {fld_ident; _} ->
-              match field.txt with
-              | Lident field -> String.equal fld_ident.txt field
-              | _ -> false (* This case shouldn't happen! *))
-            with
-            | Some {fld_type; _} ->
-              let fld_type, env = Envi.Type.copy fld_type bound_vars env in
-              let env = check_type env typ fld_type in
-              (fld_type, env)
-            | None -> raise (Error (loc, Wrong_record_field (field.txt, e.exp_type)))
-            )
-        | _ -> (
+      let field_info =
+        match field.txt with
+        | Lident _ -> None
+        | Ldot (path, _) -> (
           match Envi.TypeDecl.find_of_field field env with
           | Some (({tdec_desc= TRecord field_decls; tdec_params; _} as decl), i)
             ->
@@ -496,22 +454,74 @@ let rec get_expression env expected exp =
                 Envi.Type.refresh_vars tdec_params (Map.empty (module Int)) env
               in
               let ident =
-                Longident.(
-                  match field.txt with
-                  | Lident _ -> Location.mkloc (Lident decl.tdec_ident.txt) loc
-                  | Ldot (path, _) ->
-                      Location.mkloc (Ldot (path, decl.tdec_ident.txt)) loc
-                  | _ -> failwith "Unhandled Lapply in field name")
+                Location.mkloc (Longident.Ldot (path, decl.tdec_ident.txt)) loc
               in
-              let e_typ, env =
+              let decl_type, env =
                 Envi.TypeDecl.mk_typ ~loc ~params:vars ~ident decl env
               in
-              let env = check_type env e.exp_type e_typ in
               let {fld_type; _} = List.nth_exn field_decls i in
               let fld_type, env = Envi.Type.copy fld_type bound_vars env in
-              let fld_type, env = Envi.Type.copy fld_type bound_vars env in
-              (fld_type, env)
-          | _ -> raise (Error (loc, Unbound ("record field", field))) )
+              let env = check_type env expected fld_type in
+              Some (fld_type, decl_type, env)
+          | _ -> None )
+        | Lapply _ -> failwith "Unhandled Lapply in field name"
+      in
+      let typ, decl_type, env, resolved =
+        match field_info with
+        | Some (fld_type, decl_type, env) -> (fld_type, decl_type, env, true)
+        | None ->
+            let fld_type = expected in
+            let decl_type, env = Envi.Type.mkvar ~loc None env in
+            (fld_type, decl_type, env, false)
+      in
+      let e, env = get_expression env decl_type e in
+      let typ, env =
+        if resolved then (typ, env)
+        else
+          match Envi.TypeDecl.find_unaliased_of_type e.exp_type env with
+          | Some ({tdec_desc= TRecord field_decls; _}, bound_vars, env) -> (
+            match
+              List.find field_decls ~f:(fun {fld_ident; _} ->
+                  match field.txt with
+                  | Lident field -> String.equal fld_ident.txt field
+                  | _ -> false
+                  (* This case shouldn't happen! *) )
+            with
+            | Some {fld_type; _} ->
+                let fld_type, env = Envi.Type.copy fld_type bound_vars env in
+                let env = check_type env typ fld_type in
+                (fld_type, env)
+            | None ->
+                raise (Error (loc, Wrong_record_field (field.txt, e.exp_type)))
+            )
+          | _ -> (
+            match Envi.TypeDecl.find_of_field field env with
+            | Some
+                (({tdec_desc= TRecord field_decls; tdec_params; _} as decl), i)
+              ->
+                let vars, bound_vars, env =
+                  Envi.Type.refresh_vars tdec_params
+                    (Map.empty (module Int))
+                    env
+                in
+                let ident =
+                  Longident.(
+                    match field.txt with
+                    | Lident _ ->
+                        Location.mkloc (Lident decl.tdec_ident.txt) loc
+                    | Ldot (path, _) ->
+                        Location.mkloc (Ldot (path, decl.tdec_ident.txt)) loc
+                    | _ -> failwith "Unhandled Lapply in field name")
+                in
+                let e_typ, env =
+                  Envi.TypeDecl.mk_typ ~loc ~params:vars ~ident decl env
+                in
+                let env = check_type env e.exp_type e_typ in
+                let {fld_type; _} = List.nth_exn field_decls i in
+                let fld_type, env = Envi.Type.copy fld_type bound_vars env in
+                let fld_type, env = Envi.Type.copy fld_type bound_vars env in
+                (fld_type, env)
+            | _ -> raise (Error (loc, Unbound ("record field", field))) )
       in
       ({exp_loc= loc; exp_type= typ; exp_desc= Field (e, field)}, env)
   | Record ([], _) -> raise (Error (loc, Empty_record))


### PR DESCRIPTION
This PR
* adds field accessors
* passes an 'expected type' through `get_expression`, which we use to infer the type of a record for localising its labels correctly
* adds record update syntax `{...x, y: (), z: ()}`
* updates a test that the stricter typechecking broke