### PR TITLE
clean up group bindings

### DIFF
--- a/src/bool_vector.ml
+++ b/src/bool_vector.ml
@@ -3,7 +3,7 @@ open Ctypes
 include Vector.Make (struct
   let prefix = "camlsnark_bool_vector"
 
-  type elt = bool
+  type t = bool
 
   let typ = bool
 

--- a/src/camlsnark_c/libsnark-caml/depends/libff/libff/algebra/fields/fp2.hpp
+++ b/src/camlsnark_c/libsnark-caml/depends/libff/libff/algebra/fields/fp2.hpp
@@ -48,6 +48,7 @@ public:
 
     my_Fp c0, c1;
     Fp2_model() {};
+    Fp2_model(const std::vector<my_Fp>& v) : c0(v[0]), c1(v[1]) {};
     Fp2_model(const my_Fp& c0, const my_Fp& c1) : c0(c0), c1(c1) {};
 
     std::vector<my_Fp> all_base_field_elements();

--- a/src/camlsnark_c/libsnark-caml/depends/libff/libff/algebra/fields/fp3.hpp
+++ b/src/camlsnark_c/libsnark-caml/depends/libff/libff/algebra/fields/fp3.hpp
@@ -49,6 +49,7 @@ public:
 
     my_Fp c0, c1, c2;
     Fp3_model() {};
+    Fp3_model(const std::vector<my_Fp>& v) : c0(v[0]), c1(v[1]), c2(v[2]) {};
     Fp3_model(const my_Fp& c0, const my_Fp& c1, const my_Fp& c2) : c0(c0), c1(c1), c2(c2) {};
 
     std::vector<my_Fp> all_base_field_elements();

--- a/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_mnt4_specific.cpp
+++ b/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_mnt4_specific.cpp
@@ -415,7 +415,7 @@ camlsnark_mnt4_gm_verification_key_sign_elts(
 
 // End GM code
 
-// Start g1 ops code
+// Start g1 code
 
 libff::G1<ppT>* camlsnark_mnt4_g1_of_coords (libff::Fq<ppT>* x, libff::Fq<ppT>* y) {
   return new libff::G1<ppT>(*x, *y);
@@ -500,8 +500,58 @@ void camlsnark_mnt4_g1_vector_delete(std::vector<libff::G1<ppT>>* v) {
   delete v;
 }
 
+// End g1 code
+
+// Start g2 code
+libff::G2<ppT>* camlsnark_mnt4_g2_of_coords (
+    std::vector<libff::Fq<ppT>>* x,
+    std::vector<libff::Fq<ppT>>* y) {
+  return new libff::G2<ppT>(
+      libff::Fqe<ppT>(*x), libff::Fqe<ppT>(*y), libff::Fqe<ppT>::one() );
+}
+
+libff::G2<ppT>* camlsnark_mnt4_g2_negate (libff::G2<ppT>* a) {
+  return new libff::G2<ppT>(- *a);
+}
+
+libff::G2<ppT>* camlsnark_mnt4_g2_double (libff::G2<ppT>* a) {
+  return new libff::G2<ppT>(a->dbl());
+}
+
+libff::G2<ppT>* camlsnark_mnt4_g2_add (libff::G2<ppT>* a, libff::G2<ppT>* b) {
+  return new libff::G2<ppT>((*a) + (*b));
+}
+
+libff::G2<ppT>* camlsnark_mnt4_g2_scale (libff::bigint<libff::mnt4_r_limbs> *a, libff::G2<ppT>* x) {
+  return new libff::G2<ppT>((*a) * (*x));
+}
+
+libff::G2<ppT>* camlsnark_mnt4_g2_scale_field (FieldT *a, libff::G2<ppT>* x) {
+  return new libff::G2<ppT>((*a) * (*x));
+}
+
+libff::G2<ppT>* camlsnark_mnt4_g2_zero () {
+  return new libff::G2<ppT>(libff::G2<ppT>::zero());
+}
+
+libff::G2<ppT>* camlsnark_mnt4_g2_one () {
+  return new libff::G2<ppT>(libff::G2<ppT>::one());
+}
+
+void camlsnark_mnt4_g2_print(libff::G2<ppT>* x) {
+  x->print();
+}
+
+bool camlsnark_mnt4_g2_equal(libff::G2<ppT>* a, libff::G2<ppT>* b) {
+  return *a == *b;
+}
+
 void camlsnark_mnt4_g2_delete(libff::G2<ppT>* a) {
   delete a;
+}
+
+libff::G2<ppT>* camlsnark_mnt4_g2_random() {
+  return new libff::G2<ppT>(libff::G2<ppT>::random_element());
 }
 
 void camlsnark_mnt4_g2_to_affine_coordinates(libff::G2<ppT>* a) {
@@ -517,6 +567,29 @@ std::vector<libff::Fq<ppT>>* camlsnark_mnt4_g2_y(libff::G2<ppT>* a) {
   assert(a->Z() == libff::Fqe<ppT>::one());
   return new std::vector< libff::Fq<ppT> >(a->Y().all_base_field_elements());
 }
+
+std::vector<libff::G2<ppT>>* camlsnark_mnt4_g2_vector_create() {
+  return new std::vector<libff::G2<ppT>>();
+}
+
+int camlsnark_mnt4_g2_vector_length(std::vector<libff::G2<ppT>> *v) {
+  return v->size();
+}
+
+void camlsnark_mnt4_g2_vector_emplace_back(std::vector<libff::G2<ppT>>* v, libff::G2<ppT>* x) {
+  v->emplace_back(*x);
+}
+
+libff::G2<ppT>* camlsnark_mnt4_g2_vector_get(std::vector<libff::G2<ppT>>* v, int i) {
+  libff::G2<ppT> res = (*v)[i];
+  return new libff::G2<ppT>(res);
+}
+
+void camlsnark_mnt4_g2_vector_delete(std::vector<libff::G2<ppT>>* v) {
+  delete v;
+}
+
+// End g2 code
 
 void camlsnark_mnt4_fqk_delete(libff::Fqk<ppT>* a) {
   delete a;

--- a/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_mnt6_specific.cpp
+++ b/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_mnt6_specific.cpp
@@ -415,7 +415,7 @@ camlsnark_mnt6_gm_verification_key_sign_elts(
 
 // End GM code
 
-// Start g1 ops code
+// Start g1 code
 
 libff::G1<ppT>* camlsnark_mnt6_g1_of_coords (libff::Fq<ppT>* x, libff::Fq<ppT>* y) {
   return new libff::G1<ppT>(*x, *y);
@@ -500,8 +500,58 @@ void camlsnark_mnt6_g1_vector_delete(std::vector<libff::G1<ppT>>* v) {
   delete v;
 }
 
+// End g1 code
+
+// Start g2 code
+libff::G2<ppT>* camlsnark_mnt6_g2_of_coords (
+    std::vector<libff::Fq<ppT>>* x,
+    std::vector<libff::Fq<ppT>>* y) {
+  return new libff::G2<ppT>(
+      libff::Fqe<ppT>(*x), libff::Fqe<ppT>(*y), libff::Fqe<ppT>::one() );
+}
+
+libff::G2<ppT>* camlsnark_mnt6_g2_negate (libff::G2<ppT>* a) {
+  return new libff::G2<ppT>(- *a);
+}
+
+libff::G2<ppT>* camlsnark_mnt6_g2_double (libff::G2<ppT>* a) {
+  return new libff::G2<ppT>(a->dbl());
+}
+
+libff::G2<ppT>* camlsnark_mnt6_g2_add (libff::G2<ppT>* a, libff::G2<ppT>* b) {
+  return new libff::G2<ppT>((*a) + (*b));
+}
+
+libff::G2<ppT>* camlsnark_mnt6_g2_scale (libff::bigint<libff::mnt6_r_limbs> *a, libff::G2<ppT>* x) {
+  return new libff::G2<ppT>((*a) * (*x));
+}
+
+libff::G2<ppT>* camlsnark_mnt6_g2_scale_field (FieldT *a, libff::G2<ppT>* x) {
+  return new libff::G2<ppT>((*a) * (*x));
+}
+
+libff::G2<ppT>* camlsnark_mnt6_g2_zero () {
+  return new libff::G2<ppT>(libff::G2<ppT>::zero());
+}
+
+libff::G2<ppT>* camlsnark_mnt6_g2_one () {
+  return new libff::G2<ppT>(libff::G2<ppT>::one());
+}
+
+void camlsnark_mnt6_g2_print(libff::G2<ppT>* x) {
+  x->print();
+}
+
+bool camlsnark_mnt6_g2_equal(libff::G2<ppT>* a, libff::G2<ppT>* b) {
+  return *a == *b;
+}
+
 void camlsnark_mnt6_g2_delete(libff::G2<ppT>* a) {
   delete a;
+}
+
+libff::G2<ppT>* camlsnark_mnt6_g2_random() {
+  return new libff::G2<ppT>(libff::G2<ppT>::random_element());
 }
 
 void camlsnark_mnt6_g2_to_affine_coordinates(libff::G2<ppT>* a) {
@@ -517,6 +567,29 @@ std::vector<libff::Fq<ppT>>* camlsnark_mnt6_g2_y(libff::G2<ppT>* a) {
   assert(a->Z() == libff::Fqe<ppT>::one());
   return new std::vector< libff::Fq<ppT> >(a->Y().all_base_field_elements());
 }
+
+std::vector<libff::G2<ppT>>* camlsnark_mnt6_g2_vector_create() {
+  return new std::vector<libff::G2<ppT>>();
+}
+
+int camlsnark_mnt6_g2_vector_length(std::vector<libff::G2<ppT>> *v) {
+  return v->size();
+}
+
+void camlsnark_mnt6_g2_vector_emplace_back(std::vector<libff::G2<ppT>>* v, libff::G2<ppT>* x) {
+  v->emplace_back(*x);
+}
+
+libff::G2<ppT>* camlsnark_mnt6_g2_vector_get(std::vector<libff::G2<ppT>>* v, int i) {
+  libff::G2<ppT> res = (*v)[i];
+  return new libff::G2<ppT>(res);
+}
+
+void camlsnark_mnt6_g2_vector_delete(std::vector<libff::G2<ppT>>* v) {
+  delete v;
+}
+
+// End g2 code
 
 void camlsnark_mnt6_fqk_delete(libff::Fqk<ppT>* a) {
   delete a;

--- a/src/int_vector.ml
+++ b/src/int_vector.ml
@@ -3,7 +3,7 @@ open Ctypes
 include Vector.Make (struct
   let prefix = "camlsnark_int_vector"
 
-  type elt = int
+  type t = int
 
   let typ = int
 

--- a/src/long_vector.ml
+++ b/src/long_vector.ml
@@ -3,7 +3,7 @@ open Ctypes
 include Vector.Make (struct
   let prefix = "camlsnark_long_vector"
 
-  type elt = Signed.Long.t
+  type t = Signed.Long.t
 
   let typ = long
 

--- a/src/vector.ml
+++ b/src/vector.ml
@@ -20,24 +20,30 @@ module type S = sig
   val length : t -> int
 end
 
+module type S_binable = sig
+  include S
+
+  include Binable.S with type t := t
+end
+
 let with_prefix prefix s = sprintf "%s_%s" prefix s
 
-module Make (M : sig
-  type elt
+module Make (Elt : sig
+  type t
 
-  val typ : elt Ctypes.typ
+  val typ : t Ctypes.typ
 
-  val schedule_delete : elt -> unit
+  val schedule_delete : t -> unit
 
   val prefix : string
-end) : S with type elt = M.elt = struct
-  type elt = M.elt
+end) : S with type elt = Elt.t = struct
+  type elt = Elt.t
 
   type t = unit ptr
 
   let typ = ptr void
 
-  let func_name = with_prefix M.prefix
+  let func_name = with_prefix Elt.prefix
 
   let delete = foreign (func_name "delete") (typ @-> returning void)
 
@@ -48,13 +54,89 @@ end) : S with type elt = M.elt = struct
       Caml.Gc.finalise delete t ; t
 
   let get =
-    let stub = foreign (func_name "get") (typ @-> int @-> returning M.typ) in
+    let stub = foreign (func_name "get") (typ @-> int @-> returning Elt.typ) in
     fun t i ->
       let x = stub t i in
-      M.schedule_delete x ; x
+      Elt.schedule_delete x ; x
 
   let length = foreign (func_name "length") (typ @-> returning int)
 
   let emplace_back =
-    foreign (func_name "emplace_back") (typ @-> M.typ @-> returning void)
+    foreign (func_name "emplace_back") (typ @-> Elt.typ @-> returning void)
+end
+
+module Make_binable (Elt : sig
+  type t [@@deriving bin_io]
+
+  val typ : t Ctypes.typ
+
+  val schedule_delete : t -> unit
+
+  val prefix : string
+end) : S_binable with type elt = Elt.t = struct
+  include Make (Elt)
+
+  module Minmal = struct
+    type nonrec t = t
+
+    let arch_sixtyfour = Sys.word_size = 64
+
+    let bin_read_t buf ~pos_ref =
+      let open Bin_prot.Common in
+      let start_pos = !pos_ref in
+      let len = (Bin_prot.Read.bin_read_nat0 buf ~pos_ref :> int) in
+      if len = 0 then create ()
+      else (
+        if arch_sixtyfour then (
+          if len > Caml.Sys.max_array_length then
+            raise_read_error ReadError.Array_too_long start_pos )
+        else if len > Caml.Sys.max_array_length / 2 then
+          raise_read_error ReadError.Array_too_long start_pos ;
+        let res = create () in
+        for _ = 0 to len - 1 do
+          let el = Elt.bin_read_t buf ~pos_ref in
+          emplace_back res el
+        done ;
+        res )
+
+    let bin_shape_t =
+      let open Bin_prot.Shape in
+      basetype (Uuid.of_string "array") [Elt.bin_shape_t]
+
+    let bin_size_len len =
+      let plen = Bin_prot.Nat0.unsafe_of_int len in
+      Bin_prot.Size.bin_size_nat0 plen
+
+    (* TODO: This could be optimized to allocate less *)
+    let bin_size_t_loop ar ~total_len ~n =
+      let total_len_ref = ref total_len in
+      for i = 0 to n - 1 do
+        let el = get ar i in
+        total_len_ref := !total_len_ref + Elt.bin_size_t el
+      done ;
+      !total_len_ref
+
+    let bin_size_t ar =
+      let n = length ar in
+      let total_len = bin_size_len n in
+      bin_size_t_loop ar ~total_len ~n
+
+    let bin_write_t_loop buf ~els_pos ~n ar =
+      let els_pos_ref = ref els_pos in
+      for i = 0 to n - 1 do
+        els_pos_ref := Elt.bin_write_t buf ~pos:!els_pos_ref (get ar i)
+      done ;
+      !els_pos_ref
+
+    let bin_write_t buf ~pos ar =
+      let n = length ar in
+      let pn = Bin_prot.Nat0.unsafe_of_int n in
+      let els_pos = Bin_prot.Write.bin_write_nat0 buf ~pos pn in
+      bin_write_t_loop buf ~els_pos ~n ar
+
+    let __bin_read_t__ _buf ~pos_ref _vint =
+      Bin_prot.Common.raise_variant_wrong_type "array" !pos_ref
+  end
+
+  include Bin_prot.Utils.Of_minimal (Minmal)
 end


### PR DESCRIPTION
This cleans up the group bindings, unifying the G1 and G2 bindings. It also adds a Binable instance for vectors.