### PR TITLE
Don't reformat in the node_modules subdir

### DIFF
--- a/app/reformat-snarky/reformat.ml
+++ b/app/reformat-snarky/reformat.ml
@@ -25,7 +25,8 @@ let main dry_run check path =
             && (not (String.is_suffix ~suffix:"stationary" path))
             && (not (String.is_suffix ~suffix:".un~" path))
             && (not (String.is_suffix ~suffix:"external" path))
-            && not (String.is_suffix ~suffix:"ocamlformat" path)
+            && (not (String.is_suffix ~suffix:"ocamlformat" path))
+            && not (String.is_suffix ~suffix:"node_modules" path)
         | `File ->
             (not
                (List.exists whitelist ~f:(fun s ->


### PR DESCRIPTION
One of our `node_modules ` for the website includes a `docs.mli` file which isn't an OCaml interface file. This PR stops us from trying to reformat anything under `node_modules`.