### PR TITLE
Expose an optional public_output parameter to Proof_system methods

### DIFF
--- a/examples/election/election_main.ml
+++ b/examples/election/election_main.ml
@@ -39,4 +39,9 @@ let () =
     )
   in
   let commitments, winner, proof = tally_and_prove received_ballots in
-  assert (verify proof (Keypair.vk keypair) (exposed ()) commitments winner)
+  assert (verify proof (Keypair.vk keypair) (exposed ()) commitments winner) ;
+  (* We can also use the [Proof_system] API for this: *)
+  let commitments, winner, proof = tally_and_prove_ps received_ballots in
+  assert (
+    Proof_system.verify proof_system proof ~public_input:[commitments]
+      ~public_output:winner )

--- a/src/snark_intf.ml
+++ b/src/snark_intf.ml
@@ -848,6 +848,10 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
   module Proof_system : sig
     (** A proof system instance for a checked computation producing a value of
         type ['a], with prover state ['s] and public inputs ['public_input].
+
+        If the checked computation's output is to be checked by the verifier,
+        the ['public_output] type is the OCaml type corresponding to the return
+        value ['a].
     *)
     type ('a, 's, 'public_input, 'public_output) t
 


### PR DESCRIPTION
This PR adds a parameter to `Proof_system.create` and `Proof_system.verify` that handles a 'public output'.

This is implemented as an additional input that
* is not passed to the checked computation
* has no known value until the end of the checked computation
* is verified to equal the return value of the function, by a user-passed `assert_equal`

This lets us avoid precomputing the expected output before we begin the proof; see the election example for example usage.