### PR TITLE
unify the bindings for getting mnt curve coefficients

### DIFF
--- a/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_mnt4753_specific.cpp
+++ b/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_mnt4753_specific.cpp
@@ -13,6 +13,14 @@ void camlsnark_mnt4753_emplace_bits_of_field(std::vector<bool>* v, FieldT &x) {
 
 // Start g1 code
 
+libff::Fq<ppT>* camlsnark_mnt4753_g1_coeff_a () {
+  return &libff::G1<ppT>::coeff_a;
+}
+
+libff::Fq<ppT>* camlsnark_mnt4753_g1_coeff_b () {
+  return &libff::G1<ppT>::coeff_b;
+}
+
 libff::G1<ppT>* camlsnark_mnt4753_g1_of_coords (libff::Fq<ppT>* x, libff::Fq<ppT>* y) {
   return new libff::G1<ppT>(*x, *y);
 }

--- a/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_mnt4_specific.cpp
+++ b/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_mnt4_specific.cpp
@@ -13,6 +13,14 @@ void camlsnark_mnt4_emplace_bits_of_field(std::vector<bool>* v, FieldT &x) {
 
 // Start g1 code
 
+libff::Fq<ppT>* camlsnark_mnt4_g1_coeff_a () {
+  return &libff::G1<ppT>::coeff_a;
+}
+
+libff::Fq<ppT>* camlsnark_mnt4_g1_coeff_b () {
+  return &libff::G1<ppT>::coeff_b;
+}
+
 libff::G1<ppT>* camlsnark_mnt4_g1_of_coords (libff::Fq<ppT>* x, libff::Fq<ppT>* y) {
   return new libff::G1<ppT>(*x, *y);
 }

--- a/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_mnt6753_specific.cpp
+++ b/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_mnt6753_specific.cpp
@@ -13,6 +13,14 @@ void camlsnark_mnt6753_emplace_bits_of_field(std::vector<bool>* v, FieldT &x) {
 
 // Start g1 code
 
+libff::Fq<ppT>* camlsnark_mnt6753_g1_coeff_a () {
+  return &libff::G1<ppT>::coeff_a;
+}
+
+libff::Fq<ppT>* camlsnark_mnt6753_g1_coeff_b () {
+  return &libff::G1<ppT>::coeff_b;
+}
+
 libff::G1<ppT>* camlsnark_mnt6753_g1_of_coords (libff::Fq<ppT>* x, libff::Fq<ppT>* y) {
   return new libff::G1<ppT>(*x, *y);
 }

--- a/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_mnt6_specific.cpp
+++ b/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_mnt6_specific.cpp
@@ -13,6 +13,14 @@ void camlsnark_mnt6_emplace_bits_of_field(std::vector<bool>* v, FieldT &x) {
 
 // Start g1 code
 
+libff::Fq<ppT>* camlsnark_mnt6_g1_coeff_a () {
+  return &libff::G1<ppT>::coeff_a;
+}
+
+libff::Fq<ppT>* camlsnark_mnt6_g1_coeff_b () {
+  return &libff::G1<ppT>::coeff_b;
+}
+
 libff::G1<ppT>* camlsnark_mnt6_g1_of_coords (libff::Fq<ppT>* x, libff::Fq<ppT>* y) {
   return new libff::G1<ppT>(*x, *y);
 }

--- a/src/camlsnark_c/libsnark-caml/libsnark/caml/common.cpp
+++ b/src/camlsnark_c/libsnark-caml/libsnark/caml/common.cpp
@@ -83,40 +83,6 @@ void camlsnark_int_vector_delete(std::vector<int>* v) {
   delete v;
 }
 
-libff::Fr<libff::mnt4_pp>* camlsnark_mnt6_G1_coeff_a() {
-  return &libff::mnt6_G1::coeff_a;
-}
-
-libff::Fr<libff::mnt4_pp>* camlsnark_mnt6_G1_coeff_b() {
-  return &libff::mnt6_G1::coeff_b;
-}
-
-libff::Fr<libff::mnt4_pp>* camlsnark_mnt6_G1_generator_x() {
-  return new libff::Fr<libff::mnt4_pp>(libff::mnt6_G1::G1_one.X());
-}
-
-libff::Fr<libff::mnt4_pp>* camlsnark_mnt6_G1_generator_y() {
-  return new libff::Fr<libff::mnt4_pp>(libff::mnt6_G1::G1_one.Y());
-}
-
-
-
-libff::Fr<libff::mnt6_pp>* camlsnark_mnt4_G1_coeff_a() {
-  return &libff::mnt4_G1::coeff_a;
-}
-
-libff::Fr<libff::mnt6_pp>* camlsnark_mnt4_G1_coeff_b() {
-  return &libff::mnt4_G1::coeff_b;
-}
-
-libff::Fr<libff::mnt6_pp>* camlsnark_mnt4_G1_generator_x() {
-  return new libff::Fr<libff::mnt6_pp>(libff::mnt4_G1::G1_one.X());
-}
-
-libff::Fr<libff::mnt6_pp>* camlsnark_mnt4_G1_generator_y() {
-  return new libff::Fr<libff::mnt6_pp>(libff::mnt4_G1::G1_one.Y());
-}
-
 const char* camlsnark_string_to_char_pointer(std::string* s) {
   return s->c_str();
 }

--- a/src/snark.ml
+++ b/src/snark.ml
@@ -1,7 +1,6 @@
 include Snark0
 module Backend_intf = Backend_intf
 module Backends = Backends
-module Curve_params = Libsnark.Curves
 module Merkle_tree = Merkle_tree
 module Knapsack = Knapsack
 module Curves = Curves


### PR DESCRIPTION
This unifies the bindings for getting the coefficients for the MNT weierstrass curves so that we can switch easily between the curves and deletes some crufty old bindings.