### PR TITLE
Add a Proof.message type and an optional message argument to prove/verify

### DIFF
--- a/src/backend_intf.ml
+++ b/src/backend_intf.ml
@@ -61,14 +61,21 @@ module type S = sig
   end
 
   module Proof : sig
+    type message
+
     type t = Field.t Backend_types.Proof.t
 
     include Stringable.S with type t := t
 
     val create :
-      Proving_key.t -> primary:Field.Vector.t -> auxiliary:Field.Vector.t -> t
+         ?message:message
+      -> Proving_key.t
+      -> primary:Field.Vector.t
+      -> auxiliary:Field.Vector.t
+      -> t
 
-    val verify : t -> Verification_key.t -> Field.Vector.t -> bool
+    val verify :
+      ?message:message -> t -> Verification_key.t -> Field.Vector.t -> bool
   end
 
   module R1CS_constraint_system : sig

--- a/src/snark0.mli
+++ b/src/snark0.mli
@@ -18,6 +18,7 @@ module Make (Backend : Backend_intf.S) :
    and type Verification_key.t = Backend.Verification_key.t
    and type Proving_key.t = Backend.Proving_key.t
    and type Proof.t = Backend.Proof.t
+   and type Proof.message = Backend.Proof.message
 
 module Run : sig
   module Make (Backend : Backend_intf.S) :
@@ -30,6 +31,7 @@ module Run : sig
      and type Verification_key.t = Backend.Verification_key.t
      and type Proving_key.t = Backend.Proving_key.t
      and type Proof.t = Backend.Proof.t
+     and type Proof.message = Backend.Proof.message
 end
 
 type 'field m = (module Snark_intf.Run with type field = 'field)

--- a/src/snark_intf.ml
+++ b/src/snark_intf.ml
@@ -739,6 +739,9 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
   module Proof : sig
     type t
 
+    (** The type of messages that can be associated with a proof. *)
+    type message
+
     include Stringable.S with type t := t
   end
 
@@ -955,6 +958,7 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
          public_input:(unit, 'public_input) H_list.t
       -> ?proving_key:Proving_key.t
       -> ?handlers:Handler.t list
+      -> ?message:Proof.message
       -> ('a, 's, 'public_input) t
       -> 's
       -> Proof.t
@@ -965,11 +969,14 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
         - The [handlers] argument adds handlers to those already given to
           {!val:create}. If handlers for the same requests were provided to
           both, the ones passed here are given priority.
+        - The [message] argument specifies the message to associate with the
+          proof, if any.
     *)
 
     val verify :
          public_input:(unit, 'public_input) H_list.t
       -> ?verification_key:Verification_key.t
+      -> ?message:Proof.message
       -> ('a, 's, 'public_input) t
       -> Proof.t
       -> bool
@@ -999,13 +1006,15 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
 
     val prove :
          run:('a, 't) t
+      -> ?message:Proof.message
       -> Proving_key.t
       -> ('t, Proof.t, 'k_var, 'k_value) Data_spec.t
       -> 'k_var
       -> 'k_value
 
     val verify :
-         Proof.t
+         ?message:Proof.message
+      -> Proof.t
       -> Verification_key.t
       -> (_, bool, _, 'k_value) Data_spec.t
       -> 'k_value
@@ -1142,7 +1151,8 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
   *)
 
   val prove :
-       Proving_key.t
+       ?message:Proof.message
+    -> Proving_key.t
     -> ((unit, 's) Checked.t, Proof.t, 'k_var, 'k_value) Data_spec.t
     -> 's
     -> 'k_var
@@ -1152,7 +1162,8 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
   *)
 
   val verify :
-       Proof.t
+       ?message:Proof.message
+    -> Proof.t
     -> Verification_key.t
     -> (_, bool, _, 'k_value) Data_spec.t
     -> 'k_value
@@ -1682,6 +1693,8 @@ module type Run = sig
   module Proof : sig
     type t
 
+    type message
+
     include Stringable.S with type t := t
   end
 
@@ -1794,12 +1807,14 @@ module type Run = sig
          public_input:(unit, 'public_input) H_list.t
       -> ?proving_key:Proving_key.t
       -> ?handlers:Handler.t list
+      -> ?message:Proof.message
       -> ('a, 'public_input) t
       -> Proof.t
 
     val verify :
          public_input:(unit, 'public_input) H_list.t
       -> ?verification_key:Verification_key.t
+      -> ?message:Proof.message
       -> ('a, 'public_input) t
       -> Proof.t
       -> bool
@@ -1850,13 +1865,15 @@ module type Run = sig
     exposing:(unit -> 'a, _, 'k_var, _) Data_spec.t -> 'k_var -> Keypair.t
 
   val prove :
-       Proving_key.t
+       ?message:Proof.message
+    -> Proving_key.t
     -> (unit -> 'a, Proof.t, 'k_var, 'k_value) Data_spec.t
     -> 'k_var
     -> 'k_value
 
   val verify :
-       Proof.t
+       ?message:Proof.message
+    -> Proof.t
     -> Verification_key.t
     -> (_, bool, _, 'k_value) Data_spec.t
     -> 'k_value


### PR DESCRIPTION
This PR adds a `message` type and an optional `message` argument to `Proof.create`, `prove` and `verify`, to support messages in BG snarks.

This is an alternative to PR #163.