### PR TITLE
fix type of make checked

### DIFF
--- a/examples/imperative_test/imperative_test.ml
+++ b/examples/imperative_test/imperative_test.ml
@@ -70,16 +70,14 @@ let verify proof vk =
 module Intf = Snark.Run.Make (Backends.Mnt4.GM)
 
 module Old = struct
-  module M = Snark.Make(Backends.Mnt4.GM)
+  module M = Snark.Make (Backends.Mnt4.GM)
   open M
 
   let f = Field.Checked.mul
 
   let foo x y =
     let%bind z = f x y in
-    Intf.make_checked (fun () ->
-      test2 (module Intf) z
-    )
+    Intf.make_checked (fun () -> test2 (module Intf) z)
 end
 
 let exposing = Intf.(Data_spec.[Field.typ])

--- a/examples/imperative_test/imperative_test.ml
+++ b/examples/imperative_test/imperative_test.ml
@@ -69,6 +69,19 @@ let verify proof vk =
 
 module Intf = Snark.Run.Make (Backends.Mnt4.GM)
 
+module Old = struct
+  module M = Snark.Make(Backends.Mnt4.GM)
+  open M
+
+  let f = Field.Checked.mul
+
+  let foo x y =
+    let%bind z = f x y in
+    Intf.make_checked (fun () ->
+      test2 (module Intf) z
+    )
+end
+
 let exposing = Intf.(Data_spec.[Field.typ])
 
 let prove2 () =

--- a/src/snark_intf.ml
+++ b/src/snark_intf.ml
@@ -1759,7 +1759,7 @@ module type Run = sig
   val with_label : string -> (unit -> 'a) -> 'a
 
   val make_checked :
-    (unit -> 'a) -> ('a, 's, Field.t, unit Typ.run_state) Types.Checked.t
+    (unit -> 'a) -> ('a, 's, field, unit Typ.run_state) Types.Checked.t
 
   val constraint_system :
        exposing:(unit -> 'a, _, 'k_var, _) Data_spec.t


### PR DESCRIPTION
This PR fixes the type of `make_checked` and adds an example which failed to compile before but should now. @mrmr1993 what do you think of adding a value

```ocaml
val direct : (m : Field.t m -> 'a) -> ('a, _) Checked.t
```
?

Somehow that seems sort of more intuitive to me, but maybe it's bad if we have some new-style code which is written against some explicit run module? Not sure…