### PR TITLE
Rework reduce_to_prover to keep the original AST

### DIFF
--- a/src/checked.ml
+++ b/src/checked.ml
@@ -14,7 +14,7 @@ module T0 = struct
     match t with
     | Pure x -> Pure (f x)
     | Direct (d, k) -> Direct (d, fun b -> map (k b) ~f)
-    | Reduced (t, d, k) -> Reduced (t, d, map k ~f)
+    | Reduced (t, d, res, k) -> Reduced (t, d, res, fun b -> map (k b) ~f)
     | With_label (s, t, k) -> With_label (s, t, fun b -> map (k b) ~f)
     | As_prover (x, k) -> As_prover (x, map k ~f)
     | Add_constraint (c, t1) -> Add_constraint (c, map t1 ~f)
@@ -33,7 +33,7 @@ module T0 = struct
     match t with
     | Pure x -> f x
     | Direct (d, k) -> Direct (d, fun b -> bind (k b) ~f)
-    | Reduced (t, d, k) -> Reduced (t, d, bind k ~f)
+    | Reduced (t, d, res, k) -> Reduced (t, d, res, fun b -> bind (k b) ~f)
     | With_label (s, t, k) -> With_label (s, t, fun b -> bind (k b) ~f)
     | As_prover (x, k) -> As_prover (x, bind k ~f)
     (* Someday: This case is probably a performance bug *)

--- a/src/checked.ml
+++ b/src/checked.ml
@@ -14,6 +14,7 @@ module T0 = struct
     match t with
     | Pure x -> Pure (f x)
     | Direct (d, k) -> Direct (d, fun b -> map (k b) ~f)
+    | Reduced (t, d, k) -> Reduced (t, d, map k ~f)
     | With_label (s, t, k) -> With_label (s, t, fun b -> map (k b) ~f)
     | As_prover (x, k) -> As_prover (x, map k ~f)
     | Add_constraint (c, t1) -> Add_constraint (c, map t1 ~f)
@@ -32,6 +33,7 @@ module T0 = struct
     match t with
     | Pure x -> f x
     | Direct (d, k) -> Direct (d, fun b -> bind (k b) ~f)
+    | Reduced (t, d, k) -> Reduced (t, d, bind k ~f)
     | With_label (s, t, k) -> With_label (s, t, fun b -> bind (k b) ~f)
     | As_prover (x, k) -> As_prover (x, bind k ~f)
     (* Someday: This case is probably a performance bug *)

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -481,12 +481,11 @@ module Make_basic (Backend : Backend_intf.S) = struct
             let s', y = run t {s with stack= lab :: stack} in
             run (k y) {s' with stack}
         | Add_constraint (c, t) ->
-            if s.eval_constraints && not (Constraint.eval c (get_value s)) then (
-              Constraint.print c (get_value s) ;
+            if s.eval_constraints && not (Constraint.eval c (get_value s)) then
               failwithf "Constraint unsatisfied:\n%s\n%s\n"
                 (Constraint.annotation c)
                 (Constraint.stack_to_string s.stack)
-                () ) ;
+                () ;
             Option.iter s.system ~f:(fun system ->
                 Constraint.add ~stack:s.stack c system ) ;
             run t s

--- a/src/snark_intf.ml
+++ b/src/snark_intf.ml
@@ -1182,20 +1182,38 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
   *)
 
   val reduce_to_prover :
-    (('a, 's) Checked.t, _, 'checked, _) Data_spec.t -> 'checked -> 'checked
-  (** Reduce a checked computation to be run as the prover.
+       ((unit, 's) Checked.t, Proof.t, 'k_var, 'k_value) Data_spec.t
+    -> 'k_var
+    -> Proving_key.t
+    -> ?handlers:Handler.t list
+    -> 's
+    -> 'k_value
+  (** Reduce a checked computation, then generate a proof.
 
-      This precomputes all parts of a {!type:Checked.t} except
-      {!module:As_prover} blocks, and creates a new checked computation that
-      uses this precomputed information to evaluate only the
-      {!module:As_prover} blocks.
+      [reduce_to_prover public_input computation] evaluates all parts of the
+      {!type:Checked.t} [computation] except {!module:As_prover} blocks, and
+      generates a program that can be used to generate proofs more quickly with
+      different inputs.
+
+      For example, for a checked computation [main] with inputs [inputs] and
+      proving key [pk],
+{[
+  let prove_main = reduce_to_prover inputs main
+
+  let proof1 = prove_main pk s1 input1a input1b input1c
+  let proof2 = prove_main pk s2 input2a input2b input2c
+  let proof3 = prove_main pk s3 input3a input3b input3c
+}]
+      is equivalent to
+{[
+  let proof1 = prove pk inputs s1 main input1a input1b input1c
+  let proof2 = prove pk inputs s2 main input2a input2b input2c
+  let proof3 = prove pk inputs s3 main input3a input3b input3c
+}]
 
       **WARNING**: Any code inside a [Checked.t] that isn't inside an
       [As_prover] block will only be run once. DO NOT USE if you use mutation
       inside [Checked.t].
-
-      The resulting checked computation will generate 0 constraints; use the
-      original checked computation if you need to generate a keypair.
   *)
 
   val constraint_count :

--- a/src/types.ml
+++ b/src/types.ml
@@ -45,6 +45,11 @@ and Checked : sig
         (('s, 'f) Run_state.t -> ('s, 'f) Run_state.t * 'a)
         * ('a -> ('b, 's, 'f) t)
         -> ('b, 's, 'f) t
+    | Reduced :
+        ('a, 's, 'f) t
+        * (('s, 'f) Run_state.t -> ('s, 'f) Run_state.t)
+        * ('b, 's, 'f) t
+        -> ('b, 's, 'f) t
     | Add_constraint :
         'f Cvar.t Constraint.t * ('a, 's, 'f) t
         -> ('a, 's, 'f) t

--- a/src/types.ml
+++ b/src/types.ml
@@ -48,7 +48,8 @@ and Checked : sig
     | Reduced :
         ('a, 's, 'f) t
         * (('s, 'f) Run_state.t -> ('s, 'f) Run_state.t)
-        * ('b, 's, 'f) t
+        * 'a
+        * ('a -> ('b, 's, 'f) t)
         -> ('b, 's, 'f) t
     | Add_constraint :
         'f Cvar.t Constraint.t * ('a, 's, 'f) t


### PR DESCRIPTION
This PR
- adds a `Reduced` constructor to `Checked.t` that carries a `reduce_to_prover`-ed version of a checked computation as well as the original `Checked.t`
- uses this to create a non-destructive version of `reduce_to_prover` -- ie. you can still use the `Checked.t` for everything, and the `reduce_to_prover` version will only be used for `prove`

This makes using and debugging `reduce_to_prover` much simpler.