### PR TITLE
Fix error in the group bindings

### DIFF
--- a/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_mnt4753_specific.cpp
+++ b/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_mnt4753_specific.cpp
@@ -195,6 +195,10 @@ void camlsnark_mnt4753_g2_vector_delete(std::vector<libff::G2<ppT>>* v) {
 
 // End g2 code
 
+libff::Fqk<ppT>* camlsnark_mnt4753_fqk_one(libff::Fqk<ppT>* a) {
+  return new libff::Fqk<ppT>(libff::Fqk<ppT>::one());
+}
+
 void camlsnark_mnt4753_fqk_delete(libff::Fqk<ppT>* a) {
   delete a;
 }

--- a/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_mnt4_specific.cpp
+++ b/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_mnt4_specific.cpp
@@ -195,6 +195,10 @@ void camlsnark_mnt4_g2_vector_delete(std::vector<libff::G2<ppT>>* v) {
 
 // End g2 code
 
+libff::Fqk<ppT>* camlsnark_mnt4_fqk_one(libff::Fqk<ppT>* a) {
+  return new libff::Fqk<ppT>(libff::Fqk<ppT>::one());
+}
+
 void camlsnark_mnt4_fqk_delete(libff::Fqk<ppT>* a) {
   delete a;
 }

--- a/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_mnt6753_specific.cpp
+++ b/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_mnt6753_specific.cpp
@@ -195,6 +195,10 @@ void camlsnark_mnt6753_g2_vector_delete(std::vector<libff::G2<ppT>>* v) {
 
 // End g2 code
 
+libff::Fqk<ppT>* camlsnark_mnt6753_fqk_one(libff::Fqk<ppT>* a) {
+  return new libff::Fqk<ppT>(libff::Fqk<ppT>::one());
+}
+
 void camlsnark_mnt6753_fqk_delete(libff::Fqk<ppT>* a) {
   delete a;
 }

--- a/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_mnt6_specific.cpp
+++ b/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_mnt6_specific.cpp
@@ -195,6 +195,10 @@ void camlsnark_mnt6_g2_vector_delete(std::vector<libff::G2<ppT>>* v) {
 
 // End g2 code
 
+libff::Fqk<ppT>* camlsnark_mnt6_fqk_one(libff::Fqk<ppT>* a) {
+  return new libff::Fqk<ppT>(libff::Fqk<ppT>::one());
+}
+
 void camlsnark_mnt6_fqk_delete(libff::Fqk<ppT>* a) {
   delete a;
 }


### PR DESCRIPTION
I made a stupid error using the wrong prefixes in the bindings. I wrote a unit test that should prevent anyone from making this error again by checking that the curve generator and coefficients are at least consistent with each other. 

I will make a follow up pr swapping which G1/G2 module is in Mnt4/Mnt6, which I think makes more sense.