### PR TITLE
Prettier toplevel

### DIFF
--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -1074,7 +1074,7 @@ module Make_basic (Backend : Backend_intf.S) = struct
     module Proof_system = struct
       type ('checked, 'inputs, 's) proof_system =
         { compute: unit -> 'checked
-        ; check_inputs: (unit, unit) Checked.t
+        ; check_inputs: (unit, 's) Checked.t
         ; provide_inputs: (unit, 'inputs) H_list.t -> unit
         ; has_input: bool ref
         ; has_run_with_input: bool ref
@@ -1086,7 +1086,7 @@ module Make_basic (Backend : Backend_intf.S) = struct
 
       let rec allocate_inputs : type checked r2 k1 k2.
              Field.Vector.t
-          -> (unit, unit) Checked.t
+          -> (unit, 's) Checked.t
           -> int ref
           -> (checked, unit, k1, k2) t
           -> (unit -> k1)

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -1187,11 +1187,12 @@ module Make_basic (Backend : Backend_intf.S) = struct
         proof_system.verification_key <- verification_key ;
         proof_system.proving_key_path <- proving_key_path ;
         proof_system.verification_key_path <- verification_key_path ;
-        match handler with
+        (match handler with
         | Some handler ->
             proof_system.prover_state
             <- {proof_system.prover_state with handler}
-        | None -> ()
+        | None -> ());
+        proof_system
 
       let set_inputs {provide_inputs; _} inputs = provide_inputs inputs
 

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -2171,8 +2171,8 @@ module Run = struct
 
       let run_checked ~exposing ?handler (proof_system : _ t) =
         Or_error.map
-        (run_checked ~run:as_stateful ~exposing ?handler proof_system ())
-        ~f:snd
+          (run_checked ~run:as_stateful ~exposing ?handler proof_system ())
+          ~f:snd
 
       let check ~exposing ?handler (proof_system : _ t) =
         check ~run:as_stateful ~exposing ?handler proof_system ()

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -1187,11 +1187,11 @@ module Make_basic (Backend : Backend_intf.S) = struct
         proof_system.verification_key <- verification_key ;
         proof_system.proving_key_path <- proving_key_path ;
         proof_system.verification_key_path <- verification_key_path ;
-        (match handler with
+        ( match handler with
         | Some handler ->
             proof_system.prover_state
             <- {proof_system.prover_state with handler}
-        | None -> ());
+        | None -> () ) ;
         proof_system
 
       let set_inputs {provide_inputs; _} inputs = provide_inputs inputs

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -1259,6 +1259,10 @@ module Make_basic (Backend : Backend_intf.S) = struct
             ignore (run_proof_system ~run proof_system) ;
             system
 
+      let digest ~run proof_system =
+        let system = constraint_system ~run proof_system in
+        R1CS_constraint_system.digest system
+
       let generate_keypair ~run proof_system =
         let keypair = Keypair.generate (constraint_system ~run proof_system) in
         proof_system.proving_key <- Some keypair.pk ;

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -1203,7 +1203,7 @@ module Make_basic (Backend : Backend_intf.S) = struct
 
       let constraint_system ~run proof_system =
         let system = R1CS_constraint_system.create () in
-        ignore (run_proof_system ~run ~system proof_system None);
+        ignore (run_proof_system ~run ~system proof_system None) ;
         system
 
       let digest ~run proof_system =

--- a/src/snark_intf.ml
+++ b/src/snark_intf.ml
@@ -535,11 +535,11 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
       -> ?proving_key_path:string
       -> ?verification_key_path:string
       -> ?handler:Request.Handler.t
-      -> exposing:( ('a, 's) Checked.t
-                  , unit
-                  , 'computation
-                  , 'public_input )
-                  Data_spec.t
+      -> public_input:( ('a, 's) Checked.t
+                      , unit
+                      , 'computation
+                      , 'public_input )
+                      Data_spec.t
       -> 'computation
       -> ('a, 's, 'public_input) t
 
@@ -548,28 +548,28 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
     val generate_keypair : ('a, 's, 'public_input) t -> Keypair.t
 
     val run_unchecked :
-         exposing:(unit, 'public_input) H_list.t
+         public_input:(unit, 'public_input) H_list.t
       -> ?handler:Request.Handler.t
       -> ('a, 's, 'public_input) t
       -> 's
       -> 's * 'a
 
     val run_checked :
-         exposing:(unit, 'public_input) H_list.t
+         public_input:(unit, 'public_input) H_list.t
       -> ?handler:Request.Handler.t
       -> (('a, 's) As_prover.t, 's, 'public_input) t
       -> 's
       -> ('s * 'a) Or_error.t
 
     val check :
-         exposing:(unit, 'public_input) H_list.t
+         public_input:(unit, 'public_input) H_list.t
       -> ?handler:Request.Handler.t
       -> ('a, 's, 'public_input) t
       -> 's
       -> bool
 
     val prove :
-         exposing:(unit, 'public_input) H_list.t
+         public_input:(unit, 'public_input) H_list.t
       -> ?proving_key:Proving_key.t
       -> ?handler:Request.Handler.t
       -> ('a, 's, 'public_input) t
@@ -577,7 +577,7 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
       -> Proof.t
 
     val verify :
-         exposing:(unit, 'public_input) H_list.t
+         public_input:(unit, 'public_input) H_list.t
       -> ?verification_key:Verification_key.t
       -> ('a, 's, 'public_input) t
       -> Proof.t
@@ -1224,7 +1224,11 @@ module type Run = sig
       -> ?proving_key_path:string
       -> ?verification_key_path:string
       -> ?handler:Request.Handler.t
-      -> exposing:(unit -> 'a, unit, 'computation, 'public_input) Data_spec.t
+      -> public_input:( unit -> 'a
+                      , unit
+                      , 'computation
+                      , 'public_input )
+                      Data_spec.t
       -> 'computation
       -> ('a, 'public_input) t
 
@@ -1233,32 +1237,32 @@ module type Run = sig
     val generate_keypair : ('a, 'public_input) t -> Keypair.t
 
     val run_unchecked :
-         exposing:(unit, 'public_input) H_list.t
+         public_input:(unit, 'public_input) H_list.t
       -> ?handler:Request.Handler.t
       -> ('a, 'public_input) t
       -> 'a
 
     val run_checked :
-         exposing:(unit, 'public_input) H_list.t
+         public_input:(unit, 'public_input) H_list.t
       -> ?handler:Request.Handler.t
       -> (('a, unit) As_prover.t, 'public_input) t
       -> 'a Or_error.t
 
     val check :
-         exposing:(unit, 'public_input) H_list.t
+         public_input:(unit, 'public_input) H_list.t
       -> ?handler:Request.Handler.t
       -> ('a, 'public_input) t
       -> bool
 
     val prove :
-         exposing:(unit, 'public_input) H_list.t
+         public_input:(unit, 'public_input) H_list.t
       -> ?proving_key:Proving_key.t
       -> ?handler:Request.Handler.t
       -> ('a, 'public_input) t
       -> Proof.t
 
     val verify :
-         exposing:(unit, 'public_input) H_list.t
+         public_input:(unit, 'public_input) H_list.t
       -> ?verification_key:Verification_key.t
       -> ('a, 'public_input) t
       -> Proof.t

--- a/src/snark_intf.ml
+++ b/src/snark_intf.ml
@@ -569,7 +569,7 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
       -> bool
 
     val prove :
-         ?exposing:(unit, 'public_input) H_list.t
+         exposing:(unit, 'public_input) H_list.t
       -> ?proving_key:Proving_key.t
       -> ?handler:Request.Handler.t
       -> ('a, 's, 'public_input) t
@@ -1251,7 +1251,7 @@ module type Run = sig
       -> bool
 
     val prove :
-         ?exposing:(unit, 'public_input) H_list.t
+         exposing:(unit, 'public_input) H_list.t
       -> ?proving_key:Proving_key.t
       -> ?handler:Request.Handler.t
       -> ('a, 'public_input) t

--- a/src/snark_intf.ml
+++ b/src/snark_intf.ml
@@ -526,6 +526,60 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
     val get_stack : state -> string list
   end
 
+  module Proof_system : sig
+    type ('a, 's, 'inputs) t
+
+    val create :
+         ?proving_key:Proving_key.t
+      -> ?verification_key:Verification_key.t
+      -> ?proving_key_path:string
+      -> ?verification_key_path:string
+      -> ?handler:Request.Handler.t
+      -> exposing:(('a, 's) Checked.t, unit, 'computation, 'input) Data_spec.t
+      -> 'computation
+      -> ('a, 's, 'input) t
+
+    val digest : ('a, 's, 'input) t -> Md5_lib.t
+
+    val generate_keypair : ('a, 's, 'input) t -> Keypair.t
+
+    val run_unchecked :
+         exposing:(unit, 'input) H_list.t
+      -> ?handler:Request.Handler.t
+      -> ('a, 's, 'input) t
+      -> 's
+      -> 's * 'a
+
+    val run_checked :
+         exposing:(unit, 'input) H_list.t
+      -> ?handler:Request.Handler.t
+      -> (('a, 's) As_prover.t, 's, 'input) t
+      -> 's
+      -> ('s * 'a) Or_error.t
+
+    val check :
+         exposing:(unit, 'input) H_list.t
+      -> ?handler:Request.Handler.t
+      -> (('a, 's) As_prover.t, 's, 'input) t
+      -> 's
+      -> bool
+
+    val prove :
+         exposing:(unit, 'input) H_list.t
+      -> ?proving_key:Proving_key.t
+      -> ?handler:Request.Handler.t
+      -> ('a, 's, 'input) t
+      -> 's
+      -> Proof.t
+
+    val verify :
+         exposing:(unit, 'input) H_list.t
+      -> ?verification_key:Verification_key.t
+      -> ('a, 's, 'input) t
+      -> Proof.t
+      -> bool
+  end
+
   module Perform : sig
     type ('a, 't) t = 't -> Runner.state -> Runner.state * 'a
 
@@ -1155,6 +1209,56 @@ module type Run = sig
     val value : (_, 'value) t -> ('value, unit) As_prover.t
 
     val var : ('var, _) t -> 'var
+  end
+
+  module Proof_system : sig
+    type ('a, 'inputs) t
+
+    val create :
+         ?proving_key:Proving_key.t
+      -> ?verification_key:Verification_key.t
+      -> ?proving_key_path:string
+      -> ?verification_key_path:string
+      -> ?handler:Request.Handler.t
+      -> exposing:(unit -> 'a, unit, 'computation, 'input) Data_spec.t
+      -> 'computation
+      -> ('a, 'input) t
+
+    val digest : ('a, 'input) t -> Md5_lib.t
+
+    val generate_keypair : ('a, 'input) t -> Keypair.t
+
+    val run_unchecked :
+         exposing:(unit, 'input) H_list.t
+      -> ?handler:Request.Handler.t
+      -> ('a, 'input) t
+      -> 'a
+
+    val run_checked :
+         exposing:(unit, 'input) H_list.t
+      -> ?handler:Request.Handler.t
+      -> (('a, unit) As_prover.t, 'input) t
+      -> 'a Or_error.t
+
+    val check :
+         exposing:(unit, 'input) H_list.t
+      -> ?handler:Request.Handler.t
+      -> (('a, unit) As_prover.t, 'input) t
+      -> bool
+
+    val prove :
+         exposing:(unit, 'input) H_list.t
+      -> ?proving_key:Proving_key.t
+      -> ?handler:Request.Handler.t
+      -> ('a, 'input) t
+      -> Proof.t
+
+    val verify :
+         exposing:(unit, 'input) H_list.t
+      -> ?verification_key:Verification_key.t
+      -> ('a, 'input) t
+      -> Proof.t
+      -> bool
   end
 
   val assert_ : ?label:string -> Constraint.t -> unit

--- a/src/snark_intf.ml
+++ b/src/snark_intf.ml
@@ -1216,7 +1216,7 @@ module type Run = sig
   end
 
   module Proof_system : sig
-    type ('a, 'inputs) t
+    type ('a, 'public_input) t
 
     val create :
          ?proving_key:Proving_key.t
@@ -1224,43 +1224,43 @@ module type Run = sig
       -> ?proving_key_path:string
       -> ?verification_key_path:string
       -> ?handler:Request.Handler.t
-      -> exposing:(unit -> 'a, unit, 'computation, 'input) Data_spec.t
+      -> exposing:(unit -> 'a, unit, 'computation, 'public_input) Data_spec.t
       -> 'computation
-      -> ('a, 'input) t
+      -> ('a, 'public_input) t
 
-    val digest : ('a, 'input) t -> Md5_lib.t
+    val digest : ('a, 'public_input) t -> Md5_lib.t
 
-    val generate_keypair : ('a, 'input) t -> Keypair.t
+    val generate_keypair : ('a, 'public_input) t -> Keypair.t
 
     val run_unchecked :
-         exposing:(unit, 'input) H_list.t
+         exposing:(unit, 'public_input) H_list.t
       -> ?handler:Request.Handler.t
-      -> ('a, 'input) t
+      -> ('a, 'public_input) t
       -> 'a
 
     val run_checked :
-         exposing:(unit, 'input) H_list.t
+         exposing:(unit, 'public_input) H_list.t
       -> ?handler:Request.Handler.t
-      -> (('a, unit) As_prover.t, 'input) t
+      -> (('a, unit) As_prover.t, 'public_input) t
       -> 'a Or_error.t
 
     val check :
-         exposing:(unit, 'input) H_list.t
+         exposing:(unit, 'public_input) H_list.t
       -> ?handler:Request.Handler.t
-      -> ('a, 'input) t
+      -> ('a, 'public_input) t
       -> bool
 
     val prove :
-         ?exposing:(unit, 'input) H_list.t
+         ?exposing:(unit, 'public_input) H_list.t
       -> ?proving_key:Proving_key.t
       -> ?handler:Request.Handler.t
-      -> ('a, 'input) t
+      -> ('a, 'public_input) t
       -> Proof.t
 
     val verify :
-         exposing:(unit, 'input) H_list.t
+         exposing:(unit, 'public_input) H_list.t
       -> ?verification_key:Verification_key.t
-      -> ('a, 'input) t
+      -> ('a, 'public_input) t
       -> Proof.t
       -> bool
   end

--- a/src/snark_intf.ml
+++ b/src/snark_intf.ml
@@ -527,7 +527,7 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
   end
 
   module Proof_system : sig
-    type ('a, 's, 'inputs) t
+    type ('a, 's, 'public_input) t
 
     val create :
          ?proving_key:Proving_key.t
@@ -535,47 +535,51 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
       -> ?proving_key_path:string
       -> ?verification_key_path:string
       -> ?handler:Request.Handler.t
-      -> exposing:(('a, 's) Checked.t, unit, 'computation, 'input) Data_spec.t
+      -> exposing:( ('a, 's) Checked.t
+                  , unit
+                  , 'computation
+                  , 'public_input )
+                  Data_spec.t
       -> 'computation
-      -> ('a, 's, 'input) t
+      -> ('a, 's, 'public_input) t
 
-    val digest : ('a, 's, 'input) t -> Md5_lib.t
+    val digest : ('a, 's, 'public_input) t -> Md5_lib.t
 
-    val generate_keypair : ('a, 's, 'input) t -> Keypair.t
+    val generate_keypair : ('a, 's, 'public_input) t -> Keypair.t
 
     val run_unchecked :
-         exposing:(unit, 'input) H_list.t
+         exposing:(unit, 'public_input) H_list.t
       -> ?handler:Request.Handler.t
-      -> ('a, 's, 'input) t
+      -> ('a, 's, 'public_input) t
       -> 's
       -> 's * 'a
 
     val run_checked :
-         exposing:(unit, 'input) H_list.t
+         exposing:(unit, 'public_input) H_list.t
       -> ?handler:Request.Handler.t
-      -> (('a, 's) As_prover.t, 's, 'input) t
+      -> (('a, 's) As_prover.t, 's, 'public_input) t
       -> 's
       -> ('s * 'a) Or_error.t
 
     val check :
-         exposing:(unit, 'input) H_list.t
+         exposing:(unit, 'public_input) H_list.t
       -> ?handler:Request.Handler.t
-      -> (('a, 's) As_prover.t, 's, 'input) t
+      -> ('a, 's, 'public_input) t
       -> 's
       -> bool
 
     val prove :
-         exposing:(unit, 'input) H_list.t
+         ?exposing:(unit, 'public_input) H_list.t
       -> ?proving_key:Proving_key.t
       -> ?handler:Request.Handler.t
-      -> ('a, 's, 'input) t
+      -> ('a, 's, 'public_input) t
       -> 's
       -> Proof.t
 
     val verify :
-         exposing:(unit, 'input) H_list.t
+         exposing:(unit, 'public_input) H_list.t
       -> ?verification_key:Verification_key.t
-      -> ('a, 's, 'input) t
+      -> ('a, 's, 'public_input) t
       -> Proof.t
       -> bool
   end
@@ -1243,11 +1247,11 @@ module type Run = sig
     val check :
          exposing:(unit, 'input) H_list.t
       -> ?handler:Request.Handler.t
-      -> (('a, unit) As_prover.t, 'input) t
+      -> ('a, 'input) t
       -> bool
 
     val prove :
-         exposing:(unit, 'input) H_list.t
+         ?exposing:(unit, 'input) H_list.t
       -> ?proving_key:Proving_key.t
       -> ?handler:Request.Handler.t
       -> ('a, 'input) t


### PR DESCRIPTION
This PR creates the `Proof_system` interface, currently generalised over all the frontends we expose/are planning to expose, and not exposed in the `snark0.mli` file.

Basic interface structure:
```ocaml
  (* The entry point to create a `proof_system` *)
  val create :
    ?proving_key:Proving_key.t ->
    ?verification_key:Verification_key.t ->
    ?proving_key_path:string ->
    ?verification_key_path:string ->
    ?handler:Request.Handler.t ->
    exposing:('checked, unit, 'computation, 'inputs) Data_spec.t ->
    'computation ->
    ('checked, 'inputs, 'state) proof_system

  val set_inputs : ('a, 'b, 'c) proof_system -> (unit, 'b) H_list.t -> unit
  val clear_inputs : ('a, 'b, 'c) proof_system -> unit
  val set_proving_key : ('a, 'b, 'c) proof_system -> Proving_key.t -> unit
  val proving_key : ('a, 'b, 'c) proof_system -> Proving_key.t option
  val set_verification_key : ('a, 'b, 'c) proof_system -> Verification_key.t -> unit
  val verification_key : ('a, 'b, 'c) proof_system -> Verification_key.t option
  val clear_keys : ('a, 'b, 'c) proof_system -> unit

  val set_proving_key_path : ('a, 'b, 'c) proof_system -> string -> unit
  val clear_proving_key_path : ('a, 'b, 'c) proof_system -> unit
  val set_verification_key_path : ('a, 'b, 'c) proof_system -> string -> unit
  val clear_verification_key_path : ('a, 'b, 'c) proof_system -> unit

  (* MD5 digest for the constraint system *)
  val digest : ('a, 'b, 'c) proof_system -> Md5.t

  (* Generate a new keypair for the constraint system, storing it in the [proof_system] *)
  val generate_keypair : ('a, 'c, unit) proof_system -> Keypair.t

  val run_unchecked :
    ?exposing:(unit, 'c) H_list.t ->
    ?handler:Request.Handler.t ->
    ('a, 'c, unit) proof_system -> unit -> unit * 'b

  val run_checked :
    ?exposing:(unit, 'c) H_list.t ->
    ?handler:Request.Handler.t ->
    ('a, 'c, unit) proof_system -> unit -> (unit * 'b, Error.t) result

  val check :
    ?exposing:(unit, 'c) H_list.t ->
    ?handler:Request.Handler.t ->
    ('a, 'c, unit) proof_system -> unit -> bool

  val prove :
    ?exposing:(unit, 'c) H_list.t ->
    ?proving_key:Proving_key.t ->
    ?handler:Request.Handler.t ->
    ('a, 'c, unit) proof_system -> unit -> Proof.t

  val verify :
    ?exposing:(unit, 'b) H_list.t ->
    ?verification_key:Verification_key.t ->
    ('c, 'b, 'd) proof_system -> Proof.t -> bool
end
```

@imeckler I think this roughly follows the design of the toplevel API that we discussed, what do you think?