### PR TITLE
Add generate_auxiliary_input for timing tests

### DIFF
--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -1461,6 +1461,24 @@ module Make_basic (Backend : Backend_intf.S) = struct
           in
           Proof.create key ~primary ~auxiliary )
         t k
+
+    let generate_auxiliary_input :
+           run:('a, 's, 'checked) Checked.Runner.run
+        -> ('checked, unit, 'k_var, 'k_value) t
+        -> 's
+        -> 'k_var
+        -> 'k_value =
+     fun ~run t s k ->
+      conv
+        (fun c primary ->
+          let auxiliary =
+            Checked.auxiliary_input ~run
+              ~num_inputs:(Field.Vector.length primary)
+              c s primary
+          in
+          ignore auxiliary )
+        t k
+
   end
 
   module Cvar1 = struct
@@ -1740,6 +1758,8 @@ module Make_basic (Backend : Backend_intf.S) = struct
   let conv f = Run.conv (fun x _ -> f x)
 
   let prove key t s k = Run.prove ~run:Runner.run key t s k
+
+  let generate_auxiliary_input t s k = Run.generate_auxiliary_input ~run:Runner.run t s k
 
   let verify = Run.verify
 

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -1478,7 +1478,6 @@ module Make_basic (Backend : Backend_intf.S) = struct
           in
           ignore auxiliary )
         t k
-
   end
 
   module Cvar1 = struct
@@ -1759,7 +1758,8 @@ module Make_basic (Backend : Backend_intf.S) = struct
 
   let prove key t s k = Run.prove ~run:Runner.run key t s k
 
-  let generate_auxiliary_input t s k = Run.generate_auxiliary_input ~run:Runner.run t s k
+  let generate_auxiliary_input t s k =
+    Run.generate_auxiliary_input ~run:Runner.run t s k
 
   let verify = Run.verify
 

--- a/src/snark_intf.ml
+++ b/src/snark_intf.ml
@@ -1143,6 +1143,17 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
   (** Run a checked computation as the prover, returning [true] if the
       constraints are all satisfied, or [false] otherwise. *)
 
+  val generate_auxiliary_input :
+       (('a, 's) Checked.t, unit, 'k_var, 'k_value) Data_spec.t
+    -> 's
+    -> 'k_var
+    -> 'k_value
+  (** Run the checked computation and generate the auxiliary input, but don't
+      generate a proof.
+
+      Returns [unit]; this is for testing only.
+  *)
+
   val constraint_count :
     ?log:(?start:bool -> string -> int -> unit) -> (_, _) Checked.t -> int
   (** Returns the number of constraints in the constraint system.


### PR DESCRIPTION
This PR adds `generate_auxiliary_input`, which is just `prove` with the proving part removed, for tests.

This is the main component of the runner for tests in #148.