### PR TITLE
Monadless As_prover.t

### DIFF
--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -2143,9 +2143,39 @@ module Run = struct
       end
     end
 
+    module Prover = struct
+      type t = unit
+
+      let eval_as_prover f =
+        if !(!state.as_prover) && Option.is_some !state.prover_state then (
+          let s = Option.value_exn !state.Run_state.prover_state in
+          let s, a = f (Runner.get_value !state) s in
+          state := Runner.set_prover_state (Some s) !state ;
+          a )
+        else failwith "Can't evaluate prover code outside an as_prover block"
+
+      let read_var ~p var = eval_as_prover (As_prover.read_var var)
+
+      let get_state ~p = eval_as_prover As_prover.get_state
+
+      let set_state ~p s = eval_as_prover (As_prover.set_state s)
+
+      let read ~p typ var = eval_as_prover (As_prover.read typ var)
+
+      include Field.Constant.T
+    end
+
     module As_prover = struct
       include As_prover
       include Field.Constant.T
+
+      let run_prover f tbl s =
+        if !(!state.as_prover) && Option.is_some !state.prover_state then (
+          state := Runner.set_prover_state (Some s) !state ;
+          let a = f () in
+          let s' = Option.value_exn !state.prover_state in
+          (s', a) )
+        else failwith "Can't evaluate prover code outside an as_prover block"
     end
 
     module Handle = Handle

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -2143,8 +2143,8 @@ module Run = struct
       end
     end
 
-    module Prover = struct
-      type t = unit
+    module As_prover = struct
+      type 'a t = 'a
 
       let eval_as_prover f =
         if !(!state.as_prover) && Option.is_some !state.prover_state then (
@@ -2154,19 +2154,16 @@ module Run = struct
           a )
         else failwith "Can't evaluate prover code outside an as_prover block"
 
-      let read_var ~p var = eval_as_prover (As_prover.read_var var)
+      let read_var var = eval_as_prover (As_prover.read_var var)
 
-      let get_state ~p = eval_as_prover As_prover.get_state
+      let get_state = eval_as_prover As_prover.get_state
 
-      let set_state ~p s = eval_as_prover (As_prover.set_state s)
+      let set_state s = eval_as_prover (As_prover.set_state s)
 
-      let read ~p typ var = eval_as_prover (As_prover.read typ var)
+      let modify_state f = eval_as_prover (As_prover.modify_state f)
 
-      include Field.Constant.T
-    end
+      let read typ var = eval_as_prover (As_prover.read typ var)
 
-    module As_prover = struct
-      include As_prover
       include Field.Constant.T
 
       let run_prover f tbl s =
@@ -2178,7 +2175,14 @@ module Run = struct
         else failwith "Can't evaluate prover code outside an as_prover block"
     end
 
-    module Handle = Handle
+    module Handle = struct
+      type ('var, 'value) t = ('var, 'value) Handle.t =
+        {var: 'var; value: 'value option}
+
+      let value handle () = As_prover.eval_as_prover (Handle.value handle)
+
+      let var = Handle.var
+    end
 
     module Proof_system = struct
       open Run.Proof_system
@@ -2200,11 +2204,13 @@ module Run = struct
 
       let run_checked ~public_input ?handlers (proof_system : _ t) =
         Or_error.map
-          (run_checked ~run:as_stateful ~public_input ?handlers proof_system ())
-          ~f:snd
+          (run_checked' ~run:as_stateful ~public_input ?handlers proof_system
+             ()) ~f:(fun (s, x, state) -> x )
 
       let check ~public_input ?handlers (proof_system : _ t) =
-        check ~run:as_stateful ~public_input ?handlers proof_system ()
+        Or_error.is_ok
+          (run_checked' ~run:as_stateful ~public_input ?handlers proof_system
+             ())
 
       let prove ~public_input ?proving_key ?handlers (proof_system : _ t) =
         prove ~run:as_stateful ~public_input ?proving_key ?handlers
@@ -2222,22 +2228,26 @@ module Run = struct
 
     let assert_square ?label x y = run (assert_square ?label x y)
 
-    let as_prover p = run (as_prover p)
+    let as_prover p = run (as_prover (As_prover.run_prover p))
 
     let next_auxiliary () = run next_auxiliary
 
-    let request_witness typ p = run (request_witness typ p)
+    let request_witness typ p =
+      run (request_witness typ (As_prover.run_prover p))
 
-    let perform p = run (perform p)
+    let perform p = run (perform (As_prover.run_prover p))
 
     let request ?such_that typ r =
       match such_that with
-      | None -> request_witness typ (As_prover0.return r)
+      | None -> request_witness typ (fun () -> r)
       | Some such_that ->
-          let x = request_witness typ (As_prover0.return r) in
+          let x = request_witness typ (fun () -> r) in
           such_that x ; x
 
-    let exists ?request ?compute typ = run (exists ?request ?compute typ)
+    let exists ?request ?compute typ =
+      let request = Option.map request ~f:As_prover.run_prover in
+      let compute = Option.map compute ~f:As_prover.run_prover in
+      run (exists ?request ?compute typ)
 
     type nonrec response = response
 
@@ -2286,7 +2296,7 @@ module Run = struct
         Perform.run_and_check ~run:as_stateful (fun () ->
             let prover_block = x () in
             !state.as_prover := true ;
-            prover_block )
+            As_prover.run_prover prover_block )
       in
       !state.as_prover := false ;
       res

--- a/src/snark_intf.ml
+++ b/src/snark_intf.ml
@@ -1776,7 +1776,7 @@ module type Run = sig
 
   val run_unchecked : (unit -> 'a) -> 'a
 
-  val run_and_check : (unit -> unit -> 'a) -> 'a Or_error.t
+  val run_and_check : (unit -> (unit -> 'a) As_prover.t) -> 'a Or_error.t
 
   val check : (unit -> 'a) -> bool
 

--- a/src/snark_intf.ml
+++ b/src/snark_intf.ml
@@ -1614,6 +1614,27 @@ module type Run = sig
     end
   end
 
+  module Prover : sig
+    (** A handle to call prover functions with. Use {!val:As_prover.run_prover}
+        to convert a function using this handle into an {!type:As_prover.t}. *)
+    type t
+
+    val read_var : p:t -> Field.t -> Field.Constant.t
+
+    val get_state : p:t -> unit
+
+    val set_state : p:t -> unit -> unit
+
+    val read : p:t -> ('var, 'value) Typ.t -> 'var -> 'value
+
+    include Field_intf.Extended with type t := field
+
+    val unpack : field -> bool list
+    (** Convert a field element into its constituent bits. *)
+
+    val project : bool list -> field
+  end
+
   module As_prover : sig
     (** An [('a, 'prover_state) t] value uses the current ['prover_state] to
         generate a value of type ['a], and update the ['prover_state] as
@@ -1639,6 +1660,8 @@ module type Run = sig
       ('prover_state -> 'prover_state) -> (unit, 'prover_state) t
 
     val read : ('var, 'value) Typ.t -> 'var -> ('value, 'prover_state) t
+
+    val run_prover : (Prover.t -> 'a) -> ('a, unit) t
 
     include Field_intf.Extended with type t := field
 


### PR DESCRIPTION
This PR
* adds checking that imperative checked functions aren't run inside `As_prover` blocks
* adds `Prover` to the imperative interface, which expose the `As_prover` functions without being wrapped in a monad.