### PR TITLE
Use phantom types to associate libsnark types with the field

### DIFF
--- a/src/backend_intf.ml
+++ b/src/backend_intf.ml
@@ -10,7 +10,7 @@ module type S = sig
   val field_size : Bigint.R.t
 
   module Var : sig
-    type t
+    type t = Field.t Backend_types.Var.t
 
     val index : t -> int
 
@@ -18,7 +18,7 @@ module type S = sig
   end
 
   module Linear_combination : sig
-    type t
+    type t = Field.t Backend_types.Linear_combination.t
 
     val create : unit -> t
 
@@ -30,7 +30,7 @@ module type S = sig
   end
 
   module R1CS_constraint : sig
-    type t
+    type t = Field.t Backend_types.R1CS_constraint.t
 
     val create :
       Linear_combination.t -> Linear_combination.t -> Linear_combination.t -> t
@@ -39,7 +39,7 @@ module type S = sig
   end
 
   module Proving_key : sig
-    type t [@@deriving bin_io]
+    type t = Field.t Backend_types.Proving_key.t [@@deriving bin_io]
 
     val to_string : t -> string
 
@@ -51,7 +51,7 @@ module type S = sig
   end
 
   module Verification_key : sig
-    type t
+    type t = Field.t Backend_types.Verification_key.t
 
     include Stringable.S with type t := t
 
@@ -61,7 +61,7 @@ module type S = sig
   end
 
   module Proof : sig
-    type t
+    type t = Field.t Backend_types.Proof.t
 
     include Stringable.S with type t := t
 
@@ -72,7 +72,7 @@ module type S = sig
   end
 
   module R1CS_constraint_system : sig
-    type t
+    type t = Field.t Backend_types.R1CS_constraint_system.t
 
     val create : unit -> t
 
@@ -103,7 +103,7 @@ module type S = sig
   end
 
   module Keypair : sig
-    type t
+    type t = Field.t Backend_types.Keypair.t
 
     val pk : t -> Proving_key.t
 

--- a/src/backend_types.ml
+++ b/src/backend_types.ml
@@ -43,25 +43,20 @@ end
 module Field_constrained = struct
   type 'field t = unit ptr
 
-  module Make (M : Field_prefix_intf) : S with type t = M.field t = Make_foreign (M)
+  module Make (M : Field_prefix_intf) : S with type t = M.field t =
+    Make_foreign (M)
 end
 
 module Var = Field_constrained
 
 module Linear_combination = struct
   include Field_constrained
-
   module Term = Field_constrained
 end
 
 module R1CS_constraint = Field_constrained
-
 module R1CS_constraint_system = Field_constrained
-
 module Proving_key = Field_constrained
-
 module Verification_key = Field_constrained
-
 module Keypair = Field_constrained
-
 module Proof = Field_constrained

--- a/src/backend_types.ml
+++ b/src/backend_types.ml
@@ -1,0 +1,67 @@
+open Core
+open Ctypes
+open Foreign
+
+let with_prefix prefix s = sprintf "%s_%s" prefix s
+
+module type Prefix_intf = sig
+  val prefix : string
+end
+
+module type S = sig
+  type t
+
+  val typ : t typ
+
+  val func_name : string -> string
+
+  val delete : t -> unit
+end
+
+module Make_foreign (M : Prefix_intf) = struct
+  type t = unit ptr
+
+  let typ = ptr void
+
+  let func_name = with_prefix M.prefix
+
+  let delete = foreign (func_name "delete") (typ @-> returning void)
+end
+
+module type Field_prefix_intf = sig
+  include Prefix_intf
+
+  type field
+end
+
+module type Field_constrained = sig
+  type 'field t
+
+  module Make (M : Field_prefix_intf) : S with type t = M.field t
+end
+
+module Field_constrained = struct
+  type 'field t = unit ptr
+
+  module Make (M : Field_prefix_intf) : S with type t = M.field t = Make_foreign (M)
+end
+
+module Var = Field_constrained
+
+module Linear_combination = struct
+  include Field_constrained
+
+  module Term = Field_constrained
+end
+
+module R1CS_constraint = Field_constrained
+
+module R1CS_constraint_system = Field_constrained
+
+module Proving_key = Field_constrained
+
+module Verification_key = Field_constrained
+
+module Keypair = Field_constrained
+
+module Proof = Field_constrained

--- a/src/backend_types.mli
+++ b/src/backend_types.mli
@@ -1,0 +1,51 @@
+open Ctypes
+
+val with_prefix : string -> string -> string
+
+module type Prefix_intf = sig
+  val prefix : string
+end
+
+module type S = sig
+  type t
+
+  val typ : t typ
+
+  val func_name : string -> string
+
+  val delete : t -> unit
+end
+
+module Make_foreign (M : Prefix_intf) : S
+
+module type Field_prefix_intf = sig
+  include Prefix_intf
+
+  type field
+end
+
+module type Field_constrained = sig
+  type 'field t
+
+  module Make (M : Field_prefix_intf) : S with type t = M.field t
+end
+
+module Var : Field_constrained
+
+module Linear_combination : sig
+  include Field_constrained
+
+  module Term : Field_constrained
+end
+
+module R1CS_constraint : Field_constrained
+
+module R1CS_constraint_system : Field_constrained
+
+module Proving_key : Field_constrained
+
+module Verification_key : Field_constrained
+
+module Keypair : Field_constrained
+
+module Proof : Field_constrained

--- a/src/run_state.ml
+++ b/src/run_state.ml
@@ -1,5 +1,5 @@
-type ('prover_state, 'system, 'field) t =
-  { system: 'system option
+type ('prover_state, 'field) t =
+  { system: 'field Backend_types.R1CS_constraint_system.t option
   ; input: 'field Vector.t
   ; aux: 'field Vector.t
   ; eval_constraints: bool
@@ -11,6 +11,5 @@ type ('prover_state, 'system, 'field) t =
   ; is_running: bool
   ; as_prover: bool ref
   ; run_special:
-      'a 's.
-      (('a, 's, 'field, (unit, 'system, 'field) t) Types.Checked.t -> 'a)
-      option }
+      'a 's. (('a, 's, 'field, (unit, 'field) t) Types.Checked.t -> 'a) option
+  }

--- a/src/run_state.ml
+++ b/src/run_state.ml
@@ -1,7 +1,7 @@
-type ('prover_state, 'system, 'field, 'vector) t =
+type ('prover_state, 'system, 'field) t =
   { system: 'system option
-  ; input: 'vector
-  ; aux: 'vector
+  ; input: 'field Vector.t
+  ; aux: 'field Vector.t
   ; eval_constraints: bool
   ; num_inputs: int
   ; next_auxiliary: int ref
@@ -12,5 +12,5 @@ type ('prover_state, 'system, 'field, 'vector) t =
   ; as_prover: bool ref
   ; run_special:
       'a 's.
-      (   ('a, 's, 'field, (unit, 'system, 'field, 'vector) t) Types.Checked.t
-       -> 'a) option }
+      (('a, 's, 'field, (unit, 'system, 'field) t) Types.Checked.t -> 'a)
+      option }

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -285,8 +285,7 @@ module Make_basic (Backend : Backend_intf.S) = struct
     type 'prover_state run_state =
       ( 'prover_state
       , R1CS_constraint_system.t
-      , Field.t
-      , Field.Vector.t )
+      , Field.t )
       Run_state.t
 
     module T = struct

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -282,8 +282,7 @@ module Make_basic (Backend : Backend_intf.S) = struct
   end
 
   module Checked0 = struct
-    type 'prover_state run_state =
-      ('prover_state, Field.t) Run_state.t
+    type 'prover_state run_state = ('prover_state, Field.t) Run_state.t
 
     module T = struct
       type ('a, 's) t = ('a, 's, Field.t, unit run_state) Checked.t

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -283,10 +283,7 @@ module Make_basic (Backend : Backend_intf.S) = struct
 
   module Checked0 = struct
     type 'prover_state run_state =
-      ( 'prover_state
-      , R1CS_constraint_system.t
-      , Field.t )
-      Run_state.t
+      ('prover_state, Field.t) Run_state.t
 
     module T = struct
       type ('a, 's) t = ('a, 's, Field.t, unit run_state) Checked.t

--- a/src/snark_intf.ml
+++ b/src/snark_intf.ml
@@ -442,11 +442,7 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
     *)
 
     type 'prover_state run_state =
-      ( 'prover_state
-      , R1CS_constraint_system.t
-      , Field.t
-      , Field.Vector.t )
-      Run_state.t
+      ('prover_state, R1CS_constraint_system.t, Field.t) Run_state.t
 
     include
       Monad_let.S2
@@ -1328,11 +1324,7 @@ module type Run = sig
     end
 
     type 'prover_state run_state =
-      ( 'prover_state
-      , R1CS_constraint_system.t
-      , Field.Constant.t
-      , Field.Constant.Vector.t )
-      Run_state.t
+      ('prover_state, R1CS_constraint_system.t, Field.Constant.t) Run_state.t
 
     type ('var, 'value) t = ('var, 'value, field, unit run_state) Types.Typ.t
 

--- a/src/snark_intf.ml
+++ b/src/snark_intf.ml
@@ -441,8 +441,7 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
 ]}
     *)
 
-    type 'prover_state run_state =
-      ('prover_state, R1CS_constraint_system.t, Field.t) Run_state.t
+    type 'prover_state run_state = ('prover_state, Field.t) Run_state.t
 
     include
       Monad_let.S2
@@ -1324,7 +1323,7 @@ module type Run = sig
     end
 
     type 'prover_state run_state =
-      ('prover_state, R1CS_constraint_system.t, Field.Constant.t) Run_state.t
+      ('prover_state, Field.Constant.t) Run_state.t
 
     type ('var, 'value) t = ('var, 'value, field, unit run_state) Types.Typ.t
 

--- a/src/vector.ml
+++ b/src/vector.ml
@@ -2,10 +2,12 @@ open Ctypes
 open Foreign
 open Core
 
+type 'a t = unit ptr
+
 module type S = sig
   type elt
 
-  type t
+  type nonrec t = elt t
 
   val typ : t Ctypes.typ
 
@@ -39,7 +41,7 @@ module Make (Elt : sig
 end) : S with type elt = Elt.t = struct
   type elt = Elt.t
 
-  type t = unit ptr
+  type nonrec t = elt t
 
   let typ = ptr void
 

--- a/src/vector.mli
+++ b/src/vector.mli
@@ -1,0 +1,47 @@
+open Core
+
+type 'a t
+
+module type S = sig
+  type elt
+
+  type nonrec t = elt t
+
+  val typ : t Ctypes.typ
+
+  val delete : t -> unit
+
+  val create : unit -> t
+
+  val get : t -> int -> elt
+
+  val emplace_back : t -> elt -> unit
+
+  val length : t -> int
+end
+
+module type S_binable = sig
+  include S
+
+  include Binable.S with type t := t
+end
+
+module Make (Elt : sig
+  type t
+
+  val typ : t Ctypes.typ
+
+  val schedule_delete : t -> unit
+
+  val prefix : string
+end) : S with type elt = Elt.t
+
+module Make_binable (Elt : sig
+  type t [@@deriving bin_io]
+
+  val typ : t Ctypes.typ
+
+  val schedule_delete : t -> unit
+
+  val prefix : string
+end) : S_binable with type elt = Elt.t


### PR DESCRIPTION
This PR
- creates a generalised `'a Vector.t` representing a vector of `'a`s
- adds types with phantom parameters in a `Backend_types` module with a module constructor that ties them to the relevant field.
  * these types are opaque, so they will not unify (even though they are all secretly `void ptr`s)
- uses this to remove some unnecessary type parameters

This will let us lift more things out of `Snark0` (e.g. `Data_spec` once I pull some more parameters out of `Typ.t`), and also makes it much easier to unify the monadic and imperative APIs -- which will make the imperative API much less inefficient!

Basic sanity check:
```ocaml
let () = ignore Backends.Mnt4.(Linear_combination.Vector.emplace_back (Field.Vector.create ()) (Linear_combination.create ()))
```

```
Error: This expression has type Field.Vector.t = Field0.t Vector.t
       but an expression was expected of type
         Linear_combination.Vector.t = Linear_combination.Vector.elt Vector.t
       Type Field0.t is not compatible with type
         Linear_combination.Vector.elt =
           Field0.t Backend_types.Linear_combination.t
```