### PR TITLE
Add a Direct constructor to Checked.t

### DIFF
--- a/src/as_prover.ml
+++ b/src/as_prover.ml
@@ -19,14 +19,15 @@ module type S = sig
 
   val read_var : field Cvar.t -> (field, 's) t
 
-  val read : ('var, 'value, field) Typ.t -> 'var -> ('value, 'prover_state) t
+  val read :
+    ('var, 'value, field, 'r) Typ.t -> 'var -> ('value, 'prover_state) t
 
   module Ref : sig
     type 'a t
 
     val create :
          ('a, field, 'prover_state) As_prover0.t
-      -> ('a t, 'prover_state, field) Checked.t
+      -> ('a t, 'prover_state, field, 'r) Checked.t
 
     val get : 'a t -> ('a, field, _) As_prover0.t
 
@@ -37,7 +38,7 @@ end
 module T = struct
   include As_prover0.T
 
-  let read ({read; _} : ('var, 'value, 'field) Typ.t) (var : 'var) :
+  let read ({read; _} : ('var, 'value, 'field, 'r) Typ.t) (var : 'var) :
       ('value, 'field, 'prover_state) t =
    fun tbl s -> (s, Typ_monads.Read.run (read var) tbl)
 
@@ -45,7 +46,7 @@ module T = struct
     type 'a t = 'a option ref
 
     let create (x : ('a, 'field, 's) As_prover0.t) :
-        ('a t, 's, 'field) Checked.t =
+        ('a t, 's, 'field, 'r) Checked.t =
       let r = ref None in
       let open Checked in
       let%map () =

--- a/src/as_prover.mli
+++ b/src/as_prover.mli
@@ -27,14 +27,15 @@ module type S = sig
 
   val read_var : field Cvar.t -> (field, 's) t
 
-  val read : ('var, 'value, field) Typ.t -> 'var -> ('value, 'prover_state) t
+  val read :
+    ('var, 'value, field, 'r) Typ.t -> 'var -> ('value, 'prover_state) t
 
   module Ref : sig
     type 'a t
 
     val create :
          ('a, field, 'prover_state) As_prover0.t
-      -> ('a t, 'prover_state, field) Checked.t
+      -> ('a t, 'prover_state, field, 'r) Checked.t
 
     val get : 'a t -> ('a, field, _) As_prover0.t
 

--- a/src/checked.ml
+++ b/src/checked.ml
@@ -1,15 +1,15 @@
 open Core_kernel
 open Types.Checked
 
-type ('a, 's, 'field) t = ('a, 's, 'field) Types.Checked.t
+type ('a, 's, 'field, 'r) t = ('a, 's, 'field, 'r) Types.Checked.t
 
 module T0 = struct
   let return x = Pure x
 
   let as_prover x = As_prover (x, return ())
 
-  let rec map : type s a b field.
-      (a, s, field) t -> f:(a -> b) -> (b, s, field) t =
+  let rec map : type s a b field r.
+      (a, s, field, r) t -> f:(a -> b) -> (b, s, field, r) t =
    fun t ~f ->
     match t with
     | Pure x -> Pure (f x)
@@ -25,8 +25,8 @@ module T0 = struct
 
   let map = `Custom map
 
-  let rec bind : type s a b field.
-      (a, s, field) t -> f:(a -> (b, s, field) t) -> (b, s, field) t =
+  let rec bind : type s a b field r.
+      (a, s, field, r) t -> f:(a -> (b, s, field, r) t) -> (b, s, field, r) t =
    fun t ~f ->
     match t with
     | Pure x -> f x
@@ -78,7 +78,7 @@ end
 module T = struct
   include T0
 
-  let request_witness (typ : ('var, 'value, 'field) Types.Typ.t)
+  let request_witness (typ : ('var, 'value, 'field, 'r) Types.Typ.t)
       (r : ('value Request.t, 'field, 's) As_prover0.t) =
     Exists (typ, Request r, fun h -> return (Handle.var h))
 

--- a/src/checked.ml
+++ b/src/checked.ml
@@ -13,6 +13,7 @@ module T0 = struct
    fun t ~f ->
     match t with
     | Pure x -> Pure (f x)
+    | Direct (d, k) -> Direct (d, fun b -> map (k b) ~f)
     | With_label (s, t, k) -> With_label (s, t, fun b -> map (k b) ~f)
     | As_prover (x, k) -> As_prover (x, map k ~f)
     | Add_constraint (c, t1) -> Add_constraint (c, map t1 ~f)
@@ -30,6 +31,7 @@ module T0 = struct
    fun t ~f ->
     match t with
     | Pure x -> f x
+    | Direct (d, k) -> Direct (d, fun b -> bind (k b) ~f)
     | With_label (s, t, k) -> With_label (s, t, fun b -> bind (k b) ~f)
     | As_prover (x, k) -> As_prover (x, bind k ~f)
     (* Someday: This case is probably a performance bug *)

--- a/src/run_state.ml
+++ b/src/run_state.ml
@@ -1,4 +1,4 @@
-type ('prover_state, 'system, 'vector) t =
+type ('prover_state, 'system, 'field, 'vector) t =
   { system: 'system option
   ; input: 'vector
   ; aux: 'vector
@@ -7,4 +7,8 @@ type ('prover_state, 'system, 'vector) t =
   ; next_auxiliary: int ref
   ; prover_state: 'prover_state option
   ; stack: string list
-  ; handler: Request.Handler.t }
+  ; handler: Request.Handler.t
+  ; run_special:
+      'a 's.
+      (   ('a, 's, 'field, (unit, 'system, 'field, 'vector) t) Types.Checked.t
+       -> 'a) option }

--- a/src/run_state.ml
+++ b/src/run_state.ml
@@ -1,0 +1,10 @@
+type ('prover_state, 'system, 'vector) t =
+  { system: 'system option
+  ; input: 'vector
+  ; aux: 'vector
+  ; eval_constraints: bool
+  ; num_inputs: int
+  ; next_auxiliary: int ref
+  ; prover_state: 'prover_state option
+  ; stack: string list
+  ; handler: Request.Handler.t }

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -282,8 +282,11 @@ module Make_basic (Backend : Backend_intf.S) = struct
   end
 
   module Checked0 = struct
+    type 'prover_state run_state =
+      ('prover_state, R1CS_constraint_system.t, Field.Vector.t) Run_state.t
+
     module T = struct
-      type ('a, 's) t = ('a, 's, Field.t) Checked.t
+      type ('a, 's) t = ('a, 's, Field.t, unit run_state) Checked.t
 
       include Checked.T
     end
@@ -297,7 +300,8 @@ module Make_basic (Backend : Backend_intf.S) = struct
     include Typ_monads
     include Typ.T
 
-    type ('var, 'value) t = ('var, 'value, Field.t) Types.Typ.t
+    type ('var, 'value) t =
+      ('var, 'value, Field.t, unit Checked0.run_state) Types.Typ.t
 
     type ('var, 'value) typ = ('var, 'value) t
 
@@ -498,9 +502,6 @@ module Make_basic (Backend : Backend_intf.S) = struct
       fst (go 0 t)
 
     module Runner = struct
-      type 'prover_state run_state =
-        ('prover_state, R1CS_constraint_system.t, Field.Vector.t) Run_state.t
-
       type state = unit run_state
 
       type ('a, 's, 't) run = 't -> 's run_state -> 's run_state * 'a
@@ -1662,7 +1663,8 @@ module Make_basic (Backend : Backend_intf.S) = struct
   end
 
   module Perform = struct
-    type ('a, 't) t = 't -> unit Runner.run_state -> unit Runner.run_state * 'a
+    type ('a, 't) t =
+      't -> unit Checked.run_state -> unit Checked.run_state * 'a
 
     let generate_keypair ~run ~exposing k =
       Run.generate_keypair ~run ~exposing k
@@ -1778,6 +1780,8 @@ module Run = struct
       module Store = Store
       module Alloc = Alloc
       module Read = Read
+
+      type 'prover_state run_state = 'prover_state Snark.Checked.run_state
 
       type nonrec ('var, 'value) t = ('var, 'value) t
 

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -2184,6 +2184,8 @@ module Run = struct
       state := {!state with stack} ;
       a
 
+    let make_checked x = Types.Checked.Direct (as_stateful x, fun x -> Pure x)
+
     let constraint_system ~exposing x =
       Perform.constraint_system ~run:as_stateful ~exposing x
 

--- a/src/snark_intf.ml
+++ b/src/snark_intf.ml
@@ -305,7 +305,11 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
     *)
 
     type 'prover_state run_state =
-      ('prover_state, R1CS_constraint_system.t, Field.Vector.t) Run_state.t
+      ( 'prover_state
+      , R1CS_constraint_system.t
+      , Field.t
+      , Field.Vector.t )
+      Run_state.t
 
     include
       Monad_let.S2
@@ -891,6 +895,7 @@ module type Run = sig
     type 'prover_state run_state =
       ( 'prover_state
       , R1CS_constraint_system.t
+      , Field.Constant.t
       , Field.Constant.Vector.t )
       Run_state.t
 

--- a/src/snark_intf.ml
+++ b/src/snark_intf.ml
@@ -1362,4 +1362,7 @@ module type Run = sig
   val run_and_check : ('a, unit) As_prover.t -> 'a Or_error.t
 
   val check : (unit -> 'a) -> bool
+
+  val constraint_count :
+    ?log:(?start:bool -> string -> int -> unit) -> (unit -> 'a) -> int
 end

--- a/src/snark_intf.ml
+++ b/src/snark_intf.ml
@@ -124,7 +124,8 @@ module type Basic = sig
       val read : Field.Var.t -> field t
     end
 
-    type ('var, 'value) t = ('var, 'value, Field.t) Types.Typ.t
+    type ('var, 'value) t =
+      ('var, 'value, Field.t, unit Checked.run_state) Types.Typ.t
 
     (** Accessors for {!type:Types.Typ.t} fields: *)
 
@@ -302,8 +303,14 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
   Field.Checked.mul x_times_y z
 ]}
     *)
+
+    type 'prover_state run_state =
+      ('prover_state, R1CS_constraint_system.t, Field.Vector.t) Run_state.t
+
     include
-      Monad_let.S2 with type ('a, 's) t = ('a, 's, Field.t) Types.Checked.t
+      Monad_let.S2
+      with type ('a, 's) t =
+                  ('a, 's, Field.t, unit Checked.run_state) Types.Checked.t
 
     module List :
       Monad_sequence.S
@@ -882,7 +889,13 @@ module type Run = sig
       val read : Field.t -> field t
     end
 
-    type ('var, 'value) t = ('var, 'value, field) Types.Typ.t
+    type 'prover_state run_state =
+      ( 'prover_state
+      , R1CS_constraint_system.t
+      , Field.Constant.Vector.t )
+      Run_state.t
+
+    type ('var, 'value) t = ('var, 'value, field, unit run_state) Types.Typ.t
 
     (** Accessors for {!type:Types.Typ.t} fields: *)
 

--- a/src/snark_intf.ml
+++ b/src/snark_intf.ml
@@ -309,8 +309,7 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
 
     include
       Monad_let.S2
-      with type ('a, 's) t =
-                  ('a, 's, Field.t, unit Checked.run_state) Types.Checked.t
+      with type ('a, 's) t = ('a, 's, Field.t, unit run_state) Types.Checked.t
 
     module List :
       Monad_sequence.S
@@ -1329,6 +1328,9 @@ module type Run = sig
   val handle : (unit -> 'a) -> Handler.t -> 'a
 
   val with_label : string -> (unit -> 'a) -> 'a
+
+  val make_checked :
+    (unit -> 'a) -> ('a, 's, Field.t, unit Typ.run_state) Types.Checked.t
 
   val constraint_system :
        exposing:(unit -> 'a, _, 'k_var, _) Data_spec.t

--- a/src/typ.ml
+++ b/src/typ.ml
@@ -1,30 +1,31 @@
 open Core_kernel
 
-type ('var, 'value, 'field) t = ('var, 'value, 'field) Types.Typ.t
+type ('var, 'value, 'field, 'r) t = ('var, 'value, 'field, 'r) Types.Typ.t
 
-type ('var, 'value, 'field) typ = ('var, 'value, 'field) t
+type ('var, 'value, 'field, 'r) typ = ('var, 'value, 'field, 'r) t
 
 module T = struct
   open Types.Typ
   open Typ_monads
 
-  let store ({store; _} : ('var, 'value, 'field) t) (x : 'value) :
+  let store ({store; _} : ('var, 'value, 'field, 'r) t) (x : 'value) :
       ('var, 'field) Store.t =
     store x
 
-  let read ({read; _} : ('var, 'value, 'field) t) (v : 'var) :
+  let read ({read; _} : ('var, 'value, 'field, 'r) t) (v : 'var) :
       ('value, 'field) Read.t =
     read v
 
-  let alloc ({alloc; _} : ('var, 'value, 'field) t) : ('var, 'field) Alloc.t =
+  let alloc ({alloc; _} : ('var, 'value, 'field, 'r) t) :
+      ('var, 'field) Alloc.t =
     alloc
 
-  let check (type field) ({check; _} : ('var, 'value, field) t) (v : 'var) :
-      (unit, 's, field) Types.Checked.t =
+  let check (type field) ({check; _} : ('var, 'value, field, 'r) t) (v : 'var)
+      : (unit, 's, field, 'r) Types.Checked.t =
     let do_nothing : (unit, field, _) As_prover0.t = fun _ s -> (s, ()) in
     With_state (do_nothing, (fun () -> do_nothing), check v, Checked.return)
 
-  let unit () : (unit, unit, 'field) t =
+  let unit () : (unit, unit, 'field, 'r) t =
     let s = Store.return () in
     let r = Read.return () in
     let c = Checked.return () in
@@ -33,31 +34,32 @@ module T = struct
     ; check= (fun () -> c)
     ; alloc= Alloc.return () }
 
-  let field () : ('field Cvar.t, 'field, 'field) t =
+  let field () : ('field Cvar.t, 'field, 'field, 'r) t =
     { store= Store.store
     ; read= Read.read
     ; alloc= Alloc.alloc
     ; check= (fun _ -> Checked.return ()) }
 
-  let transport ({read; store; alloc; check} : ('var1, 'value1, 'field) t)
+  let transport ({read; store; alloc; check} : ('var1, 'value1, 'field, 'r) t)
       ~(there : 'value2 -> 'value1) ~(back : 'value1 -> 'value2) :
-      ('var1, 'value2, 'field) t =
+      ('var1, 'value2, 'field, 'r) t =
     { alloc
     ; store= (fun x -> store (there x))
     ; read= (fun v -> Read.map ~f:back (read v))
     ; check }
 
-  let transport_var ({read; store; alloc; check} : ('var1, 'value, 'field) t)
+  let transport_var
+      ({read; store; alloc; check} : ('var1, 'value, 'field, 'r) t)
       ~(there : 'var2 -> 'var1) ~(back : 'var1 -> 'var2) :
-      ('var2, 'value, 'field) t =
+      ('var2, 'value, 'field, 'r) t =
     { alloc= Alloc.map alloc ~f:back
     ; store= (fun x -> Store.map (store x) ~f:back)
     ; read= (fun x -> read (there x))
     ; check= (fun x -> check (there x)) }
 
   let list ~length
-      ({read; store; alloc; check} : ('elt_var, 'elt_value, 'field) t) :
-      ('elt_var list, 'elt_value list, 'field) t =
+      ({read; store; alloc; check} : ('elt_var, 'elt_value, 'field, 'r) t) :
+      ('elt_var list, 'elt_value list, 'field, 'r) t =
     let store ts =
       let n = List.length ts in
       if n <> length then
@@ -71,8 +73,8 @@ module T = struct
 
   (* TODO-someday: Make more efficient *)
   let array ~length
-      ({read; store; alloc; check} : ('elt_var, 'elt_value, 'field) t) :
-      ('elt_var array, 'elt_value array, 'field) t =
+      ({read; store; alloc; check} : ('elt_var, 'elt_value, 'field, 'r) t) :
+      ('elt_var array, 'elt_value array, 'field, 'r) t =
     let store ts =
       assert (Array.length ts = length) ;
       Store.map ~f:Array.of_list
@@ -101,9 +103,9 @@ module T = struct
     in
     {read; store; alloc; check}
 
-  let tuple2 (typ1 : ('var1, 'value1, 'field) t)
-      (typ2 : ('var2, 'value2, 'field) t) :
-      ('var1 * 'var2, 'value1 * 'value2, 'field) t =
+  let tuple2 (typ1 : ('var1, 'value1, 'field, 'r) t)
+      (typ2 : ('var2, 'value2, 'field, 'r) t) :
+      ('var1 * 'var2, 'value1 * 'value2, 'field, 'r) t =
     let alloc =
       let open Alloc.Let_syntax in
       let%map x = typ1.alloc and y = typ2.alloc in
@@ -128,9 +130,10 @@ module T = struct
 
   let ( * ) = tuple2
 
-  let tuple3 (typ1 : ('var1, 'value1, 'field) t)
-      (typ2 : ('var2, 'value2, 'field) t) (typ3 : ('var3, 'value3, 'field) t) :
-      ('var1 * 'var2 * 'var3, 'value1 * 'value2 * 'value3, 'field) t =
+  let tuple3 (typ1 : ('var1, 'value1, 'field, 'r) t)
+      (typ2 : ('var2, 'value2, 'field, 'r) t)
+      (typ3 : ('var3, 'value3, 'field, 'r) t) :
+      ('var1 * 'var2 * 'var3, 'value1 * 'value2 * 'value3, 'field, 'r) t =
     let alloc =
       let open Alloc.Let_syntax in
       let%map x = typ1.alloc and y = typ2.alloc and z = typ3.alloc in

--- a/src/types.ml
+++ b/src/types.ml
@@ -42,6 +42,9 @@ and Checked : sig
       - ['runner] is the internal type of the checked computation evaluator. *)
   type ('a, 's, 'f, 'r) t =
     | Pure : 'a -> ('a, 's, 'f, 'r) t
+    | Direct :
+        ('r -> 'r * 'a) * ('a -> ('b, 's, 'f, 'r) t)
+        -> ('b, 's, 'f, 'r) t
     | Add_constraint :
         'f Cvar.t Constraint.t * ('a, 's, 'f, 'r) t
         -> ('a, 's, 'f, 'r) t

--- a/src/types.ml
+++ b/src/types.ml
@@ -1,11 +1,12 @@
 module rec Typ : sig
   open Typ_monads
 
-  (** The type [('var, 'value, 'field) t] describes a mapping from OCaml types
+  (** The type [('var, 'value, 'field, 'runner_state) t] describes a mapping from OCaml types
       to the variables and constraints they represent:
       - ['value] is the OCaml type
       - ['field] is the type of the field elements
-      - ['var] is some other type that contains some R1CS variables.
+      - ['var] is some other type that contains some R1CS variables
+      - ['runner_state] is the internal type of the checked computation evaluator.
 
       For convenience and readability, it is usually best to have the ['var]
       type mirror the ['value] type in structure, for example:
@@ -20,11 +21,11 @@ module rec Typ : sig
     let or (x : t) = Snark.Boolean.(x.b1 || x.b2)
   end
 ]}*)
-  type ('var, 'value, 'field) t =
+  type ('var, 'value, 'field, 'r) t =
     { store: 'value -> ('var, 'field) Store.t
     ; read: 'var -> ('value, 'field) Read.t
     ; alloc: ('var, 'field) Alloc.t
-    ; check: 'var -> (unit, unit, 'field) Checked.t }
+    ; check: 'var -> (unit, unit, 'field, 'r) Checked.t }
 end =
   Typ
 
@@ -32,38 +33,43 @@ and Checked : sig
   (* TODO-someday: Consider having an "Assembly" type with only a store constructor for straight up Var.t's
     that this gets compiled into. *)
 
-  (** The type [('ret, 'state, 'field) t] represents a checked computation,
+  (** The type [('ret, 'state, 'field, 'runner_state) t] represents a checked computation,
       where
       - ['state] is the type that holds the state used by [As_prover]
         computations
       - ['state -> 'ret] is the type of the computation
-      - ['field] is the type of the field elements . *)
-  type ('a, 's, 'f) t =
-    | Pure : 'a -> ('a, 's, 'f) t
+      - ['field] is the type of the field elements
+      - ['runner] is the internal type of the checked computation evaluator. *)
+  type ('a, 's, 'f, 'r) t =
+    | Pure : 'a -> ('a, 's, 'f, 'r) t
     | Add_constraint :
-        'f Cvar.t Constraint.t * ('a, 's, 'f) t
-        -> ('a, 's, 'f) t
+        'f Cvar.t Constraint.t * ('a, 's, 'f, 'r) t
+        -> ('a, 's, 'f, 'r) t
     | As_prover :
-        (unit, 'f, 's) As_prover0.t * ('a, 's, 'f) t
-        -> ('a, 's, 'f) t
+        (unit, 'f, 's) As_prover0.t * ('a, 's, 'f, 'r) t
+        -> ('a, 's, 'f, 'r) t
     | With_label :
-        string * ('a, 's, 'f) t * ('a -> ('b, 's, 'f) t)
-        -> ('b, 's, 'f) t
+        string * ('a, 's, 'f, 'r) t * ('a -> ('b, 's, 'f, 'r) t)
+        -> ('b, 's, 'f, 'r) t
     | With_state :
         ('s1, 'f, 's) As_prover0.t
         * ('s1 -> (unit, 'f, 's) As_prover0.t)
-        * ('b, 's1, 'f) t
-        * ('b -> ('a, 's, 'f) t)
-        -> ('a, 's, 'f) t
+        * ('b, 's1, 'f, 'r) t
+        * ('b -> ('a, 's, 'f, 'r) t)
+        -> ('a, 's, 'f, 'r) t
     | With_handler :
-        Request.Handler.single * ('a, 's, 'f) t * ('a -> ('b, 's, 'f) t)
-        -> ('b, 's, 'f) t
-    | Clear_handler : ('a, 's, 'f) t * ('a -> ('b, 's, 'f) t) -> ('b, 's, 'f) t
+        Request.Handler.single
+        * ('a, 's, 'f, 'r) t
+        * ('a -> ('b, 's, 'f, 'r) t)
+        -> ('b, 's, 'f, 'r) t
+    | Clear_handler :
+        ('a, 's, 'f, 'r) t * ('a -> ('b, 's, 'f, 'r) t)
+        -> ('b, 's, 'f, 'r) t
     | Exists :
-        ('var, 'value, 'f) Typ.t
+        ('var, 'value, 'f, 'r) Typ.t
         * ('value, 'f, 's) Provider.t
-        * (('var, 'value) Handle.t -> ('a, 's, 'f) t)
-        -> ('a, 's, 'f) t
-    | Next_auxiliary : (int -> ('a, 's, 'f) t) -> ('a, 's, 'f) t
+        * (('var, 'value) Handle.t -> ('a, 's, 'f, 'r) t)
+        -> ('a, 's, 'f, 'r) t
+    | Next_auxiliary : (int -> ('a, 's, 'f, 'r) t) -> ('a, 's, 'f, 'r) t
 end =
   Checked


### PR DESCRIPTION
This PR
* adds the `Direct` constructor to `Checked.t`
* adds `make_checked` to `Snark_intf.Run`
* implements `constraint_count` for `Direct` and uses the same technique to provide `constraint_count` in `Run`.