### PR TITLE
Functor over checked

### DIFF
--- a/src/as_prover.mli
+++ b/src/as_prover.mli
@@ -3,7 +3,7 @@ module type Basic = sig
 
   type 'f field
 
-  module Checked : Checked_intf.S
+  type ('a, 's, 'f) checked
 
   include Monad_let.S3 with type ('a, 'f, 's) t := ('a, 'f field, 's) t
 
@@ -27,7 +27,7 @@ module type Basic = sig
   val read_var : 'f field Cvar.t -> ('f field, 'f field, 's) t
 
   val read :
-       ('var, 'value, 'f field, (unit, unit, 'f field) Checked.t) Types.Typ.t
+       ('var, 'value, 'f field, (unit, unit, 'f field) checked) Types.Typ.t
     -> 'var
     -> ('value, 'f field, 'prover_state) t
 
@@ -36,7 +36,7 @@ module type Basic = sig
 
     val create :
          ('a, 'f field, 'prover_state) as_prover
-      -> ('a t, 'prover_state, 'f field) Checked.t
+      -> ('a t, 'prover_state, 'f field) checked
 
     val get : 'a t -> ('a, 'f field, _) as_prover
 
@@ -58,22 +58,24 @@ end
 
 module Make_basic (Checked : Checked_intf.S) :
   Basic
-  with type 'f field = 'f
+  with type 'f field = 'f Checked.field
    and type ('a, 'f, 's) t = ('a, 'f, 's) As_prover0.t
-  with module Checked := Checked
+   and type ('a, 's, 'f) checked := ('a, 's, 'f) Checked.t
 
 include
   Basic
   with type 'f field := 'f
    and type ('a, 'f, 's) t = ('a, 'f, 's) As_prover0.t
-  with module Checked := Checked
+   and type ('a, 's, 'f) checked := ('a, 's, 'f) Checked.t
 
 module Make (Env : sig
   type field
 end)
-(Checked : Checked_intf.S)
-(Basic : Basic with type 'f field := Env.field with module Checked := Checked) :
+(Checked : Checked_intf.S with type 'f field := Env.field)
+(Basic : Basic
+         with type 'f field := Env.field
+          and type ('a, 's, 'f) checked := ('a, 's, 'f) Checked.t) :
   S
   with type field := Env.field
    and type ('a, 's) t = ('a, Env.field, 's) Basic.t
-  with module Checked := Checked
+   and type ('a, 's, 'f) checked := ('a, 's, 'f) Checked.t

--- a/src/checked.ml
+++ b/src/checked.ml
@@ -46,9 +46,13 @@ module T0 = struct
     | Next_auxiliary k -> Next_auxiliary (fun x -> bind (k x) ~f)
 end
 
-module Basic : Checked_intf.Basic with type ('a, 's, 'f) t = ('a, 's, 'f) t =
-struct
+module Basic :
+  Checked_intf.Basic
+  with type ('a, 's, 'f) t = ('a, 's, 'f) t
+   and type 'f field = 'f = struct
   type nonrec ('a, 's, 'f) t = ('a, 's, 'f) t
+
+  type 'f field = 'f
 
   include Monad_let.Make3 (T0)
 
@@ -70,12 +74,14 @@ struct
 end
 
 module Make (Basic : Checked_intf.Basic) :
-  Checked_intf.S with type ('a, 's, 'f) t = ('a, 's, 'f) Basic.t = struct
+  Checked_intf.S
+  with type ('a, 's, 'f) t = ('a, 's, 'f) Basic.t
+   and type 'f field = 'f Basic.field = struct
   include Basic
 
   let request_witness
-      (typ : ('var, 'value, 'field, (unit, unit, 'field) t) Types.Typ.t)
-      (r : ('value Request.t, 'field, 's) As_prover0.t) =
+      (typ : ('var, 'value, 'f field, (unit, unit, 'f field) t) Types.Typ.t)
+      (r : ('value Request.t, 'f field, 's) As_prover0.t) =
     let%map h = exists typ (Request r) in
     Handle.var h
 
@@ -142,7 +148,11 @@ end
 
 module T = struct
   include (
-    Make (Basic) : Checked_intf.S with type ('a, 's, 'f) t := ('a, 's, 'f) t)
+    Make
+      (Basic) :
+      Checked_intf.S
+      with type ('a, 's, 'f) t := ('a, 's, 'f) t
+       and type 'f field = 'f )
 end
 
 include T

--- a/src/checked_intf.ml
+++ b/src/checked_intf.ml
@@ -92,3 +92,14 @@ module type S = sig
   val assert_equal :
     ?label:Base.string -> 'f Cvar.t -> 'f Cvar.t -> (unit, 's, 'f) t
 end
+
+module type Extended = sig
+  include S
+
+  type field
+
+  val run :
+       ('a, 's, field) t
+    -> ('s, field) Types.Run_state.t
+    -> ('s, field) Types.Run_state.t * 'a
+end

--- a/src/checked_intf.ml
+++ b/src/checked_intf.ml
@@ -1,55 +1,60 @@
 module type Basic = sig
   type ('a, 's, 'f) t
 
+  type 'f field
+
   include Monad_let.S3 with type ('a, 's, 'f) t := ('a, 's, 'f) t
 
-  val add_constraint : 'f Cvar.t Constraint.t -> (unit, 's, 'f) t
+  val add_constraint : 'f field Cvar.t Constraint.t -> (unit, 's, 'f field) t
 
-  val as_prover : (unit, 'f, 's) As_prover0.t -> (unit, 's, 'f) t
+  val as_prover : (unit, 'f field, 's) As_prover0.t -> (unit, 's, 'f field) t
 
-  val with_label : string -> ('a, 's, 'f) t -> ('a, 's, 'f) t
+  val with_label : string -> ('a, 's, 'f field) t -> ('a, 's, 'f field) t
 
   val with_state :
-       ('s1, 'f, 's) As_prover0.t
-    -> ('s1 -> (unit, 'f, 's) As_prover0.t)
-    -> ('a, 's1, 'f) t
-    -> ('a, 's, 'f) t
+       ('s1, 'f field, 's) As_prover0.t
+    -> ('s1 -> (unit, 'f field, 's) As_prover0.t)
+    -> ('a, 's1, 'f field) t
+    -> ('a, 's, 'f field) t
 
-  val with_handler : Request.Handler.single -> ('a, 's, 'f) t -> ('a, 's, 'f) t
+  val with_handler :
+    Request.Handler.single -> ('a, 's, 'f field) t -> ('a, 's, 'f field) t
 
-  val clear_handler : ('a, 's, 'f) t -> ('a, 's, 'f) t
+  val clear_handler : ('a, 's, 'f field) t -> ('a, 's, 'f field) t
 
   val exists :
-       ('var, 'value, 'f, (unit, unit, 'f) t) Types.Typ.t
-    -> ('value, 'f, 's) Provider.t
-    -> (('var, 'value) Handle.t, 's, 'f) t
+       ('var, 'value, 'f field, (unit, unit, 'f field) t) Types.Typ.t
+    -> ('value, 'f field, 's) Provider.t
+    -> (('var, 'value) Handle.t, 's, 'f field) t
 
-  val next_auxiliary : (int, 's, 'f) t
+  val next_auxiliary : (int, 's, 'f field) t
 end
 
 module type S = sig
   type ('a, 's, 'f) t
 
+  type 'f field
+
   include Monad_let.S3 with type ('a, 's, 'f) t := ('a, 's, 'f) t
 
-  val as_prover : (unit, 'f, 's) As_prover0.t -> (unit, 's, 'f) t
+  val as_prover : (unit, 'f field, 's) As_prover0.t -> (unit, 's, 'f field) t
 
   val request_witness :
-       ('var, 'value, 'f, (unit, unit, 'f) t) Types.Typ.t
-    -> ('value Request.t, 'f, 's) As_prover0.t
-    -> ('var, 's, 'f) t
+       ('var, 'value, 'f field, (unit, unit, 'f field) t) Types.Typ.t
+    -> ('value Request.t, 'f field, 's) As_prover0.t
+    -> ('var, 's, 'f field) t
 
   val request :
-       ?such_that:('var -> (unit, 's, 'field) t)
-    -> ('var, 'value, 'field, (unit, unit, 'field) t) Types.Typ.t
+       ?such_that:('var -> (unit, 's, 'f field) t)
+    -> ('var, 'value, 'f field, (unit, unit, 'f field) t) Types.Typ.t
     -> 'value Request.t
-    -> ('var, 's, 'field) t
+    -> ('var, 's, 'f field) t
 
   val exists :
-       ?request:('value Request.t, 'f, 's) As_prover0.t
-    -> ?compute:('value, 'f, 's) As_prover0.t
-    -> ('var, 'value, 'f, (unit, unit, 'f) t) Types.Typ.t
-    -> ('var, 's, 'f) t
+       ?request:('value Request.t, 'f field, 's) As_prover0.t
+    -> ?compute:('value, 'f field, 's) As_prover0.t
+    -> ('var, 'value, 'f field, (unit, unit, 'f field) t) Types.Typ.t
+    -> ('var, 's, 'f field) t
 
   type response = Request.response
 
@@ -61,45 +66,69 @@ module type S = sig
         ; respond: 'a Request.Response.t -> response }
         -> request
 
-  val handle : ('a, 's, 'f) t -> (request -> response) -> ('a, 's, 'f) t
+  val handle :
+    ('a, 's, 'f field) t -> (request -> response) -> ('a, 's, 'f field) t
 
-  val next_auxiliary : (int, 's, 'f) t
+  val next_auxiliary : (int, 's, 'f field) t
 
-  val with_label : string -> ('a, 's, 'f) t -> ('a, 's, 'f) t
+  val with_label : string -> ('a, 's, 'f field) t -> ('a, 's, 'f field) t
 
   val with_state :
-       ?and_then:('s1 -> (unit, 'f, 's) As_prover0.t)
-    -> ('s1, 'f, 's) As_prover0.t
-    -> ('a, 's1, 'f) t
-    -> ('a, 's, 'f) t
+       ?and_then:('s1 -> (unit, 'f field, 's) As_prover0.t)
+    -> ('s1, 'f field, 's) As_prover0.t
+    -> ('a, 's1, 'f field) t
+    -> ('a, 's, 'f field) t
 
   val assert_ :
-    ?label:Base.string -> 'f Cvar.t Constraint.t -> (unit, 's, 'f) t
+       ?label:Base.string
+    -> 'f field Cvar.t Constraint.t
+    -> (unit, 's, 'f field) t
 
   val assert_r1cs :
        ?label:Base.string
-    -> 'f Cvar.t
-    -> 'f Cvar.t
-    -> 'f Cvar.t
-    -> (unit, 's, 'f) t
+    -> 'f field Cvar.t
+    -> 'f field Cvar.t
+    -> 'f field Cvar.t
+    -> (unit, 's, 'f field) t
 
   val assert_square :
-    ?label:Base.string -> 'f Cvar.t -> 'f Cvar.t -> (unit, 's, 'f) t
+       ?label:Base.string
+    -> 'f field Cvar.t
+    -> 'f field Cvar.t
+    -> (unit, 's, 'f field) t
 
   val assert_all :
-    ?label:Base.string -> 'f Cvar.t Constraint.t list -> (unit, 's, 'f) t
+       ?label:Base.string
+    -> 'f field Cvar.t Constraint.t list
+    -> (unit, 's, 'f field) t
 
   val assert_equal :
-    ?label:Base.string -> 'f Cvar.t -> 'f Cvar.t -> (unit, 's, 'f) t
+       ?label:Base.string
+    -> 'f field Cvar.t
+    -> 'f field Cvar.t
+    -> (unit, 's, 'f field) t
 end
 
 module type Extended = sig
-  include S
-
   type field
+
+  include S with type 'f field := field
 
   val run :
        ('a, 's, field) t
     -> ('s, field) Types.Run_state.t
     -> ('s, field) Types.Run_state.t * 'a
+end
+
+module Unextend (Checked : Extended) :
+  S
+  with type 'f field = Checked.field
+   and type ('a, 's, 'f) t = ('a, 's, 'f) Checked.t = struct
+  include (
+    Checked :
+      S
+      with type 'f field := Checked.field
+       and type ('a, 's, 'f) t = ('a, 's, 'f) Checked.t )
+
+  type 'f field = Checked.field
 end

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -280,8 +280,7 @@ module Runner = struct
   end
 end
 
-module Make_basic (Backend : Backend_intf.S) = struct
-  module Backend = Backend_extended.Make (Backend)
+module Make_basic (Backend : Backend_extended.S) = struct
   open Backend
 
   type field = Field.t
@@ -1629,7 +1628,8 @@ module Make_basic (Backend : Backend_intf.S) = struct
 end
 
 module Make (Backend : Backend_intf.S) = struct
-  module Basic = Make_basic (Backend)
+  module Backend_extended = Backend_extended.Make (Backend)
+  module Basic = Make_basic (Backend_extended)
   include Basic
   module Number = Number.Make (Basic)
   module Enumerable = Enumerable.Make (Basic)

--- a/src/typ.ml
+++ b/src/typ.ml
@@ -86,8 +86,8 @@ module Make (Checked : Checked_intf.S) = struct
         =
       alloc
 
-    let check (type field) ({check; _} : ('var, 'value, field) t) (v : 'var) :
-        (unit, 's, field) Checked.t =
+    let check (type field) ({check; _} : ('var, 'value, field Checked.field) t)
+        (v : 'var) : (unit, 's, field Checked.field) Checked.t =
       Checked.with_state (As_prover0.return ()) (check v)
 
     let unit () : (unit, unit, 'field) t =


### PR DESCRIPTION
**NOTE: This PR includes the contents of PRs #155 and #156. The new commits start at 52d01cb2d662c76f669af130c348292901d6ebf7.**

This PR
* extracts `Checked.Runner` into its own functor
* functors `Make_basic` over `Backend_extended.S` and `Checked_intf.Extended`
* generalises `Checked_intf.Basic` and `.S` with a `field` constraint type

It is now easy to create a `Snark_intf.Basic` with any type that implements the `Checked_intf.Basic` interface, which brings us most of the way to faster and better imperative interfaces. Last remaining awkward piece is abstracting `Typ.t` over `Checked.t`, which will come in a separate PR.