### PR TITLE
Feature/prove aux args

### DIFF
--- a/src/backend_intf.ml
+++ b/src/backend_intf.ml
@@ -61,12 +61,17 @@ module type S = sig
   end
 
   module Proof : sig
+    type _ with_create_args
+
+    val proof_system_type : ('a, 'a with_create_args) Proof_system_type.t
+
     type t = Field.t Backend_types.Proof.t
 
     include Stringable.S with type t := t
 
     val create :
-      Proving_key.t -> primary:Field.Vector.t -> auxiliary:Field.Vector.t -> t
+      (Proving_key.t -> primary:Field.Vector.t -> auxiliary:Field.Vector.t -> t)
+      with_create_args
 
     val verify : t -> Verification_key.t -> Field.Vector.t -> bool
   end

--- a/src/backend_intf.ml
+++ b/src/backend_intf.ml
@@ -117,3 +117,8 @@ module type S = sig
     val create : R1CS_constraint_system.t -> t
   end
 end
+
+module type S_default = S with type 'a Proof.with_create_args = 'a
+
+module type S_signature_of_knowledge =
+  S with type 'a Proof.with_create_args = ?message:bool array -> 'a

--- a/src/dune
+++ b/src/dune
@@ -1,7 +1,7 @@
 (library
  (name snarky)
  (public_name snarky)
- (flags :standard -short-paths -safe-string -warn-error -27-32-9-39-6-34)
+ (flags :standard -short-paths -safe-string -warn-error -27-32-9-39-6-34-16)
  (inline_tests)
  (libraries core_kernel fold_lib tuple_lib bitstring_lib interval_union
    bignum camlsnark_c)

--- a/src/libsnark.ml
+++ b/src/libsnark.ml
@@ -1399,6 +1399,10 @@ struct
   include Make_proof_system_keys (M)
 
   module Proof : sig
+    type 'a with_create_args = 'a
+
+    val proof_system_type : ('a, 'a with_create_args) Proof_system_type.t
+
     type t = M.Field.t Backend_types.Proof.t
 
     val typ : t Ctypes.typ
@@ -1415,6 +1419,10 @@ struct
 
     val of_string : string -> t
   end = struct
+    type 'a with_create_args = 'a
+
+    let proof_system_type = Proof_system_type.standard
+
     include Proof.Make (struct
       let prefix = with_prefix M.prefix "proof"
 
@@ -1575,6 +1583,10 @@ struct
   end)
 
   module Proof = struct
+    type 'a with_create_args = ?message:bool array -> 'a
+
+    let proof_system_type = Proof_system_type.signature_of_knowledge
+
     module Pre = struct
       module Prefix = struct
         let prefix = with_prefix M.prefix "bg_proof"
@@ -2272,10 +2284,15 @@ module type S = sig
   module Proof : sig
     type t
 
+    type _ with_create_args
+
+    val proof_system_type : ('a, 'a with_create_args) Proof_system_type.t
+
     val typ : t Ctypes.typ
 
     val create :
-      Proving_key.t -> primary:Field.Vector.t -> auxiliary:Field.Vector.t -> t
+      (Proving_key.t -> primary:Field.Vector.t -> auxiliary:Field.Vector.t -> t)
+      with_create_args
 
     val verify : t -> Verification_key.t -> Field.Vector.t -> bool
 

--- a/src/proof_system_type.ml
+++ b/src/proof_system_type.ml
@@ -1,0 +1,10 @@
+open Core_kernel
+
+type ('a, 'b) t =
+  | Standard of ('b, 'a) Type_equal.t
+  | Signature_of_knowledge of ('b, ?message:bool array -> 'a) Type_equal.t
+
+let standard : ('a, 'a) t = Standard Type_equal.T
+
+let signature_of_knowledge : type a. (a, ?message:bool array -> a) t =
+  Signature_of_knowledge Type_equal.T

--- a/src/proof_system_type.mli
+++ b/src/proof_system_type.mli
@@ -1,0 +1,9 @@
+open Core_kernel
+
+type ('a, 'b) t =
+  | Standard of ('b, 'a) Type_equal.t
+  | Signature_of_knowledge of ('b, ?message:bool array -> 'a) Type_equal.t
+
+val standard : ('a, 'a) t
+
+val signature_of_knowledge : ('a, ?message:bool array -> 'a) t

--- a/src/snark0.mli
+++ b/src/snark0.mli
@@ -18,6 +18,7 @@ module Make (Backend : Backend_intf.S) :
    and type Verification_key.t = Backend.Verification_key.t
    and type Proving_key.t = Backend.Proving_key.t
    and type Proof.t = Backend.Proof.t
+   and type 'a with_prove_args = 'a Backend.Proof.with_create_args
 
 module Run : sig
   module Make (Backend : Backend_intf.S) :
@@ -30,6 +31,7 @@ module Run : sig
      and type Verification_key.t = Backend.Verification_key.t
      and type Proving_key.t = Backend.Proving_key.t
      and type Proof.t = Backend.Proof.t
+     and type 'a with_prove_args = 'a Backend.Proof.with_create_args
 end
 
 type 'field m = (module Snark_intf.Run with type field = 'field)

--- a/src/snark_intf.ml
+++ b/src/snark_intf.ml
@@ -1252,6 +1252,11 @@ module type S = sig
      and type t := M.t
 end
 
+module type S_standard = S with type 'a with_prove_args = 'a
+
+module type S_signature_of_knowledge =
+  S with type 'a with_prove_args = 'a sok_with_prove_args
+
 (** The imperative interface to Snarky. *)
 module type Run = sig
   type _ with_prove_args
@@ -1871,3 +1876,8 @@ module type Run = sig
   val constraint_count :
     ?log:(?start:bool -> string -> int -> unit) -> (unit -> 'a) -> int
 end
+
+module type Run_standard = S with type 'a with_prove_args = 'a
+
+module type Run_signature_of_knowledge =
+  S with type 'a with_prove_args = 'a sok_with_prove_args

--- a/src/snark_intf.ml
+++ b/src/snark_intf.ml
@@ -4,8 +4,12 @@ module Constraint0 = Constraint
 module Boolean0 = Boolean
 module Typ0 = Typ
 
+type 'a sok_with_prove_args = ?message:bool array -> 'a
+
 (** The base interface to Snarky. *)
 module type Basic = sig
+  type _ with_prove_args
+
   (** The {!module:Backend_intf.S.Proving_key} module from the backend. *)
   module Proving_key : sig
     type t [@@deriving bin_io]
@@ -956,8 +960,7 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
       -> ?proving_key:Proving_key.t
       -> ?handlers:Handler.t list
       -> ('a, 's, 'public_input) t
-      -> 's
-      -> Proof.t
+      -> ('s -> Proof.t) with_prove_args
     (** Run the checked computation as the prover, generating a {!type:Proof.t}
         that the verifier may check efficiently.
         - The [proving_key] argument overrides the argument given to
@@ -1001,8 +1004,7 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
          run:('a, 't) t
       -> Proving_key.t
       -> ('t, Proof.t, 'k_var, 'k_value) Data_spec.t
-      -> 'k_var
-      -> 'k_value
+      -> ('k_var -> 'k_value) with_prove_args
 
     val verify :
          Proof.t
@@ -1145,8 +1147,7 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
        Proving_key.t
     -> ((unit, 's) Checked.t, Proof.t, 'k_var, 'k_value) Data_spec.t
     -> 's
-    -> 'k_var
-    -> 'k_value
+    -> ('k_var -> 'k_value) with_prove_args
   (** Run the checked computation, creating a proof that it has been run
       correctly (ie. satisfies its constraints).
   *)
@@ -1253,6 +1254,8 @@ end
 
 (** The imperative interface to Snarky. *)
 module type Run = sig
+  type _ with_prove_args
+
   (** The {!module:Backend_intf.S.Proving_key} module from the backend. *)
   module Proving_key : sig
     type t [@@deriving bin_io]
@@ -1794,8 +1797,7 @@ module type Run = sig
          public_input:(unit, 'public_input) H_list.t
       -> ?proving_key:Proving_key.t
       -> ?handlers:Handler.t list
-      -> ('a, 'public_input) t
-      -> Proof.t
+      -> (('a, 'public_input) t -> Proof.t) with_prove_args
 
     val verify :
          public_input:(unit, 'public_input) H_list.t
@@ -1852,8 +1854,7 @@ module type Run = sig
   val prove :
        Proving_key.t
     -> (unit -> 'a, Proof.t, 'k_var, 'k_value) Data_spec.t
-    -> 'k_var
-    -> 'k_value
+    -> ('k_var -> 'k_value) with_prove_args
 
   val verify :
        Proof.t


### PR DESCRIPTION
This PR makes it possible for the `prove` functions to take additional arguments for certain backends. This is motivated by the implementation of the BG snark, which is a signature-of-knowledge, meaning the "prove" function can take a "message" for which the proof is like a digital-signature of that message (with respect to the fact that the signer was able to provide a witness for the corresponding snarky program).

I had to turn off error-warning 16 (which says an optional argument can't be erased) because the OCaml compiler doesn't realize it gets erased for some instantiation of the functor. There is only one line which triggers this warning though and it would be nice not to turn it off in general. Is there a way to disable a warning for a particular instance of that warning?