### PR TITLE
Expose Let_syntax within As_prover.(...)

### DIFF
--- a/src/snark_intf.ml
+++ b/src/snark_intf.ml
@@ -1184,7 +1184,7 @@ module type Run = sig
 
     type ('a, 'prover_state) as_prover = ('a, 'prover_state) t
 
-    include Monad.S2 with type ('a, 's) t := ('a, 's) t
+    include Monad_let.S2 with type ('a, 's) t := ('a, 's) t
 
     val map2 : ('a, 's) t -> ('b, 's) t -> f:('a -> 'b -> 'c) -> ('c, 's) t
 


### PR DESCRIPTION
The original PR for this went out in parallel with the imperative API, must have missed this in the merge.

With this, the imperative API gets:
```ocaml
let compute x y =
  exists Field.typ
    ~compute:As_prover.(
      let%map x = read Field.typ x
      and y = read Field.typ y
      in
      add x y))
```