### PR TITLE
Add a generic if_

### DIFF
--- a/src/cvar.ml
+++ b/src/cvar.ml
@@ -9,6 +9,15 @@ type 'f t =
 
 type 'f cvar = 'f t [@@deriving sexp]
 
+let rec first_var_index = function
+  | Constant _ -> None
+  | Var var -> Some var
+  | Add (x, y) -> (
+    match first_var_index x with
+    | Some var -> Some var
+    | None -> first_var_index x )
+  | Scale (_, x) -> first_var_index x
+
 module Make
     (Field : Field_intf.Extended) (Var : sig
         include Comparable.S
@@ -21,6 +30,8 @@ struct
   type t = Field.t cvar [@@deriving sexp]
 
   let length _ = failwith "TODO"
+
+  let first_var_index = first_var_index
 
   module Unsafe = struct
     let of_index v = Var v

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -877,7 +877,7 @@ module Make_basic (Backend : Backend_intf.S) = struct
          let dummy_offset = read_offset var in
          assert (Int.equal !next_input 0 || dummy_offset >= 0) ;
          let%bind r =
-           exists typ
+           exists {typ with check= fun _ -> Checked.return ()}
              ~compute:
                (let open As_prover in
                let%bind b = read_var (b :> Cvar.t) in

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -877,7 +877,8 @@ module Make_basic (Backend : Backend_intf.S) = struct
          let dummy_offset = read_offset var in
          assert (Int.equal !next_input 0 || dummy_offset >= 0) ;
          let%bind r =
-           exists {typ with check= fun _ -> Checked.return ()}
+           exists
+             {typ with check= (fun _ -> Checked.return ())}
              ~compute:
                (let open As_prover in
                let%bind b = read_var (b :> Cvar.t) in

--- a/src/snark_intf.ml
+++ b/src/snark_intf.ml
@@ -658,6 +658,13 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
   val assert_square :
     ?label:string -> Field.Var.t -> Field.Var.t -> (unit, _) Checked.t
 
+  val if_ :
+       ('var, 'value) Typ.t
+    -> Boolean.var
+    -> then_:'var
+    -> else_:'var
+    -> ('var, _) Checked.t
+
   val as_prover : (unit, 's) As_prover.t -> (unit, 's) Checked.t
 
   val with_state :
@@ -1307,6 +1314,9 @@ module type Run = sig
   val assert_r1cs : ?label:string -> Field.t -> Field.t -> Field.t -> unit
 
   val assert_square : ?label:string -> Field.t -> Field.t -> unit
+
+  val if_ :
+    ('var, 'value) Typ.t -> Boolean.var -> then_:'var -> else_:'var -> 'var
 
   val as_prover : (unit, unit) As_prover.t -> unit
 


### PR DESCRIPTION
This PR creates an `if_` that accepts a `Typ.t`.

The basic idea is:
* we use `alloc` to work out the size of the type and allocate a dummy variable
* we use `read` to find the offset of the dummy variable and the three real values (`then_`, `else_` and the result)
* walk over the variables' underlying backend variables, asserting the `if_` constraint on each.