### PR TITLE
[Meja] Magic 'field' type

### DIFF
--- a/meja/envi.ml
+++ b/meja/envi.ml
@@ -486,25 +486,26 @@ module Type = struct
         match raw_find_type_declaration var_ident env with
         | {tdec_desc= TUnfold typ; _} -> (typ, env)
         | decl ->
-        let variant =
-          { variant with
-            var_decl_id= decl.tdec_id
-          ; var_implicit_params= decl.tdec_implicit_params }
-        in
-        let given_args_length = List.length var_params in
-        let expected_args_length = List.length decl.tdec_params in
-        if not (Int.equal given_args_length expected_args_length) then
-          raise
-            (Error
-               ( typ.type_loc
-               , Wrong_number_args
-                   (var_ident.txt, given_args_length, expected_args_length) )) ;
-        let env, var_params =
-          List.fold_map ~init:env var_params ~f:(fun env param ->
-              let param, env = import param env in
-              (env, param) )
-        in
-        (mk ~loc (Tctor {variant with var_params}) env, env) )
+            let variant =
+              { variant with
+                var_decl_id= decl.tdec_id
+              ; var_implicit_params= decl.tdec_implicit_params }
+            in
+            let given_args_length = List.length var_params in
+            let expected_args_length = List.length decl.tdec_params in
+            if not (Int.equal given_args_length expected_args_length) then
+              raise
+                (Error
+                   ( typ.type_loc
+                   , Wrong_number_args
+                       (var_ident.txt, given_args_length, expected_args_length)
+                   )) ;
+            let env, var_params =
+              List.fold_map ~init:env var_params ~f:(fun env param ->
+                  let param, env = import param env in
+                  (env, param) )
+            in
+            (mk ~loc (Tctor {variant with var_params}) env, env) )
     | Ttuple typs ->
         let env, typs =
           List.fold_map typs ~init:env ~f:(fun e t ->
@@ -1075,7 +1076,11 @@ module Core = struct
       [("bytes", 0); ("int32", 0); ("int64", 0); ("nativeint", 0)]
 
   let field, env =
-    let var = Type.mkvar ~loc:Location.none ~explicitness:Implicit (Some (mkloc "field")) env in
+    let var =
+      Type.mkvar ~loc:Location.none ~explicitness:Implicit
+        (Some (mkloc "field"))
+        env
+    in
     TypeDecl.import (mk_type_decl "field" (TUnfold var)) env
 
   module Type = struct

--- a/meja/of_ocaml.ml
+++ b/meja/of_ocaml.ml
@@ -15,7 +15,7 @@ let rec to_type_desc ~loc desc =
   let to_type_expr = to_type_expr ~loc in
   match desc with
   | Tvar x | Tunivar x ->
-      Parsetypes.Tvar (Option.map ~f:(fun x -> mkloc x loc) x, -1)
+      Parsetypes.Tvar (Option.map ~f:(fun x -> mkloc x loc) x, -1, Explicit)
   | Tarrow ((Nolabel | Labelled _), typ1, typ2, _) ->
       Parsetypes.Tarrow (to_type_expr typ1, to_type_expr typ2, Explicit)
   | Tarrow (Optional _lbl, _typ1, typ2, _) ->
@@ -45,7 +45,7 @@ let rec to_type_desc ~loc desc =
   | Tobject _ | Tfield _ | Tnil | Tvariant _ ->
       (* This type isn't supported here. For now, just replace it with a
          variable, so we can still manipulate values including it. *)
-      Parsetypes.Tvar (None, -1)
+      Parsetypes.Tvar (None, -1, Explicit)
 
 and to_type_expr ~loc typ =
   {type_desc= to_type_desc ~loc typ.desc; type_id= -1; type_loc= loc}

--- a/meja/of_ocaml.ml
+++ b/meja/of_ocaml.ml
@@ -25,7 +25,10 @@ let rec to_type_desc ~loc desc =
   | Tconstr (path, params, _) ->
       let var_ident = mkloc (longident_of_path path) loc in
       Parsetypes.Tctor
-        {var_ident; var_params= List.map ~f:to_type_expr params; var_decl_id= 0}
+        { var_ident
+        ; var_params= List.map ~f:to_type_expr params
+        ; var_implicit_params= []
+        ; var_decl_id= 0 }
   | Tlink typ | Tsubst typ -> (to_type_expr typ).type_desc
   | Tpoly (typ, typs) ->
       Parsetypes.Tpoly (List.map ~f:to_type_expr typs, to_type_expr typ)
@@ -35,7 +38,10 @@ let rec to_type_desc ~loc desc =
          to packages and valid paths to type constructors. *)
       let var_ident = mkloc (longident_of_path path) loc in
       Parsetypes.Tctor
-        {var_ident; var_params= List.map ~f:to_type_expr typs; var_decl_id= 0}
+        { var_ident
+        ; var_params= List.map ~f:to_type_expr typs
+        ; var_implicit_params= []
+        ; var_decl_id= 0 }
   | Tobject _ | Tfield _ | Tnil | Tvariant _ ->
       (* This type isn't supported here. For now, just replace it with a
          variable, so we can still manipulate values including it. *)
@@ -86,6 +92,7 @@ let rec to_signature_item item =
             { tdec_ident= mkloc (Ident.name ident) decl.type_loc
             ; tdec_params=
                 List.map ~f:(to_type_expr ~loc:decl.type_loc) decl.type_params
+            ; tdec_implicit_params= []
             ; tdec_desc
             ; tdec_id= 0
             ; tdec_loc= decl.type_loc }

--- a/meja/parser_impl.mly
+++ b/meja/parser_impl.mly
@@ -91,6 +91,7 @@ structure_item:
       mkstmt ~pos:$loc (TypeDecl
         { tdec_ident= x
         ; tdec_params= args
+        ; tdec_implicit_params= []
         ; tdec_desc= k
         ; tdec_id= -1
         ; tdec_loc= mklocation $loc }) }
@@ -102,7 +103,7 @@ structure_item:
     maybe(BAR) ctors = list(ctor_decl, BAR)
     { let (x, params) = x in
       mkstmt ~pos:$loc (TypeExtension
-        ( {var_ident= x; var_params= params; var_decl_id= 0}
+        ( {var_ident= x; var_params= params; var_implicit_params= []; var_decl_id= 0}
         , ctors)) }
 
 module_expr:
@@ -121,7 +122,7 @@ decl_type_expr:
   | x = decl_type(longident(LIDENT, UIDENT))
     { let (x, params) = x in
       mktyp ~pos:$loc
-        (Tctor {var_ident= x; var_params= params; var_decl_id= 0}) }
+        (Tctor {var_ident= x; var_params= params; var_implicit_params= []; var_decl_id= 0}) }
 
 record_field(ID, EXP):
   | id = as_loc(ID) COLON t = EXP

--- a/meja/parser_impl.mly
+++ b/meja/parser_impl.mly
@@ -11,7 +11,7 @@ let lid_last x = mkloc (last x.txt) x.loc
 
 let mktyp ~pos d = {type_desc= d; type_id= -1; type_loc= mklocation pos}
 let mkpat ~pos d = {pat_desc= d; pat_loc= mklocation pos}
-let mkexp ~pos d = {exp_desc= d; exp_loc= mklocation pos; exp_type= mktyp ~pos (Tvar (None, -1))}
+let mkexp ~pos d = {exp_desc= d; exp_loc= mklocation pos; exp_type= mktyp ~pos (Tvar (None, -1, Explicit))}
 let mkstmt ~pos d = {stmt_desc= d; stmt_loc= mklocation pos}
 let mkmod ~pos d = {mod_desc= d; mod_loc= mklocation pos}
 %}
@@ -362,9 +362,9 @@ pat_or_bare_tuple:
 
 simple_type_expr:
   | UNDERSCORE
-    { mktyp ~pos:$loc (Tvar (None, 0)) }
+    { mktyp ~pos:$loc (Tvar (None, 0, Explicit)) }
   | QUOT x = as_loc(LIDENT)
-    { mktyp ~pos:$loc (Tvar (Some x, 0)) }
+    { mktyp ~pos:$loc (Tvar (Some x, 0, Explicit)) }
   | t = decl_type_expr
     { t }
   | LBRACKET x = type_expr RBRACKET

--- a/meja/parsetypes.ml
+++ b/meja/parsetypes.ml
@@ -63,7 +63,11 @@ and type_desc =
   | Tctor of variant
   | Tpoly of type_expr list * type_expr
 
-and variant = {var_ident: lid; var_params: type_expr list; var_decl_id: int}
+and variant =
+  { var_ident: lid
+  ; var_params: type_expr list
+  ; var_implicit_params: type_expr list
+  ; var_decl_id: int }
 
 type field_decl =
   {fld_ident: str; fld_type: type_expr; fld_id: int; fld_loc: Location.t}
@@ -81,6 +85,7 @@ type ctor_decl =
 type type_decl =
   { tdec_ident: str
   ; tdec_params: type_expr list
+  ; tdec_implicit_params: type_expr list
   ; tdec_desc: type_decl_desc
   ; tdec_id: int
   ; tdec_loc: Location.t }

--- a/meja/parsetypes.ml
+++ b/meja/parsetypes.ml
@@ -56,7 +56,7 @@ type type_expr = {type_desc: type_desc; type_id: int; type_loc: Location.t}
 
 and type_desc =
   (* A type variable. Name is None when not yet chosen. *)
-  | Tvar of str option * (* depth *) int
+  | Tvar of str option * (* depth *) int * explicitness
   | Ttuple of type_expr list
   | Tarrow of type_expr * type_expr * explicitness
   (* A type name. *)
@@ -93,6 +93,7 @@ type type_decl =
 and type_decl_desc =
   | TAbstract
   | TAlias of type_expr
+  | TUnfold of type_expr
   | TRecord of field_decl list
   | TVariant of ctor_decl list
   | TOpen
@@ -164,8 +165,10 @@ let rec typ_debug_print fmt typ =
   let print_list pp = pp_print_list ~pp_sep:print_comma pp in
   print "(%i:" typ.type_id ;
   ( match typ.type_desc with
-  | Tvar (None, i) -> print "var _@%i" i
-  | Tvar (Some name, i) -> print "var %s@%i" name.txt i
+  | Tvar (None, i, Explicit) -> print "var _@%i" i
+  | Tvar (Some name, i, Explicit) -> print "var %s@%i" name.txt i
+  | Tvar (None, i, Implicit) -> print "implicit_var _@%i" i
+  | Tvar (Some name, i, Implicit) -> print "implicit_var %s@%i" name.txt i
   | Tpoly (typs, typ) ->
       print "poly [%a] %a"
         (print_list typ_debug_print)

--- a/meja/tests/magic-field.meja
+++ b/meja/tests/magic-field.meja
@@ -8,6 +8,12 @@ type with_param('a) = (unit, 'a);
 
 type field_param = with_param(field);
 
+type variant_containing_field = A(field) | B;
+
+type variant_with_field_param(_) =
+| A : variant_with_field_param(int)
+| B : variant_with_field_param(field);
+
 let add3 = fun (add : field -> field -> field, x : field, y : field, z : field) => {
   add (add (x, y), z);
 };

--- a/meja/tests/magic-field.meja
+++ b/meja/tests/magic-field.meja
@@ -1,0 +1,17 @@
+type field_pair = (field, field);
+
+type field_pair_alias = field_pair;
+
+type record_containing_field = {a : (int, (int, field))};
+
+type with_param('a) = (unit, 'a);
+
+type field_param = with_param(field);
+
+let add3 = fun (add : field -> field -> field, x : field, y : field, z : field) => {
+  add (add (x, y), z);
+};
+
+let test_add3 = fun (add : int -> int -> int) => {
+  add3 (add, 1, 2, 3);
+};

--- a/meja/tests/magic-field.ml
+++ b/meja/tests/magic-field.ml
@@ -1,0 +1,14 @@
+type 'field field_pair = 'field * 'field
+
+type 'field field_pair_alias = 'field field_pair
+
+type 'field record_containing_field = {a: int * (int * 'field)}
+
+type 'a with_param = unit * 'a
+
+type 'field field_param = 'field with_param
+
+let add3 (add : field -> field -> field) (x : field) (y : field) (z : field) =
+  add (add x y) z
+
+let test_add3 (add : int -> int -> int) = add3 add 1 2 3

--- a/meja/tests/magic-field.ml
+++ b/meja/tests/magic-field.ml
@@ -14,7 +14,8 @@ type (_, 'field) variant_with_field_param =
   | A : (int, 'field) variant_with_field_param
   | B : ('field, 'field) variant_with_field_param
 
-let add3 (add : field -> field -> field) (x : field) (y : field) (z : field) =
+let add3 (add : 'field -> 'field -> 'field) (x : 'field) (y : 'field)
+    (z : 'field) =
   add (add x y) z
 
 let test_add3 (add : int -> int -> int) = add3 add 1 2 3

--- a/meja/tests/magic-field.ml
+++ b/meja/tests/magic-field.ml
@@ -8,6 +8,12 @@ type 'a with_param = unit * 'a
 
 type 'field field_param = 'field with_param
 
+type 'field variant_containing_field = A of 'field | B
+
+type (_, 'field) variant_with_field_param =
+  | A : (int, 'field) variant_with_field_param
+  | B : ('field, 'field) variant_with_field_param
+
 let add3 (add : field -> field -> field) (x : field) (y : field) (z : field) =
   add (add x y) z
 

--- a/meja/to_ocaml.ml
+++ b/meja/to_ocaml.ml
@@ -5,8 +5,8 @@ open Parsetypes
 
 let rec of_type_desc ?loc typ =
   match typ with
-  | Tvar (None, _) -> Typ.any ?loc ()
-  | Tvar (Some name, _) -> Typ.var ?loc name.txt
+  | Tvar (None, _, _) -> Typ.any ?loc ()
+  | Tvar (Some name, _, _) -> Typ.var ?loc name.txt
   | Tpoly (_, typ) -> of_type_expr typ
   | Tarrow (typ1, typ2, _) ->
       Typ.arrow ?loc Nolabel (of_type_expr typ1) (of_type_expr typ2)
@@ -50,6 +50,7 @@ let of_type_decl decl =
         ~kind:(Parsetree.Ptype_variant (List.map ~f:of_ctor_decl ctors))
   | TOpen -> Type.mk name ~loc ~params ~kind:Parsetree.Ptype_open
   | TExtend _ -> failwith "Cannot convert TExtend to OCaml"
+  | TUnfold _ -> failwith "Cannot convert TUnfold to OCaml"
 
 let rec of_pattern_desc ?loc = function
   | PAny -> Pat.any ?loc ()

--- a/meja/typechecker.ml
+++ b/meja/typechecker.ml
@@ -199,10 +199,17 @@ let get_ctor (name : lid) env =
   let loc = name.loc in
   match (Envi.TypeDecl.find_of_constructor name env, name) with
   | ( Some
-        (({tdec_desc= TVariant ctors; tdec_ident; tdec_params; _} as decl), i)
+        ( ( { tdec_desc= TVariant ctors
+            ; tdec_ident
+            ; tdec_params
+            ; tdec_implicit_params; _ } as decl )
+        , i )
     , name )
    |( Some
-        ( {tdec_desc= TExtend (name, decl, ctors); tdec_ident; tdec_params; _}
+        ( { tdec_desc= TExtend (name, decl, ctors)
+          ; tdec_ident
+          ; tdec_params
+          ; tdec_implicit_params; _ }
         , i )
     , _ ) ->
       let ctor = List.nth_exn ctors i in
@@ -229,6 +236,7 @@ let get_ctor (name : lid) env =
               (Tctor
                  { var_ident= make_name ctor.ctor_ident
                  ; var_params= params
+                 ; var_implicit_params= tdec_implicit_params
                  ; var_decl_id= tdec_id })
               env
         | Ctor_tuple [typ] -> typ
@@ -673,7 +681,11 @@ let rec check_statement env stmt =
       let m = Envi.find_module ~loc name env in
       (Envi.open_namespace_scope m env, stmt)
   | TypeExtension (variant, ctors) ->
-      let ({tdec_ident; tdec_params; tdec_desc; tdec_id; _} as decl) =
+      let ( { tdec_ident
+            ; tdec_params
+            ; tdec_implicit_params
+            ; tdec_desc
+            ; tdec_id; _ } as decl ) =
         match Envi.raw_find_type_declaration variant.var_ident env with
         | open_decl -> open_decl
         | exception _ ->
@@ -691,6 +703,7 @@ let rec check_statement env stmt =
       let decl =
         { tdec_ident
         ; tdec_params= variant.var_params
+        ; tdec_implicit_params
         ; tdec_id
         ; tdec_desc= TExtend (variant.var_ident, decl, ctors)
         ; tdec_loc= loc }

--- a/meja/typechecker.ml
+++ b/meja/typechecker.ml
@@ -57,7 +57,7 @@ let rec check_type_aux typ ctyp env =
   | _, _ when Int.equal typ.type_id ctyp.type_id -> ()
   | Tpoly (_, typ), _ -> check_type_aux typ ctyp env
   | _, Tpoly (_, ctyp) -> check_type_aux typ ctyp env
-  | Tvar (_, depth), Tvar (_, constr_depth) ->
+  | Tvar (_, depth, _), Tvar (_, constr_depth, _) ->
       bind_none
         (without_instance typ env ~f:(fun typ -> check_type_aux typ ctyp))
         (fun () ->

--- a/meja/typechecker.ml
+++ b/meja/typechecker.ml
@@ -698,7 +698,7 @@ let rec check_statement env stmt =
       (env, {stmt with stmt_desc= Value (p, e)})
   | Instance (name, e) ->
       let dummy_type =
-        {type_desc= Tvar (None, -1); type_id= -1; type_loc= loc}
+        {type_desc= Tvar (None, -1, Explicit); type_id= -1; type_loc= loc}
       in
       let p =
         {pat_desc= PVariable name; pat_loc= name.loc; pat_type= dummy_type}

--- a/src/snark_intf.ml
+++ b/src/snark_intf.ml
@@ -73,24 +73,46 @@ module type Basic = sig
 
   (** Rank-1 constraints over {!type:Var.t}s. *)
   module rec Constraint : sig
+    (** The type of constraints.
+        In the proof system, every constraint is a rank-1 constraint; that is,
+        the constraint takes the form [a * b = c] for some [a], [b] and [c]
+        which are made up of some linear combination of {!type:Field.Var.t}s.
+
+        For example, a constraint could be [(w + 2*x) * (y + z) = a + b], where
+        [w], [x], [y], [z], [a], and [b] are field variables.
+        Note that a linear combination is the result of adding together some of
+        these variables, each multiplied by a field constant ({!type:Field.t}); 
+        any time we want to multiply our *variables*, we need to add a new 
+        rank-1 constraint.
+    *)
     type t = Field.Var.t Constraint0.t
 
     type 'k with_constraint_args = ?label:string -> 'k
 
     val boolean : (Field.Var.t -> t) with_constraint_args
+    (** A constraint that asserts that the field variable is a boolean: either
+        {!val:Field.zero} or {!val:Field.one}.
+    *)
 
     val equal : (Field.Var.t -> Field.Var.t -> t) with_constraint_args
+    (** A constraint that asserts that the field variable arguments are equal.
+    *)
 
     val r1cs :
       (Field.Var.t -> Field.Var.t -> Field.Var.t -> t) with_constraint_args
+    (** A bare rank-1 constraint. *)
 
     val square : (Field.Var.t -> Field.Var.t -> t) with_constraint_args
+    (** A constraint that asserts that the first variable squares to the
+        second, ie. [square x y] => [x*x = y] within the field.
+    *)
   end
   
   (** The data specification for checked computations. *)
   and Data_spec : sig
-    (** A list of {!type:Typ.t} values, describing the inputs to a checked computation.
-        The type [('r_var, 'r_value, 'k_var, 'k_value) t] represents
+    (** A list of {!type:Typ.t} values, describing the inputs to a checked
+        computation. The type [('r_var, 'r_value, 'k_var, 'k_value) t]
+        represents
         - ['k_value] is the OCaml type of the computation
         - ['r_value] is the OCaml type of the result
         - ['k_var] is the type of the computation within the R1CS
@@ -102,40 +124,116 @@ module type Basic = sig
       | [] : ('r_var, 'r_value, 'r_var, 'r_value) t
 
     val size : (_, _, _, _) t -> int
+    (** [size [typ1; ...; typn]] returns the number of {!type:Var.t} variables
+        allocated by allocating [typ1], followed by [typ2], etc. *)
   end
   
   (** Mappings from OCaml types to R1CS variables and constraints. *)
   and Typ : sig
     module Store : sig
+      (** A ['value Store.t] value describes storing {!type:Field.t}s in
+          variables for use in the R1CS. It is a monad, which lets us combine
+          these variables to create more complex values.
+
+          For example, we can store a 3-tuple of values by writing
+{[
+  let store3 (store_a : 'a Store.t) (store_b : 'b Store.t)
+    (store_c : 'b Store.t) : ('a, 'b, 'c) Store.t =
+    let open Store in
+    let%map a = store_a
+    and b = store_b
+    and c = store_c
+    in
+    (a, b, c)
+]}
+      *)
       include Monad_let.S with type 'a t = ('a, Field.t) Typ_monads.Store.t
 
       val store : field -> Field.Var.t t
+      (** Store a single field element for the R1CS, and return the variable
+          that refers to it. *)
     end
 
     module Alloc : sig
+      (** A ['value Alloc.t] describes allocating variables for the R1CS to use
+          without explicitly giving the values to store in them. This is
+          analogous to {!type:Store.t}.
+
+          The main use of this is in generating the constraint system and
+          generating the {!type:Keypair.t} with {!val:generate_keypair}; we
+          can't know yet what values we will want to store in the variables,
+          but we still want to know what constraints they will have to satisfy.
+      *)
       include Monad_let.S with type 'a t = ('a, Field.t) Typ_monads.Alloc.t
 
       val alloc : Field.Var.t t
+      (** Allocate a variable in the R1CS that can hold a single field element.
+      *)
     end
 
     module Read : sig
+      (** A ['value Read.t] describes reading values back out of the R1CS
+          variables, so that the prover can use them in {!module:As_prover}
+          blocks. It is a monad, which lets us combine these values to
+          create more complex ones.
+
+          For example, we can create a record containing the results of some
+          reads by writing
+{[
+  type ('a, 'b) t = {a : 'a; b : 'b}
+
+  let read_t (read_a : 'a Read.t) (read_b : 'b Read.t) : ('a, 'b) t =
+    let open Read in
+    let%map a = read_a
+    and b = read_b
+    in
+    {a; b}
+]}
+      *)
       include Monad_let.S with type 'a t = ('a, Field.t) Typ_monads.Read.t
 
       val read : Field.Var.t -> field t
+      (** Read the contents of a single R1CS variable. *)
     end
 
+    (** The type [('var, 'value) t] describes a mapping from the OCaml type
+        ['value] to a type representing the value using R1CS variables
+        (['var]).
+        This description includes
+        - a {!type:Store.t} for storing ['value]s as ['var]s
+        - a {!type:Alloc.t} for creating a ['var] when we don't know what values
+          it should contain yet
+        - a {!type:Read.t} for reading the contents of the ['var] back out as a
+          ['value] in {!module:As_prover} blocks
+        - a {!type:Checked.t} for asserting constraints on the ['var] -- for
+          example, that a [Boolean.t] is either a {!val:Field.zero} or a
+          {!val:Field.one}.
+    *)
     type ('var, 'value) t =
       ('var, 'value, Field.t, unit Checked.run_state) Types.Typ.t
 
     (** Accessors for {!type:Types.Typ.t} fields: *)
 
     val store : ('var, 'value) t -> 'value -> 'var Store.t
+    (** [store typ x] stores [x] as a ['var] according to the description given
+        by [typ].
+    *)
 
     val read : ('var, 'value) t -> 'var -> 'value Read.t
+    (** [read typ x] reads [x] as a ['value] according to the description given
+    by [typ].
+    *)
 
     val alloc : ('var, 'value) t -> 'var Alloc.t
+    (** [alloc typ] allocates the R1CS variables necessary to represent a
+        ['value] and creates a ['var] from them, according to the description
+        given by [typ].
+    *)
 
     val check : ('var, 'value) t -> 'var -> (unit, _) Checked.t
+    (** [check typ x] runs a checked computation to generate the constraints
+        described by [typ] that [x] should satisfy.
+    *)
 
     (** Basic instances: *)
 
@@ -154,7 +252,7 @@ module type Basic = sig
          ('var1, 'value1) t
       -> ('var2, 'value2) t
       -> ('var1 * 'var2, 'value1 * 'value2) t
-    (** synonym for tuple2 *)
+    (** synonym for {!val:tuple2} *)
 
     val tuple3 :
          ('var1, 'value1) t
@@ -163,8 +261,28 @@ module type Basic = sig
       -> ('var1 * 'var2 * 'var3, 'value1 * 'value2 * 'value3) t
 
     val list : length:int -> ('var, 'value) t -> ('var list, 'value list) t
+    (** [list ~length typ] describes how to convert between a ['value list] and
+        a ['var list], given a description of how to convert between a ['value]
+        and a ['var].
+
+        [length] must be the length of the lists that are converted. This value
+        must be constant for every use; otherwise the constraint system may use
+        a different number of variables depending on the data given.
+
+        Passing a list of the wrong length throws an error.
+    *)
 
     val array : length:int -> ('var, 'value) t -> ('var array, 'value array) t
+    (** [array ~length typ] describes how to convert between a ['value array]
+        and a ['var array], given a description of how to convert between a
+        ['value] and a ['var].
+
+        [length] must be the length of the arrays that are converted. This
+        value must be constant for every use; otherwise the constraint system
+        may use a different number of variables depending on the data given.
+
+        Passing an array of the wrong length throws an error.
+    *)
 
     val hlist :
          (unit, unit, 'k_var, 'k_value) Data_spec.t
@@ -194,6 +312,10 @@ module type Basic = sig
       -> value_to_hlist:('value -> (unit, 'k_value) H_list.t)
       -> value_of_hlist:((unit, 'k_value) H_list.t -> 'value)
       -> ('var, 'value) t
+    (** A specialised version of {!val:transport}/{!val:transport_var} that
+        describes the relationship between ['var] and ['value] in terms of a
+        {!type:Data_spec.t}.
+    *)
 
     module Of_traversable (T : Traversable.S) : sig
       val typ :
@@ -207,33 +329,47 @@ module type Basic = sig
       [false] to {!val:Field.zero}, adding a check in {!val:Boolean.typ} to
       ensure that these are the only vales. *)
   and Boolean : sig
+    (** The type that stores booleans as R1CS variables. *)
     type var = Field.Var.t Boolean0.t
 
     type value = bool
 
     val true_ : var
+    (** An R1CS variable containing {!val:Field.one}, representing [true]. *)
 
     val false_ : var
+    (** An R1CS variable containing {!val:Field.zero}, representing [false]. *)
 
     val if_ : var -> then_:var -> else_:var -> (var, _) Checked.t
+    (** [if_ b ~then_ ~else_] returns [then_] if [b] is true, or [else_]
+        otherwise.
+    *)
 
     val not : var -> var
+    (** Negate a boolean value *)
 
     val ( && ) : var -> var -> (var, _) Checked.t
+    (** Boolean and *)
 
     val ( || ) : var -> var -> (var, _) Checked.t
+    (** Boolean or *)
 
     val ( lxor ) : var -> var -> (var, _) Checked.t
+    (** Boolean xor (exclusive-or) *)
 
     val any : var list -> (var, _) Checked.t
+    (** Returns [true] if any value in the list is true, false otherwise. *)
 
     val all : var list -> (var, _) Checked.t
+    (** Returns [true] if all value in the list are true, false otherwise. *)
 
     val of_field : Field.Var.t -> (var, _) Checked.t
     (** Convert a value in a field to a boolean, adding checks to the R1CS that
        it is a valid boolean value. *)
 
     val var_of_value : value -> var
+    (** Convert an OCaml [bool] into a R1CS variable representing the same
+        value. *)
 
     val typ : (var, value) Typ.t
     (** The relationship between {!val:var} and {!val:value}, with a check that
@@ -244,6 +380,7 @@ module type Basic = sig
 
     val equal : var -> var -> (var, _) Checked.t
 
+    (** Build trees representing boolean expressions. *)
     module Expr : sig
       (** Expression trees. *)
       type t
@@ -331,7 +468,8 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
   end
   
   and Field : sig
-    (** The finite field over which the R1CS operates. *)
+    (** The finite field over which the R1CS operates.
+        Values may be between 0 and {!val:size}. *)
     type t = field [@@deriving bin_io, sexp, hash, compare, eq]
 
     val gen : t Core_kernel.Quickcheck.Generator.t
@@ -342,12 +480,15 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
     include Stringable.S with type t := t
 
     val size : Bignum_bigint.t
+    (** The number at which values in the field wrap back around to 0. *)
 
     val unpack : t -> bool list
     (** Convert a field element into its constituent bits. *)
 
     val project : bool list -> t
-    (** Convert a list of bits into a field element. *)
+    (** Convert a list of bits into a field element. This is the inverse of
+        unpack.
+    *)
 
     val project_reference : bool list -> t
     (** [project], but slow. Exposed for benchmarks. *)
@@ -355,6 +496,7 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
     type var' = Var.t
 
     module Var : sig
+      (** The type that stores booleans as R1CS variables. *)
       type t = field Cvar.t
 
       val length : t -> int
@@ -367,56 +509,169 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
           scaled R1CS variables. *)
 
       val constant : field -> t
+      (** [constant x] creates a new R1CS variable containing the constant
+          field element [x]. *)
 
       val to_constant : t -> field option
+      (** [to_constant x] returns [Some f] if x holds only the constant field
+          element [f]. Otherwise, it returns [None].
+      *)
 
       val linear_combination : (field * t) list -> t
+      (** [linear_combination [(f1, x1);...;(fn, xn)]] returns the result of
+          calculating [f1 * x1 + f2 * x2 + ... + fn * xn].
+          This does not add a new constraint; see {!type:Constraint.t} for more
+          information.
+      *)
 
       val sum : t list -> t
+      (** [sum l] returns the sum of all R1CS variables in [l].
+
+          If the result would be greater than or equal to {!val:Field.size}
+          then the value will overflow to be less than {!val:Field.size}.
+      *)
 
       val add : t -> t -> t
+      (** [add x y] returns the result of adding the R1CS variables [x] and
+          [y].
+
+          If the result would be greater than or equal to {!val:Field.size}
+          then the value will overflow to be less than {!val:Field.size}.
+      *)
 
       val sub : t -> t -> t
+      (** [sub x y] returns the result of subtracting the R1CS variables [x]
+          and [y].
+
+          If the result would be less than 0 then the value will underflow
+          to be between 0 and {!val:Field.size}.
+      *)
 
       val scale : t -> field -> t
+      (** [scale x f] returns the result of multiplying the R1CS variable [x]
+          by the constant field element [f].
+
+          If the result would be greater than or equal to {!val:Field.size}
+          then the value will overflow to be less than {!val:Field.size}.
+      *)
 
       val project : Boolean.var list -> t
+      (** Convert a list of bits into a field element.
+
+          [project [b1;...;bn] = b1 + 2*b2 + 4*b3 + ... + 2^(n-1) * bn]
+
+          If the result would be greater than or equal to {!val:Field.size}
+          then the value will overflow to be less than {!val:Field.size}.
+      *)
 
       val pack : Boolean.var list -> t
+      (** Convert a list of bits into a field element.
+
+          [pack [b1;...;bn] = b1 + 2*b2 + 4*b3 + ... + 2^(n-1) * bn]
+      
+          This will raise an assertion error if the length of the list is not
+          strictly less than number of bits in {!val:Field.size}.
+
+          Use [project] if you know that the list represents a value less than
+          {!val:Field.size} but where the number of bits may be the maximum, or
+          where overflow is appropriate.
+      *)
     end
 
     module Checked : sig
       val mul : Var.t -> Var.t -> (Var.t, _) Checked.t
+      (** [mul x y] returns the result of multiplying the R1CS variables [x]
+          and [y].
+
+          If the result would be greater than or equal to {!val:Field.size}
+          then the value will overflow to be less than {!val:Field.size}.
+      *)
 
       val square : Var.t -> (Var.t, _) Checked.t
+      (** [square x] returns the result of multiplying the R1CS variables [x]
+          by itself.
+
+          If the result would be greater than or equal to {!val:Field.size}
+          then the value will overflow to be less than {!val:Field.size}.
+      *)
 
       val div : Var.t -> Var.t -> (Var.t, _) Checked.t
+      (** [div x y] returns the result of dividing the R1CS variable [x] by
+          [y].
+
+          If [x] is not an integer multiple of [y], the result could be any
+          value; it is equivalent to computing [mul x (inv y)].
+
+          If [y] is 0, this raises a [Failure].
+      *)
 
       val inv : Var.t -> (Var.t, _) Checked.t
+      (** [inv x] returns the value such that [mul x (inv x) = 1].
+
+          If [x] is 0, this raises a [Failure].
+      *)
 
       val equal : Var.t -> Var.t -> (Boolean.var, 's) Checked.t
+      (** [equal x y] returns a R1CS variable containing the value [true] if
+          the R1CS variables [x] and [y] are equal, or [false] otherwise.
+      *)
 
       val unpack : Var.t -> length:int -> (Boolean.var list, _) Checked.t
+      (** [unpack x ~length] returns a list of R1CS variables containing the
+          [length] lowest bits of [x]. If [length] is greater than the number
+          of bits in {!val:Field.size} then this raises a [Failure].
+
+          For example,
+          - [unpack 8 ~length:4 = [0; 0; 0; 1]]
+          - [unpack 9 ~length:3 = [1; 0; 0]]
+          - [unpack 9 ~length:5 = [1; 0; 0; 1; 0]]
+      *)
 
       val unpack_flagged :
            Var.t
         -> length:int
         -> (Boolean.var list * [`Success of Boolean.var], _) Checked.t
+      (** [unpack x ~length = (unpack x ~length, `Success success)], where
+          [success] is an R1CS variable containing [true] if the returned bits
+          represent [x], and [false] otherwise.
+
+          If [length] is greater than the number of bits in {!val:Field.size}
+          then this raises a [Failure].
+      *)
 
       val unpack_full :
         Var.t -> (Boolean.var Bitstring_lib.Bitstring.Lsb_first.t, _) Checked.t
+      (** [unpack x ~length] returns a list of R1CS variables containing the
+          bits of [x].
+      *)
 
       val choose_preimage_var :
         Var.t -> length:int -> (Boolean.var list, _) Checked.t
+      (** [unpack x ~length] returns a list of R1CS variables containing the
+          [length] lowest bits of [x].
+      *)
 
+      (** The type of results from checked comparisons, stored as boolean R1CS
+          variables.
+      *)
       type comparison_result = {less: Boolean.var; less_or_equal: Boolean.var}
 
       val compare :
         bit_length:int -> Var.t -> Var.t -> (comparison_result, _) Checked.t
+      (** [compare ~bit_length x y] compares the [bit_length] lowest bits of
+          [x] and [y].
+
+          This requires converting the R1CS variables [x] and [y] into a list
+          of bits.
+      *)
 
       val if_ :
         Boolean.var -> then_:Var.t -> else_:Var.t -> (Var.t, _) Checked.t
+      (** [if_ b ~then_ ~else_] returns [then_] if [b] is true, or [else_]
+          otherwise.
+      *)
 
+      (** Infix notations for the basic field operations. *)
       module Infix : sig
         val ( + ) : Var.t -> Var.t -> Var.t
 
@@ -429,6 +684,7 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
         val of_index : int -> Var.t
       end
 
+      (** Assertions *)
       module Assert : sig
         val lte : bit_length:int -> Var.t -> Var.t -> (unit, _) Checked.t
 
@@ -447,17 +703,20 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
     end
 
     val typ : (Var.t, t) Typ.t
+    (** Describes how to convert between {!type:t} and {!type:Var.t} values. *)
   end
 
   module Let_syntax :
     Monad_let.Syntax2 with type ('a, 's) t := ('a, 's) Checked.t
 
+  (** Zero-knowledge proofs generated from checked computations. *)
   module Proof : sig
     type t
 
     include Stringable.S with type t := t
   end
 
+  (** Utility functions for dealing with lists of bits in the R1CS. *)
   module Bitstring_checked : sig
     type t = Boolean.var list
 
@@ -473,6 +732,10 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
     end
   end
 
+  (** Code that can be run by the prover only, using 'superpowers' like looking
+      at the contents of R1CS variables and creating new variables from other
+      OCaml values.
+  *)
   module As_prover : sig
     (** An [('a, 'prover_state) t] value uses the current ['prover_state] to
         generate a value of type ['a], and update the ['prover_state] as
@@ -501,27 +764,43 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
     include Monad_let.S2 with type ('a, 's) t := ('a, 's) t
 
     val map2 : ('a, 's) t -> ('b, 's) t -> f:('a -> 'b -> 'c) -> ('c, 's) t
+    (** Combine 2 {!type:As_prover.t} blocks using another function. *)
 
     val read_var : Field.Var.t -> (field, 'prover_state) t
+    (** Read the contents of a R1CS variable representing a single field
+        element. *)
 
     val get_state : ('prover_state, 'prover_state) t
+    (** Read the ['prover_state] carried by the {!type:As_prover.t} monad. *)
 
     val set_state : 'prover_state -> (unit, 'prover_state) t
+    (** Update the ['prover_state] carried by the {!type:As_prover.t} monad. *)
 
     val modify_state :
       ('prover_state -> 'prover_state) -> (unit, 'prover_state) t
+    (** Change the ['prover_state] carried by the {!type:As_prover.t} monad. *)
 
     val read : ('var, 'value) Typ.t -> 'var -> ('value, 'prover_state) t
+    (** [read typ x] reads the contents of the R1CS variables in [x] to create
+        an OCaml variable of type ['value], according to the description given
+        by [typ].
+    *)
   end
 
+  (** Representation of an R1CS value and an OCaml value (if running as the
+      prover) together.
+  *)
   module Handle : sig
     type ('var, 'value) t = {var: 'var; value: 'value option}
 
     val value : (_, 'value) t -> ('value, _) As_prover.t
+    (** Get the value of a handle as the prover. *)
 
     val var : ('var, _) t -> 'var
+    (** Get the R1CS representation of a value. *)
   end
 
+  (** Utility functions for calling single checked computations. *)
   module Runner : sig
     type state
 
@@ -540,17 +819,36 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
 
   val unhandled : response
 
+  (** The argument type for request handlers.
+
+{[
+  type _ Request.t += My_request : 'a list -> 'a Request.t
+
+  let handled (c : ('a, _) Checked.t) : ('a, _) Checked.t =
+    handle (fun (With {request; respond}) ->
+      match request with
+      | My_request l ->
+        let x = (* Do something with l to create a single value. *) in
+        respond (Provide x)
+      | _ -> unhandled )
+]}
+  *)
   type request = Request.request =
     | With :
         { request: 'a Request.t
         ; respond: 'a Request.Response.t -> response }
         -> request
 
+  (** The type of handlers. *)
   module Handler : sig
     type t = request -> response
   end
 
+  (** The interface for managing proof systems. *)
   module Proof_system : sig
+    (** A proof system instance for a checked computation producing a value of
+        type ['a], with prover state ['s] and public inputs ['public_input].
+    *)
     type ('a, 's, 'public_input) t
 
     val create :
@@ -566,10 +864,37 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
                       Data_spec.t
       -> 'computation
       -> ('a, 's, 'public_input) t
+    (** Create a new proof system. The arguments are
+        - [proving_key] -- optional, defines the key to be used for proving.
+          If not present, a key will be read from [proving_key_path], or one
+          will be generated automatically.
+        - [verification_key] -- optional, defines the key to be used for
+          verification of a proof.
+          If not present, a key will be read from [verification_key_path], or
+          one will be generated automatically.
+        - [proving_key_path] -- optional, defines the path to a file where the
+          proving key can be found. If the file does not exist and no
+          [proving_key] argument is given, the generated key will be written to
+          this file.
+        - [verification_key_path] -- optional, defines the path to a file where
+          the verification key can be found. If the file does not exist and no
+          [verification_key] argument is given, the generated key will be
+          written to this file.
+        - [handlers] -- optional, the list of handlers that should be used to
+          handle requests made from the checked computation
+        - [public_input] -- the {!type:Data_spec.t} that describes the form
+          that the public inputs must take
+        - ['computation] -- a checked computation that takes as arguments
+          values with the types described by [public_input] to the output type.
+    *)
 
     val digest : ('a, 's, 'public_input) t -> Md5_lib.t
+    (** The MD5 hash of the constraint system. *)
 
     val generate_keypair : ('a, 's, 'public_input) t -> Keypair.t
+    (** Generate a keypair for the checked computation, writing it to the
+        [proving_key_path] and [verification_key_path], if set.
+    *)
 
     val run_unchecked :
          public_input:(unit, 'public_input) H_list.t
@@ -577,6 +902,9 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
       -> ('a, 's, 'public_input) t
       -> 's
       -> 's * 'a
+    (** Run the checked computation as the prover, without checking any
+        constraints.
+    *)
 
     val run_checked :
          public_input:(unit, 'public_input) H_list.t
@@ -584,6 +912,7 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
       -> (('a, 's) As_prover.t, 's, 'public_input) t
       -> 's
       -> ('s * 'a) Or_error.t
+    (** Run the checked computation as the prover, checking any constraints. *)
 
     val check :
          public_input:(unit, 'public_input) H_list.t
@@ -591,6 +920,9 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
       -> ('a, 's, 'public_input) t
       -> 's
       -> bool
+    (** Run the checked computation as the prover, returning [true] if all of
+        the constraints are correct, or [false] otherwise.
+    *)
 
     val prove :
          public_input:(unit, 'public_input) H_list.t
@@ -599,6 +931,14 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
       -> ('a, 's, 'public_input) t
       -> 's
       -> Proof.t
+    (** Run the checked computation as the prover, generating a {!type:Proof.t}
+        that the verifier may check efficiently.
+        - The [proving_key] argument overrides the argument given to
+          {!val:create}, if any.
+        - The [handlers] argument adds handlers to those already given to
+          {!val:create}. If handlers for the same requests were provided to
+          both, the ones passed here are given priority.
+    *)
 
     val verify :
          public_input:(unit, 'public_input) H_list.t
@@ -606,8 +946,15 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
       -> ('a, 's, 'public_input) t
       -> Proof.t
       -> bool
+    (** Verify a {!type:Proof.t} generated by a prover.
+       [verification_key] overrides the argument given to {!val:create}, if
+       any.
+    *)
   end
 
+  (** Utility functions for running different representations of checked
+      computations using a standard interface.
+  *)
   module Perform : sig
     type ('a, 't) t = 't -> Runner.state -> Runner.state * 'a
 
@@ -645,8 +992,13 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
   end
 
   val assert_ : ?label:string -> Constraint.t -> (unit, 's) Checked.t
+  (** Add a constraint to the constraint system, optionally with the label
+      given by [label]. *)
 
   val assert_all : ?label:string -> Constraint.t list -> (unit, 's) Checked.t
+  (** Add all of the constraints in the list to the constraint system,
+      optionally with the label given by [label].
+  *)
 
   val assert_r1cs :
        ?label:string
@@ -654,59 +1006,113 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
     -> Field.Var.t
     -> Field.Var.t
     -> (unit, _) Checked.t
+  (** Add a rank-1 constraint to the constraint system, optionally with the
+      label given by [label].
+
+      See {!val:Constraint.r1cs} for more information on rank-1 constraints.
+  *)
 
   val assert_square :
     ?label:string -> Field.Var.t -> Field.Var.t -> (unit, _) Checked.t
+  (** Add a 'square' constraint to the constraint system, optionally with the
+      label given by [label].
+
+      See {!val:Constraint.square} for more information.
+  *)
 
   val as_prover : (unit, 's) As_prover.t -> (unit, 's) Checked.t
+  (** Run an {!module:As_prover} block. *)
 
   val with_state :
        ?and_then:('s1 -> (unit, 's) As_prover.t)
     -> ('s1, 's) As_prover.t
     -> ('a, 's1) Checked.t
     -> ('a, 's) Checked.t
+  (** Update the prover state by running an {!module:As_prover} block. *)
 
   val next_auxiliary : (int, 's) Checked.t
+  (** Internal: read the value of the next unused auxiliary input index. *)
 
   val request_witness :
        ('var, 'value) Typ.t
     -> ('value Request.t, 's) As_prover.t
     -> ('var, 's) Checked.t
+  (** [request_witness typ create_request] runs the [create_request]
+      {!type:As_prover.t} block to generate a {!type:Request.t}.
+
+      This allows us to introduce values into the R1CS without passing them as
+      public inputs.
+
+      If no handler for the request is attached by {!val:handle}, this raises
+      a [Failure].
+  *)
 
   val perform : (unit Request.t, 's) As_prover.t -> (unit, 's) Checked.t
+  (** Like {!val:request_witness}, but the request doesn't return any usable
+      value.
+  *)
 
   val request :
        ?such_that:('var -> (unit, 's) Checked.t)
     -> ('var, 'value) Typ.t
     -> 'value Request.t
     -> ('var, 's) Checked.t
-  (** TODO: Come up with a better name for this in relation to the above *)
+  (** Like {!val:request_witness}, but generates the request without using
+      any {!module:As_prover} 'superpowers'.
+
+      The argument [such_that] allows adding extra constraints on the returned
+      value.
+
+      (* TODO: Come up with a better name for this in relation to the above *)
+  *)
 
   val exists :
        ?request:('value Request.t, 's) As_prover.t
     -> ?compute:('value, 's) As_prover.t
     -> ('var, 'value) Typ.t
     -> ('var, 's) Checked.t
+  (** Introduce a value into the R1CS.
+      - The [request] argument functions like {!val:request_witness}, creating
+        a request and returning the result.
+      - If no [request] argument is given, or if the [request] isn't handled,
+        then [compute] is run to create a value.
+
+      If [compute] is not given and [request] fails/is also not given, then
+      this function raises a [Failure].
+  *)
 
   val handle : ('a, 's) Checked.t -> Handler.t -> ('a, 's) Checked.t
+  (** Add a request handler to the checked computation, to be used by
+      {!val:request_witness}, {!val:perform}, {!val:request} or {!val:exists}.
+  *)
 
   val with_label : string -> ('a, 's) Checked.t -> ('a, 's) Checked.t
+  (** Add a label to all of the constraints added in the checked computation.
+      If a constraint is checked and isn't satisfied, this label will be shown
+      in the error message.
+  *)
 
   val constraint_system :
        exposing:((unit, 's) Checked.t, _, 'k_var, _) Data_spec.t
     -> 'k_var
     -> R1CS_constraint_system.t
+  (** Generate the R1CS for the checked computation. *)
 
   val generate_keypair :
        exposing:((unit, 's) Checked.t, _, 'k_var, _) Data_spec.t
     -> 'k_var
     -> Keypair.t
+  (** Create a new keypair for the R1CS generated by the checked computation.
+  *)
 
   val conv :
        ('r_var -> 'r_value)
     -> ('r_var, 'r_value, 'k_var, 'k_value) Data_spec.t
     -> 'k_var
     -> 'k_value
+  (** Internal: supplies arguments to a checked computation by storing them
+      according to the {!type:Data_spec.t} and passing the R1CS versions.
+  *)
 
   val prove :
        Proving_key.t
@@ -714,22 +1120,40 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
     -> 's
     -> 'k_var
     -> 'k_value
+  (** Run the checked computation, creating a proof that it has been run
+      correctly (ie. satisfies its constraints).
+  *)
 
   val verify :
        Proof.t
     -> Verification_key.t
     -> (_, bool, _, 'k_value) Data_spec.t
     -> 'k_value
+  (** Verify a {!type:Proof.t} generated from a checked computation. *)
 
   val run_unchecked : ('a, 's) Checked.t -> 's -> 's * 'a
+  (** Run a checked computation as the prover, without checking the
+      constraints. *)
 
   val run_and_check :
     (('a, 's) As_prover.t, 's) Checked.t -> 's -> ('s * 'a) Or_error.t
+  (** Run a checked computation as the prover, checking the constraints. *)
 
   val check : ('a, 's) Checked.t -> 's -> bool
+  (** Run a checked computation as the prover, returning [true] if the
+      constraints are all satisfied, or [false] otherwise. *)
 
   val constraint_count :
     ?log:(?start:bool -> string -> int -> unit) -> (_, _) Checked.t -> int
+  (** Returns the number of constraints in the constraint system.
+
+      The optional [log] argument is called at the start and end of each
+      [with_label], with the arguments [log ?start label count], where:
+      - [start] is [Some true] if it the start of the [with_label], or [None]
+        otherwise
+      - [label] is the label added by [with_label]
+      - [count] is the number of constraints at that point.
+  *)
 
   module Test : sig
     val checked_to_unchecked :


### PR DESCRIPTION
This PR
* implements implicit type parameters
* adds an `explicitness` flag to `Tvar` to give us implicit variables
* lifts implicit variables to be implicit type parameters in type declarations
* adds the `TUnfold` type declaration kind, as an immediately-unfolding version of `TAlias`
* adds a `field` type, implemented as a `TUnfold` of an implicit variable

Note: the test includes `let add3` etc., which needs PR #133 to work properly.