### PR TITLE
Functor Typ.t over Checked_intf

### DIFF
--- a/src/checked.ml
+++ b/src/checked.ml
@@ -71,7 +71,8 @@ module Make (Basic : Checked_intf.Basic) :
   Checked_intf.S with type ('a, 's, 'f) t = ('a, 's, 'f) Basic.t = struct
   include Basic
 
-  let request_witness (typ : ('var, 'value, 'field) Types.Typ.t)
+  let request_witness
+      (typ : ('var, 'value, 'field, (unit, unit, 'field) t) Types.Typ.t)
       (r : ('value Request.t, 'field, 's) As_prover0.t) =
     let%map h = exists typ (Request r) in
     Handle.var h

--- a/src/checked_intf.ml
+++ b/src/checked_intf.ml
@@ -20,7 +20,7 @@ module type Basic = sig
   val clear_handler : ('a, 's, 'f) t -> ('a, 's, 'f) t
 
   val exists :
-       ('var, 'value, 'f) Types.Typ.t
+       ('var, 'value, 'f, (unit, unit, 'f) t) Types.Typ.t
     -> ('value, 'f, 's) Provider.t
     -> (('var, 'value) Handle.t, 's, 'f) t
 
@@ -35,20 +35,20 @@ module type S = sig
   val as_prover : (unit, 'f, 's) As_prover0.t -> (unit, 's, 'f) t
 
   val request_witness :
-       ('var, 'value, 'f) Types.Typ.t
+       ('var, 'value, 'f, (unit, unit, 'f) t) Types.Typ.t
     -> ('value Request.t, 'f, 's) As_prover0.t
     -> ('var, 's, 'f) t
 
   val request :
        ?such_that:('var -> (unit, 's, 'field) t)
-    -> ('var, 'value, 'field) Types.Typ.t
+    -> ('var, 'value, 'field, (unit, unit, 'field) t) Types.Typ.t
     -> 'value Request.t
     -> ('var, 's, 'field) t
 
   val exists :
        ?request:('value Request.t, 'f, 's) As_prover0.t
     -> ?compute:('value, 'f, 's) As_prover0.t
-    -> ('var, 'value, 'f) Types.Typ.t
+    -> ('var, 'value, 'f, (unit, unit, 'f) t) Types.Typ.t
     -> ('var, 's, 'f) t
 
   type response = Request.response

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -284,51 +284,20 @@ module Make_basic (Backend : Backend_intf.S) = struct
   end
 
   module Typ = struct
-    open Types.Typ
+    include Types.Typ.T
+    module T = Typ.Make (Checked)
     include Typ_monads
-    include Typ.T
+    include T.T
 
-    type ('var, 'value) t = ('var, 'value, Field.t) Types.Typ.t
-
-    type ('var, 'value) typ = ('var, 'value) t
+    type ('var, 'value) t = ('var, 'value, Field.t) T.t
 
     module Data_spec = struct
-      (** TODO: This exists only to bring the constructors into scope in this
-                module. Upstream a patch to permit different arities in types
-                with a different arity type manifest.
-      *)
-      type ('r_var, 'r_value, 'k_var, 'k_value, 'field) data_spec =
-                                                                   ( 'r_var
-                                                                   , 'r_value
-                                                                   , 'k_var
-                                                                   , 'k_value
-                                                                   , 'field )
-                                                                   Typ
-                                                                   .Data_spec
-                                                                   .t =
-        | ( :: ) :
-            ('var, 'value, 'f) Types.Typ.t
-            * ('r_var, 'r_value, 'k_var, 'k_value, 'f) data_spec
-            -> ( 'r_var
-               , 'r_value
-               , 'var -> 'k_var
-               , 'value -> 'k_value
-               , 'f )
-               data_spec
-        | [] : ('r_var, 'r_value, 'r_var, 'r_value, 'f) data_spec
+      include Typ.Data_spec0
 
       type ('r_var, 'r_value, 'k_var, 'k_value) t =
-        ('r_var, 'r_value, 'k_var, 'k_value, field) Typ.Data_spec.t
+        ('r_var, 'r_value, 'k_var, 'k_value, field) T.Data_spec.t
 
-      let size t =
-        let rec go : type r_var r_value k_var k_value.
-            int -> (r_var, r_value, k_var, k_value) t -> int =
-         fun acc t ->
-          match t with
-          | [] -> acc
-          | {alloc; _} :: t' -> go (acc + Alloc.size alloc) t'
-        in
-        go 0 t
+      let size t = T.Data_spec.size t
     end
 
     let unit : (unit, unit) t = unit ()

--- a/src/snark_intf.ml
+++ b/src/snark_intf.ml
@@ -141,24 +141,7 @@ module type Basic = sig
     (** [size [typ1; ...; typn]] returns the number of {!type:Var.t} variables
         allocated by allocating [typ1], followed by [typ2], etc. *)
 
-    type ('r_var, 'r_value, 'k_var, 'k_value, 'field) data_spec =
-                                                                 ( 'r_var
-                                                                 , 'r_value
-                                                                 , 'k_var
-                                                                 , 'k_value
-                                                                 , 'field )
-                                                                 Typ0.Data_spec
-                                                                 .t =
-      | ( :: ) :
-          ('var, 'value, 'f) Typ0.t
-          * ('r_var, 'r_value, 'k_var, 'k_value, 'f) data_spec
-          -> ( 'r_var
-             , 'r_value
-             , 'var -> 'k_var
-             , 'value -> 'k_value
-             , 'f )
-             data_spec
-      | [] : ('r_var, 'r_value, 'r_var, 'r_value, 'f) data_spec
+    include module type of Typ0.Data_spec0
   end
   
   (** Mappings from OCaml types to R1CS variables and constraints. *)
@@ -242,7 +225,8 @@ module type Basic = sig
           example, that a [Boolean.t] is either a {!val:Field.zero} or a
           {!val:Field.one}.
     *)
-    type ('var, 'value) t = ('var, 'value, Field.t) Types.Typ.t
+    type ('var, 'value) t =
+      ('var, 'value, Field.t, (unit, unit) Checked.t) Types.Typ.t
 
     (** Accessors for {!type:Types.Typ.t} fields: *)
 
@@ -353,6 +337,8 @@ module type Basic = sig
       val typ :
         template:unit T.t -> ('var, 'value) t -> ('var T.t, 'value T.t) t
     end
+
+    include module type of Types.Typ.T
   end
   
   (** Representation of booleans within a field.
@@ -1366,24 +1352,7 @@ module type Run = sig
     (** [size [typ1; ...; typn]] returns the number of {!type:Var.t} variables
         allocated by allocating [typ1], followed by [typ2], etc. *)
 
-    type ('r_var, 'r_value, 'k_var, 'k_value, 'field) data_spec =
-                                                                 ( 'r_var
-                                                                 , 'r_value
-                                                                 , 'k_var
-                                                                 , 'k_value
-                                                                 , 'field )
-                                                                 Typ0.Data_spec
-                                                                 .t =
-      | ( :: ) :
-          ('var, 'value, 'f) Types.Typ.t
-          * ('r_var, 'r_value, 'k_var, 'k_value, 'f) data_spec
-          -> ( 'r_var
-             , 'r_value
-             , 'var -> 'k_var
-             , 'value -> 'k_value
-             , 'f )
-             data_spec
-      | [] : ('r_var, 'r_value, 'r_var, 'r_value, 'f) data_spec
+    include module type of Typ0.Data_spec0
   end
   
   (** Mappings from OCaml types to R1CS variables and constraints. *)
@@ -1409,7 +1378,8 @@ module type Run = sig
     type 'prover_state run_state =
       ('prover_state, Field.Constant.t) Types.Run_state.t
 
-    type ('var, 'value) t = ('var, 'value, field) Types.Typ.t
+    type ('var, 'value) t =
+      ('var, 'value, field, (unit, unit, field) Checked.t) Types.Typ.t
 
     (** Accessors for {!type:Types.Typ.t} fields: *)
 

--- a/src/typ.ml
+++ b/src/typ.ml
@@ -1,10 +1,7 @@
 open Core_kernel
+open Types.Typ
 
-type ('var, 'value, 'field) t = ('var, 'value, 'field) Types.Typ.t
-
-type ('var, 'value, 'field) typ = ('var, 'value, 'field) t
-
-module Data_spec = struct
+module Data_spec0 = struct
   (** A list of {!type:Type.Typ.t} values, describing the inputs to a checked
       computation. The type [('r_var, 'r_value, 'k_var, 'k_value, 'field) t]
       represents
@@ -12,7 +9,9 @@ module Data_spec = struct
       - ['r_value] is the OCaml type of the result
       - ['k_var] is the type of the computation within the R1CS
       - ['k_value] is the type of the result within the R1CS
-      - ['field] is the field over which the R1CS operates.
+      - ['field] is the field over which the R1CS operates
+      - ['checked] is the type of checked computation that verifies the stored
+        contents as R1CS variables.
 
       This functions the same as OCaml's default list type:
 {[
@@ -29,253 +28,282 @@ module Data_spec = struct
 ]}
       all function as you would expect.
   *)
-  type ('r_var, 'r_value, 'k_var, 'k_value, 'f) t =
+  type ('r_var, 'r_value, 'k_var, 'k_value, 'f, 'checked) data_spec =
     | ( :: ) :
-        ('var, 'value, 'f) typ * ('r_var, 'r_value, 'k_var, 'k_value, 'f) t
-        -> ('r_var, 'r_value, 'var -> 'k_var, 'value -> 'k_value, 'f) t
-    | [] : ('r_var, 'r_value, 'r_var, 'r_value, 'f) t
-
-  let size t =
-    let rec go : type r_var r_value k_var k_value.
-        int -> (r_var, r_value, k_var, k_value, 'f) t -> int =
-     fun acc t ->
-      match t with
-      | [] -> acc
-      | {alloc; _} :: t' -> go (acc + Typ_monads.Alloc.size alloc) t'
-    in
-    go 0 t
+        ('var, 'value, 'f, 'checked) Types.Typ.t
+        * ('r_var, 'r_value, 'k_var, 'k_value, 'f, 'checked) data_spec
+        -> ( 'r_var
+           , 'r_value
+           , 'var -> 'k_var
+           , 'value -> 'k_value
+           , 'f
+           , 'checked )
+           data_spec
+    | [] : ('r_var, 'r_value, 'r_var, 'r_value, 'f, 'checked) data_spec
 end
 
-module T = struct
-  open Types.Typ
-  open Typ_monads
+module Make (Checked : Checked_intf.S) = struct
+  type ('var, 'value, 'field) t =
+    ('var, 'value, 'field, (unit, unit, 'field) Checked.t) Types.Typ.t
 
-  let store ({store; _} : ('var, 'value, 'field) t) (x : 'value) :
-      ('var, 'field) Store.t =
-    store x
+  type ('var, 'value, 'field) typ = ('var, 'value, 'field) t
 
-  let read ({read; _} : ('var, 'value, 'field) t) (v : 'var) :
-      ('value, 'field) Read.t =
-    read v
+  module Data_spec = struct
+    include Data_spec0
 
-  let alloc ({alloc; _} : ('var, 'value, 'field) t) : ('var, 'field) Alloc.t =
-    alloc
+    type ('r_var, 'r_value, 'k_var, 'k_value, 'f) t =
+      ( 'r_var
+      , 'r_value
+      , 'k_var
+      , 'k_value
+      , 'f
+      , (unit, unit, 'f) Checked.t )
+      data_spec
 
-  let check (type field) ({check; _} : ('var, 'value, field) t) (v : 'var) :
-      (unit, 's, field) Types.Checked.t =
-    let do_nothing : (unit, field, _) As_prover0.t = fun _ s -> (s, ()) in
-    With_state (do_nothing, (fun () -> do_nothing), check v, Checked.return)
-
-  let unit () : (unit, unit, 'field) t =
-    let s = Store.return () in
-    let r = Read.return () in
-    let c = Checked.return () in
-    { store= (fun () -> s)
-    ; read= (fun () -> r)
-    ; check= (fun () -> c)
-    ; alloc= Alloc.return () }
-
-  let field () : ('field Cvar.t, 'field, 'field) t =
-    { store= Store.store
-    ; read= Read.read
-    ; alloc= Alloc.alloc
-    ; check= (fun _ -> Checked.return ()) }
-
-  let transport ({read; store; alloc; check} : ('var1, 'value1, 'field) t)
-      ~(there : 'value2 -> 'value1) ~(back : 'value1 -> 'value2) :
-      ('var1, 'value2, 'field) t =
-    { alloc
-    ; store= (fun x -> store (there x))
-    ; read= (fun v -> Read.map ~f:back (read v))
-    ; check }
-
-  let transport_var ({read; store; alloc; check} : ('var1, 'value, 'field) t)
-      ~(there : 'var2 -> 'var1) ~(back : 'var1 -> 'var2) :
-      ('var2, 'value, 'field) t =
-    { alloc= Alloc.map alloc ~f:back
-    ; store= (fun x -> Store.map (store x) ~f:back)
-    ; read= (fun x -> read (there x))
-    ; check= (fun x -> check (there x)) }
-
-  let list ~length
-      ({read; store; alloc; check} : ('elt_var, 'elt_value, 'field) t) :
-      ('elt_var list, 'elt_value list, 'field) t =
-    let store ts =
-      let n = List.length ts in
-      if n <> length then
-        failwithf "Typ.list: Expected length %d, got %d" length n () ;
-      Store.all (List.map ~f:store ts)
-    in
-    let alloc = Alloc.all (List.init length ~f:(fun _ -> alloc)) in
-    let check ts = Checked.all_unit (List.map ts ~f:check) in
-    let read vs = Read.all (List.map vs ~f:read) in
-    {read; store; alloc; check}
-
-  (* TODO-someday: Make more efficient *)
-  let array ~length
-      ({read; store; alloc; check} : ('elt_var, 'elt_value, 'field) t) :
-      ('elt_var array, 'elt_value array, 'field) t =
-    let store ts =
-      assert (Array.length ts = length) ;
-      Store.map ~f:Array.of_list
-        (Store.all (List.map ~f:store (Array.to_list ts)))
-    in
-    let alloc =
-      let open Alloc.Let_syntax in
-      let%map vs = Alloc.all (List.init length ~f:(fun _ -> alloc)) in
-      Array.of_list vs
-    in
-    let read vs =
-      assert (Array.length vs = length) ;
-      Read.map ~f:Array.of_list
-        (Read.all (List.map ~f:read (Array.to_list vs)))
-    in
-    let check ts =
-      assert (Array.length ts = length) ;
-      let open Checked in
-      let rec go i =
-        if i = length then return ()
-        else
-          let%map () = check ts.(i) and () = go (i + 1) in
-          ()
+    let size t =
+      let rec go : type r_var r_value k_var k_value.
+          int -> (r_var, r_value, k_var, k_value, 'f) t -> int =
+       fun acc t ->
+        match t with
+        | [] -> acc
+        | {alloc; _} :: t' -> go (acc + Typ_monads.Alloc.size alloc) t'
       in
-      go 0
-    in
-    {read; store; alloc; check}
+      go 0 t
+  end
 
-  let tuple2 (typ1 : ('var1, 'value1, 'field) t)
-      (typ2 : ('var2, 'value2, 'field) t) :
-      ('var1 * 'var2, 'value1 * 'value2, 'field) t =
-    let alloc =
-      let open Alloc.Let_syntax in
-      let%map x = typ1.alloc and y = typ2.alloc in
-      (x, y)
-    in
-    let read (x, y) =
-      let open Read.Let_syntax in
-      let%map x = typ1.read x and y = typ2.read y in
-      (x, y)
-    in
-    let store (x, y) =
-      let open Store.Let_syntax in
-      let%map x = typ1.store x and y = typ2.store y in
-      (x, y)
-    in
-    let check (x, y) =
-      let open Checked in
-      let%map () = typ1.check x and () = typ2.check y in
-      ()
-    in
-    {read; store; alloc; check}
+  module T = struct
+    open Typ_monads
 
-  let ( * ) = tuple2
+    let store ({store; _} : ('var, 'value, 'field) t) (x : 'value) :
+        ('var, 'field) Store.t =
+      store x
 
-  let tuple3 (typ1 : ('var1, 'value1, 'field) t)
-      (typ2 : ('var2, 'value2, 'field) t) (typ3 : ('var3, 'value3, 'field) t) :
-      ('var1 * 'var2 * 'var3, 'value1 * 'value2 * 'value3, 'field) t =
-    let alloc =
-      let open Alloc.Let_syntax in
-      let%map x = typ1.alloc and y = typ2.alloc and z = typ3.alloc in
-      (x, y, z)
-    in
-    let read (x, y, z) =
-      let open Read.Let_syntax in
-      let%map x = typ1.read x and y = typ2.read y and z = typ3.read z in
-      (x, y, z)
-    in
-    let store (x, y, z) =
-      let open Store.Let_syntax in
-      let%map x = typ1.store x and y = typ2.store y and z = typ3.store z in
-      (x, y, z)
-    in
-    let check (x, y, z) =
-      let open Checked in
-      let%map () = typ1.check x and () = typ2.check y and () = typ3.check z in
-      ()
-    in
-    {read; store; alloc; check}
+    let read ({read; _} : ('var, 'value, 'field) t) (v : 'var) :
+        ('value, 'field) Read.t =
+      read v
 
-  let hlist (type k_var k_value)
-      (spec0 : (unit, unit, k_var, k_value, 'f) Data_spec.t) :
-      ((unit, k_var) H_list.t, (unit, k_value) H_list.t, 'f) t =
-    let store xs0 : _ Store.t =
-      let rec go : type k_var k_value.
-             (unit, unit, k_var, k_value, 'f) Data_spec.t
-          -> (unit, k_value) H_list.t
-          -> ((unit, k_var) H_list.t, 'f) Store.t =
-       fun spec0 xs0 ->
-        let open H_list in
-        match (spec0, xs0) with
-        | [], [] -> Store.return H_list.[]
-        | s :: spec, x :: xs ->
-            let open Store.Let_syntax in
-            let%map y = store s x and ys = go spec xs in
-            y :: ys
+    let alloc ({alloc; _} : ('var, 'value, 'field) t) : ('var, 'field) Alloc.t
+        =
+      alloc
+
+    let check (type field) ({check; _} : ('var, 'value, field) t) (v : 'var) :
+        (unit, 's, field) Checked.t =
+      Checked.with_state (As_prover0.return ()) (check v)
+
+    let unit () : (unit, unit, 'field) t =
+      let s = Store.return () in
+      let r = Read.return () in
+      let c = Checked.return () in
+      { store= (fun () -> s)
+      ; read= (fun () -> r)
+      ; check= (fun () -> c)
+      ; alloc= Alloc.return () }
+
+    let field () : ('field Cvar.t, 'field, 'field) t =
+      { store= Store.store
+      ; read= Read.read
+      ; alloc= Alloc.alloc
+      ; check= (fun _ -> Checked.return ()) }
+
+    let transport ({read; store; alloc; check} : ('var1, 'value1, 'field) t)
+        ~(there : 'value2 -> 'value1) ~(back : 'value1 -> 'value2) :
+        ('var1, 'value2, 'field) t =
+      { alloc
+      ; store= (fun x -> store (there x))
+      ; read= (fun v -> Read.map ~f:back (read v))
+      ; check }
+
+    let transport_var ({read; store; alloc; check} : ('var1, 'value, 'field) t)
+        ~(there : 'var2 -> 'var1) ~(back : 'var1 -> 'var2) :
+        ('var2, 'value, 'field) t =
+      { alloc= Alloc.map alloc ~f:back
+      ; store= (fun x -> Store.map (store x) ~f:back)
+      ; read= (fun x -> read (there x))
+      ; check= (fun x -> check (there x)) }
+
+    let list ~length
+        ({read; store; alloc; check} : ('elt_var, 'elt_value, 'field) t) :
+        ('elt_var list, 'elt_value list, 'field) t =
+      let store ts =
+        let n = List.length ts in
+        if n <> length then
+          failwithf "Typ.list: Expected length %d, got %d" length n () ;
+        Store.all (List.map ~f:store ts)
       in
-      go spec0 xs0
-    in
-    let read xs0 : ((unit, k_value) H_list.t, 'f) Read.t =
-      let rec go : type k_var k_value.
-             (unit, unit, k_var, k_value, 'f) Data_spec.t
-          -> (unit, k_var) H_list.t
-          -> ((unit, k_value) H_list.t, 'f) Read.t =
-       fun spec0 xs0 ->
-        let open H_list in
-        match (spec0, xs0) with
-        | [], [] -> Read.return H_list.[]
-        | s :: spec, x :: xs ->
-            let open Read.Let_syntax in
-            let%map y = read s x and ys = go spec xs in
-            y :: ys
+      let alloc = Alloc.all (List.init length ~f:(fun _ -> alloc)) in
+      let check ts = Checked.all_unit (List.map ts ~f:check) in
+      let read vs = Read.all (List.map vs ~f:read) in
+      {read; store; alloc; check}
+
+    (* TODO-someday: Make more efficient *)
+    let array ~length
+        ({read; store; alloc; check} : ('elt_var, 'elt_value, 'field) t) :
+        ('elt_var array, 'elt_value array, 'field) t =
+      let store ts =
+        assert (Array.length ts = length) ;
+        Store.map ~f:Array.of_list
+          (Store.all (List.map ~f:store (Array.to_list ts)))
       in
-      go spec0 xs0
-    in
-    let alloc : _ Alloc.t =
-      let rec go : type k_var k_value.
-             (unit, unit, k_var, k_value, 'f) Data_spec.t
-          -> ((unit, k_var) H_list.t, 'f) Alloc.t =
-       fun spec0 ->
-        let open H_list in
-        match spec0 with
-        | [] -> Alloc.return H_list.[]
-        | s :: spec ->
-            let open Alloc.Let_syntax in
-            let%map y = alloc s and ys = go spec in
-            y :: ys
+      let alloc =
+        let open Alloc.Let_syntax in
+        let%map vs = Alloc.all (List.init length ~f:(fun _ -> alloc)) in
+        Array.of_list vs
       in
-      go spec0
-    in
-    let check xs0 : (unit, unit, 'f) Types.Checked.t =
-      let rec go : type k_var k_value.
-             (unit, unit, k_var, k_value, 'f) Data_spec.t
-          -> (unit, k_var) H_list.t
-          -> (unit, unit, 'f) Types.Checked.t =
-       fun spec0 xs0 ->
-        let open H_list in
-        let open Checked.Let_syntax in
-        match (spec0, xs0) with
-        | [], [] -> return ()
-        | s :: spec, x :: xs ->
-            let%map () = check s x and () = go spec xs in
+      let read vs =
+        assert (Array.length vs = length) ;
+        Read.map ~f:Array.of_list
+          (Read.all (List.map ~f:read (Array.to_list vs)))
+      in
+      let check ts =
+        assert (Array.length ts = length) ;
+        let open Checked in
+        let rec go i =
+          if i = length then return ()
+          else
+            let%map () = check ts.(i) and () = go (i + 1) in
             ()
+        in
+        go 0
       in
-      go spec0 xs0
-    in
-    {read; store; alloc; check}
+      {read; store; alloc; check}
 
-  (* TODO: Do a CPS style thing instead if it ends up being an issue converting
+    let tuple2 (typ1 : ('var1, 'value1, 'field) t)
+        (typ2 : ('var2, 'value2, 'field) t) :
+        ('var1 * 'var2, 'value1 * 'value2, 'field) t =
+      let alloc =
+        let open Alloc.Let_syntax in
+        let%map x = typ1.alloc and y = typ2.alloc in
+        (x, y)
+      in
+      let read (x, y) =
+        let open Read.Let_syntax in
+        let%map x = typ1.read x and y = typ2.read y in
+        (x, y)
+      in
+      let store (x, y) =
+        let open Store.Let_syntax in
+        let%map x = typ1.store x and y = typ2.store y in
+        (x, y)
+      in
+      let check (x, y) =
+        let open Checked in
+        let%map () = typ1.check x and () = typ2.check y in
+        ()
+      in
+      {read; store; alloc; check}
+
+    let ( * ) = tuple2
+
+    let tuple3 (typ1 : ('var1, 'value1, 'field) t)
+        (typ2 : ('var2, 'value2, 'field) t) (typ3 : ('var3, 'value3, 'field) t)
+        : ('var1 * 'var2 * 'var3, 'value1 * 'value2 * 'value3, 'field) t =
+      let alloc =
+        let open Alloc.Let_syntax in
+        let%map x = typ1.alloc and y = typ2.alloc and z = typ3.alloc in
+        (x, y, z)
+      in
+      let read (x, y, z) =
+        let open Read.Let_syntax in
+        let%map x = typ1.read x and y = typ2.read y and z = typ3.read z in
+        (x, y, z)
+      in
+      let store (x, y, z) =
+        let open Store.Let_syntax in
+        let%map x = typ1.store x and y = typ2.store y and z = typ3.store z in
+        (x, y, z)
+      in
+      let check (x, y, z) =
+        let open Checked in
+        let%map () = typ1.check x
+        and () = typ2.check y
+        and () = typ3.check z in
+        ()
+      in
+      {read; store; alloc; check}
+
+    let hlist (type k_var k_value)
+        (spec0 : (unit, unit, k_var, k_value, 'f) Data_spec.t) :
+        ((unit, k_var) H_list.t, (unit, k_value) H_list.t, 'f) t =
+      let store xs0 : _ Store.t =
+        let rec go : type k_var k_value.
+               (unit, unit, k_var, k_value, 'f) Data_spec.t
+            -> (unit, k_value) H_list.t
+            -> ((unit, k_var) H_list.t, 'f) Store.t =
+         fun spec0 xs0 ->
+          let open H_list in
+          match (spec0, xs0) with
+          | [], [] -> Store.return H_list.[]
+          | s :: spec, x :: xs ->
+              let open Store.Let_syntax in
+              let%map y = store s x and ys = go spec xs in
+              y :: ys
+        in
+        go spec0 xs0
+      in
+      let read xs0 : ((unit, k_value) H_list.t, 'f) Read.t =
+        let rec go : type k_var k_value.
+               (unit, unit, k_var, k_value, 'f) Data_spec.t
+            -> (unit, k_var) H_list.t
+            -> ((unit, k_value) H_list.t, 'f) Read.t =
+         fun spec0 xs0 ->
+          let open H_list in
+          match (spec0, xs0) with
+          | [], [] -> Read.return H_list.[]
+          | s :: spec, x :: xs ->
+              let open Read.Let_syntax in
+              let%map y = read s x and ys = go spec xs in
+              y :: ys
+        in
+        go spec0 xs0
+      in
+      let alloc : _ Alloc.t =
+        let rec go : type k_var k_value.
+               (unit, unit, k_var, k_value, 'f) Data_spec.t
+            -> ((unit, k_var) H_list.t, 'f) Alloc.t =
+         fun spec0 ->
+          let open H_list in
+          match spec0 with
+          | [] -> Alloc.return H_list.[]
+          | s :: spec ->
+              let open Alloc.Let_syntax in
+              let%map y = alloc s and ys = go spec in
+              y :: ys
+        in
+        go spec0
+      in
+      let check xs0 : (unit, unit, 'f) Checked.t =
+        let rec go : type k_var k_value.
+               (unit, unit, k_var, k_value, 'f) Data_spec.t
+            -> (unit, k_var) H_list.t
+            -> (unit, unit, 'f) Checked.t =
+         fun spec0 xs0 ->
+          let open H_list in
+          let open Checked in
+          match (spec0, xs0) with
+          | [], [] -> return ()
+          | s :: spec, x :: xs ->
+              let%map () = check s x and () = go spec xs in
+              ()
+        in
+        go spec0 xs0
+      in
+      {read; store; alloc; check}
+
+    (* TODO: Do a CPS style thing instead if it ends up being an issue converting
      back and forth. *)
-  let of_hlistable (spec : (unit, unit, 'k_var, 'k_value, 'f) Data_spec.t)
-      ~(var_to_hlist : 'var -> (unit, 'k_var) H_list.t)
-      ~(var_of_hlist : (unit, 'k_var) H_list.t -> 'var)
-      ~(value_to_hlist : 'value -> (unit, 'k_value) H_list.t)
-      ~(value_of_hlist : (unit, 'k_value) H_list.t -> 'value) :
-      ('var, 'value, 'f) t =
-    let {read; store; alloc; check} = hlist spec in
-    { read= (fun v -> Read.map ~f:value_of_hlist (read (var_to_hlist v)))
-    ; store= (fun x -> Store.map ~f:var_of_hlist (store (value_to_hlist x)))
-    ; alloc= Alloc.map ~f:var_of_hlist alloc
-    ; check= (fun v -> check (var_to_hlist v)) }
+    let of_hlistable (spec : (unit, unit, 'k_var, 'k_value, 'f) Data_spec.t)
+        ~(var_to_hlist : 'var -> (unit, 'k_var) H_list.t)
+        ~(var_of_hlist : (unit, 'k_var) H_list.t -> 'var)
+        ~(value_to_hlist : 'value -> (unit, 'k_value) H_list.t)
+        ~(value_of_hlist : (unit, 'k_value) H_list.t -> 'value) :
+        ('var, 'value, 'f) t =
+      let {read; store; alloc; check} = hlist spec in
+      { read= (fun v -> Read.map ~f:value_of_hlist (read (var_to_hlist v)))
+      ; store= (fun x -> Store.map ~f:var_of_hlist (store (value_to_hlist x)))
+      ; alloc= Alloc.map ~f:var_of_hlist alloc
+      ; check= (fun v -> check (var_to_hlist v)) }
+  end
 end
 
+include Make (Checked)
 include T

--- a/src/types.ml
+++ b/src/types.ml
@@ -1,12 +1,14 @@
-module rec Typ : sig
+module Typ = struct
   open Typ_monads
 
-  (** The type [('var, 'value, 'field, 'runner_state) t] describes a mapping from OCaml types
-      to the variables and constraints they represent:
+  module T = struct
+    (** The type [('var, 'value, 'field, 'checked) t] describes a mapping from
+      OCaml types to the variables and constraints they represent:
       - ['value] is the OCaml type
       - ['field] is the type of the field elements
       - ['var] is some other type that contains some R1CS variables
-      - ['runner_state] is the internal type of the checked computation evaluator.
+      - ['checked] is the type of checked computation that verifies the stored
+        contents as R1CS variables.
 
       For convenience and readability, it is usually best to have the ['var]
       type mirror the ['value] type in structure, for example:
@@ -21,15 +23,20 @@ module rec Typ : sig
     let or (x : t) = Snark.Boolean.(x.b1 || x.b2)
   end
 ]}*)
-  type ('var, 'value, 'field) t =
-    { store: 'value -> ('var, 'field) Store.t
-    ; read: 'var -> ('value, 'field) Read.t
-    ; alloc: ('var, 'field) Alloc.t
-    ; check: 'var -> (unit, unit, 'field) Checked.t }
-end =
-  Typ
+    type ('var, 'value, 'field, 'checked) typ =
+      { store: 'value -> ('var, 'field) Store.t
+      ; read: 'var -> ('value, 'field) Read.t
+      ; alloc: ('var, 'field) Alloc.t
+      ; check: 'var -> 'checked }
+  end
 
-and Checked : sig
+  include T
+
+  type ('var, 'value, 'field, 'checked) t =
+    ('var, 'value, 'field, 'checked) typ
+end
+
+module rec Checked : sig
   (* TODO-someday: Consider having an "Assembly" type with only a store constructor for straight up Var.t's
     that this gets compiled into. *)
 
@@ -65,7 +72,7 @@ and Checked : sig
         -> ('b, 's, 'f) t
     | Clear_handler : ('a, 's, 'f) t * ('a -> ('b, 's, 'f) t) -> ('b, 's, 'f) t
     | Exists :
-        ('var, 'value, 'f) Typ.t
+        ('var, 'value, 'f, (unit, unit, 'f) t) Typ.t
         * ('value, 'f, 's) Provider.t
         * (('var, 'value) Handle.t -> ('a, 's, 'f) t)
         -> ('a, 's, 'f) t


### PR DESCRIPTION
~~**NOTE: This PR includes the contents of PR #155. The new commits start at 2306cf9.**~~

This PR creates a functor over `Checked_intf.S` for `Typ`, so that the type of the checked computations in `Typ` and those in the rest of the `Snark_intf.S` match.

*Edit: rebased onto master, which now includes #155.*