### PR TITLE
Functor Snark0.Make_basic over Checked, As_prover and Typ

### DIFF
--- a/examples/merkle_update/merkle_update.ml
+++ b/examples/merkle_update/merkle_update.ml
@@ -107,7 +107,8 @@ let update_many root_start
             exists Value.typ
               ~compute:
                 As_prover.(
-                  map2 ~f:Merkle_tree.get_exn get_state (read address_typ addr))
+                  map2 ~f:Merkle_tree.get_exn (get_state ())
+                    (read address_typ addr))
           in
           Merkle_tree_checked.update addr ~depth ~root:curr_root
             ~prev:prev_value ~next:x

--- a/src/as_prover.ml
+++ b/src/as_prover.ml
@@ -16,7 +16,7 @@ struct
     let map = `Custom map
   end)
 
-  let get_state = wrap (fun s -> (s, s))
+  let get_state () = wrap (fun s -> (s, s))
 
   let set_state s = wrap (fun _ -> (s, ()))
 

--- a/src/as_prover.ml
+++ b/src/as_prover.ml
@@ -5,9 +5,13 @@ type ('a, 'f, 's) t = ('a, 'f, 's) As_prover0.t
 module Make
     (Checked : Checked_intf.S)
     (As_prover : As_prover_intf.Basic
-                 with type 'f field = 'f Checked.field
-                  and module Types = Checked.Types) =
+                 with type 'f field := 'f Checked.field
+                  and module Types := Checked.Types) =
 struct
+  type 'f field = 'f Checked.field
+
+  module Types = Checked.Types
+
   include As_prover
 
   include Monad_let.Make3 (struct

--- a/src/as_prover.ml
+++ b/src/as_prover.ml
@@ -11,7 +11,6 @@ struct
   type 'f field = 'f Checked.field
 
   module Types = Checked.Types
-
   include As_prover
 
   include Monad_let.Make3 (struct
@@ -68,19 +67,18 @@ struct
           | exception _ -> run c tbl s
           | x -> (s', x) )
   end
+
+  module Handle = struct
+    include Handle
+
+    let value (t : ('var, 'value) t) : ('value, 'field, 's) As_prover.t =
+      wrap (fun s -> (s, Option.value_exn t.value))
+  end
 end
 
 module T :
   As_prover_intf.S' with type 'f field := 'f with module Types := Checked.Types =
-  Make
-    (Checked)
-    (struct
-      include As_prover0
-
-      type 'f field = 'f
-
-      module Types = Checked.Types
-    end)
+  Make (Checked) (As_prover0)
 
 include T
 

--- a/src/as_prover.ml
+++ b/src/as_prover.ml
@@ -72,7 +72,9 @@ module T :
     (Checked)
     (struct
       include As_prover0
+
       type 'f field = 'f
+
       module Types = Checked.Types
     end)
 

--- a/src/as_prover.mli
+++ b/src/as_prover.mli
@@ -1,8 +1,8 @@
 module Make
     (Checked : Checked_intf.S)
     (As_prover : As_prover_intf.Basic
-                 with type 'f field = 'f Checked.field
-                 with module Types = Checked.Types) :
+                 with type 'f field := 'f Checked.field
+                 with module Types := Checked.Types) :
   As_prover_intf.S
   with type 'f field = 'f Checked.field
   with module Types = Checked.Types

--- a/src/as_prover.mli
+++ b/src/as_prover.mli
@@ -1,81 +1,19 @@
-module type Basic = sig
-  type ('a, 'f, 's) t
-
-  type 'f field
-
-  type ('a, 's, 'f) checked
-
-  include Monad_let.S3 with type ('a, 'f, 's) t := ('a, 'f field, 's) t
-
-  type ('a, 'f, 's) as_prover = ('a, 'f, 's) t
-
-  val run :
-    ('a, 'f field, 's) t -> ('f field Cvar.t -> 'f field) -> 's -> 's * 'a
-
-  val get_state : ('s, 'f field, 's) t
-
-  val set_state : 's -> (unit, 'f field, 's) t
-
-  val modify_state : ('s -> 's) -> (unit, 'f field, 's) t
-
-  val map2 :
-       ('a, 'f field, 's) t
-    -> ('b, 'f field, 's) t
-    -> f:('a -> 'b -> 'c)
-    -> ('c, 'f field, 's) t
-
-  val read_var : 'f field Cvar.t -> ('f field, 'f field, 's) t
-
-  val read :
-       ('var, 'value, 'f field, (unit, unit, 'f field) checked) Types.Typ.t
-    -> 'var
-    -> ('value, 'f field, 'prover_state) t
-
-  module Ref : sig
-    type 'a t
-
-    val create :
-         ('a, 'f field, 'prover_state) as_prover
-      -> ('a t, 'prover_state, 'f field) checked
-
-    val get : 'a t -> ('a, 'f field, _) as_prover
-
-    val set : 'a t -> 'a -> (unit, 'f field, _) as_prover
-  end
-end
-
-module type S = sig
-  type ('a, 's) t
-
-  type field
-
-  include
-    Basic
-    with type 'f field := field
-     and type ('a, 'f, 's) t := ('a, 's) t
-     and type ('a, 'f, 's) as_prover := ('a, 's) t
-end
-
-module Make_basic (Checked : Checked_intf.S) :
-  Basic
+module Make
+    (Checked : Checked_intf.S)
+    (As_prover : As_prover_intf.Basic
+                 with type 'f field = 'f Checked.field
+                 with module Types = Checked.Types) :
+  As_prover_intf.S
   with type 'f field = 'f Checked.field
-   and type ('a, 'f, 's) t = ('a, 'f, 's) As_prover0.t
-   and type ('a, 's, 'f) checked := ('a, 's, 'f) Checked.t
+  with module Types = Checked.Types
 
 include
-  Basic
-  with type 'f field := 'f
-   and type ('a, 'f, 's) t = ('a, 'f, 's) As_prover0.t
-   and type ('a, 's, 'f) checked := ('a, 's, 'f) Checked.t
+  As_prover_intf.S with type 'f field := 'f with module Types := Checked.Types
 
-module Make (Env : sig
+module Make_extended (Env : sig
   type field
 end)
-(Checked : Checked_intf.S with type 'f field := Env.field)
-(Basic : Basic
-         with type 'f field := Env.field
-          and type ('a, 's, 'f) checked := ('a, 's, 'f) Checked.t) :
-  S
-  with type field := Env.field
-   and type ('a, 's) t = ('a, Env.field, 's) Basic.t
-   and type ('a, 's, 'f) checked := ('a, 's, 'f) Checked.t
+(As_prover : As_prover_intf.S with type 'f field := Env.field) :
+  As_prover_intf.Extended
+  with type field = Env.field
+  with module Types = As_prover.Types

--- a/src/as_prover0.ml
+++ b/src/as_prover0.ml
@@ -13,30 +13,9 @@ module T = struct
 
   let run t tbl s = t tbl s
 
-  let get_state _tbl s = (s, s)
+  let wrap f _ = f
 
-  let read_var v tbl s = (s, tbl v)
-
-  let set_state s tbl _ = (s, ())
-
-  let modify_state f _tbl s = (f s, ())
-
-  let map2 x y ~f tbl s =
-    let s, x = x tbl s in
-    let s, y = y tbl s in
-    (s, f x y)
-
-  let read_var (v : 'var) : ('field, 'field, 's) t = fun tbl s -> (s, tbl v)
-
-  include Monad_let.Make3 (struct
-    type nonrec ('a, 'e, 's) t = ('a, 'e, 's) t
-
-    let map = `Custom map
-
-    let bind = bind
-
-    let return = return
-  end)
+  let with_read f tbl s = (s, f tbl)
 end
 
 include T

--- a/src/as_prover0.ml
+++ b/src/as_prover0.ml
@@ -40,3 +40,19 @@ module T = struct
 end
 
 include T
+
+module Provider = struct
+  include Provider.T
+
+  let run t stack tbl s (handler : Request.Handler.t) =
+    match t with
+    | Request rc ->
+        let s', r = run rc tbl s in
+        (s', Request.Handler.run handler stack r)
+    | Compute c -> run c tbl s
+    | Both (rc, c) -> (
+        let s', r = run rc tbl s in
+        match Request.Handler.run handler stack r with
+        | exception _ -> run c tbl s
+        | x -> (s', x) )
+end

--- a/src/as_prover_intf.ml
+++ b/src/as_prover_intf.ml
@@ -80,6 +80,15 @@ module type S' = sig
       -> Request.Handler.t
       -> 's * 'a
   end
+
+  module Handle : sig
+    type ('var, 'value) t = ('var, 'value) Handle.t =
+      {var: 'var; mutable value: 'value option}
+
+    val var : ('var, 'value) t -> 'var
+
+    val value : ('var, 'value) t -> ('value, 'f field, 's) Types.As_prover.t
+  end
 end
 
 module type S = sig

--- a/src/as_prover_intf.ml
+++ b/src/as_prover_intf.ml
@@ -38,7 +38,7 @@ module type S' = sig
   val run :
     ('a, 'f field, 's) t -> ('f field Cvar.t -> 'f field) -> 's -> 's * 'a
 
-  val get_state : unit -> ('s, 'f field, 's) t
+  val get_state : ('s, 'f field, 's) t
 
   val set_state : 's -> (unit, 'f field, 's) t
 
@@ -94,6 +94,8 @@ module type Extended = sig
   module Types : Types.Types
 
   type ('a, 's) t = ('a, field, 's) Types.As_prover.t
+
+  type ('a, 's) as_prover = ('a, 's) t
 
   include S' with type 'f field := field with module Types := Types
 end

--- a/src/as_prover_intf.ml
+++ b/src/as_prover_intf.ml
@@ -38,7 +38,7 @@ module type S' = sig
   val run :
     ('a, 'f field, 's) t -> ('f field Cvar.t -> 'f field) -> 's -> 's * 'a
 
-  val get_state : ('s, 'f field, 's) t
+  val get_state : unit -> ('s, 'f field, 's) t
 
   val set_state : 's -> (unit, 'f field, 's) t
 

--- a/src/as_prover_intf.ml
+++ b/src/as_prover_intf.ml
@@ -1,0 +1,99 @@
+module type Basic' = sig
+  module Types : Types.Types
+
+  open Types.As_prover
+
+  type 'f field
+
+  val return : 'a -> ('a, 'f, 's) t
+
+  val map : ('a, 'f, 's) t -> f:('a -> 'b) -> ('b, 'f, 's) t
+
+  val bind : ('a, 'f, 's) t -> f:('a -> ('b, 'f, 's) t) -> ('b, 'f, 's) t
+
+  val run :
+    ('a, 'f field, 's) t -> ('f field Cvar.t -> 'f field) -> 's -> 's * 'a
+
+  val wrap : ('s -> 's * 'a) -> ('a, 'f field, 's) t
+
+  val with_read : (('f field Cvar.t -> 'f field) -> 'a) -> ('a, 'f field, 's) t
+end
+
+module type Basic = sig
+  include Basic'
+
+  type ('a, 'f, 's) t = ('a, 'f, 's) Types.As_prover.t
+end
+
+module type S' = sig
+  module Types : Types.Types
+
+  open Types.As_prover
+
+  type 'f field
+
+  include
+    Monad_let.S3 with type ('a, 'f, 's) t := ('a, 'f, 's) Types.As_prover.t
+
+  val run :
+    ('a, 'f field, 's) t -> ('f field Cvar.t -> 'f field) -> 's -> 's * 'a
+
+  val get_state : unit -> ('s, 'f field, 's) t
+
+  val set_state : 's -> (unit, 'f field, 's) t
+
+  val modify_state : ('s -> 's) -> (unit, 'f field, 's) t
+
+  val map2 :
+       ('a, 'f field, 's) t
+    -> ('b, 'f field, 's) t
+    -> f:('a -> 'b -> 'c)
+    -> ('c, 'f field, 's) t
+
+  val read_var : 'f field Cvar.t -> ('f field, 'f field, 's) t
+
+  val read :
+       ('var, 'value, 'f field) Types.Typ.t
+    -> 'var
+    -> ('value, 'f field, 'prover_state) t
+
+  module Ref : sig
+    type 'a t
+
+    val create :
+         ('a, 'f field, 'prover_state) Types.As_prover.t
+      -> ('a t, 'prover_state, 'f field) Types.Checked.t
+
+    val get : 'a t -> ('a, 'f field, _) Types.As_prover.t
+
+    val set : 'a t -> 'a -> (unit, 'f field, _) Types.As_prover.t
+  end
+
+  module Provider : sig
+    include module type of Types.Provider
+
+    val run :
+         ('a, 'f field, 's) t
+      -> string list
+      -> ('f field Cvar.t -> 'f field)
+      -> 's
+      -> Request.Handler.t
+      -> 's * 'a
+  end
+end
+
+module type S = sig
+  include S'
+
+  type ('a, 'f, 's) t = ('a, 'f, 's) Types.As_prover.t
+end
+
+module type Extended = sig
+  type field
+
+  module Types : Types.Types
+
+  type ('a, 's) t = ('a, field, 's) Types.As_prover.t
+
+  include S' with type 'f field := field with module Types := Types
+end

--- a/src/checked.ml
+++ b/src/checked.ml
@@ -190,7 +190,6 @@ module Make
   let assert_equal ?label x y = assert_ (Constraint.equal ?label x y)
 end
 
-
 module T = struct
   include (
     Make

--- a/src/checked.ml
+++ b/src/checked.ml
@@ -1,6 +1,8 @@
 open Core_kernel
 open Types.Checked
 
+module Types0 = Types
+
 type ('a, 's, 'field) t = ('a, 's, 'field) Types.Checked.t
 
 module T0 = struct
@@ -46,6 +48,42 @@ module T0 = struct
     | Next_auxiliary k -> Next_auxiliary (fun x -> bind (k x) ~f)
 end
 
+module Types = struct
+  module Checked = struct
+    type nonrec ('a, 's, 'f) t = ('a, 's, 'f) t
+
+    type ('a, 's, 'f, 'arg) thunk = ('a, 's, 'f) t
+  end
+
+  module As_prover = struct
+    type ('a, 'f, 's) t = ('a, 'f, 's) As_prover0.t
+  end
+
+  module Provider = Types.Provider
+
+  module Typ = struct
+    type ('var, 'value, 'f) t =
+      ('var, 'value, 'f, (unit, unit, 'f) Checked.t) Types.Typ.t
+
+    module T = Types.Typ.T
+    include T
+  end
+
+  module Data_spec = struct
+    type ('r_var, 'r_value, 'k_var, 'k_value, 'f) t =
+      ( 'r_var
+      , 'r_value
+      , 'k_var
+      , 'k_value
+      , 'f
+      , (unit, unit, 'f) Checked.t )
+      Types.Data_spec.t
+
+    module T = Types.Data_spec.T
+    include T
+  end
+end
+
 module Basic :
   Checked_intf.Basic
   with type ('a, 's, 'f) t = ('a, 's, 'f) t
@@ -79,8 +117,7 @@ module Make (Basic : Checked_intf.Basic) :
    and type 'f field = 'f Basic.field = struct
   include Basic
 
-  let request_witness
-      (typ : ('var, 'value, 'f field, (unit, unit, 'f field) t) Types.Typ.t)
+  let request_witness (typ : ('var, 'value, 'f field, (unit, unit, 'f field) t) Types0.Typ.t)
       (r : ('value Request.t, 'f field, 's) As_prover0.t) =
     let%map h = exists typ (Request r) in
     Handle.var h

--- a/src/checked_intf.ml
+++ b/src/checked_intf.ml
@@ -122,8 +122,8 @@ module type Extended = sig
 
   val run :
        ('a, 's, field) t
-    -> ('s, field) Types.Run_state.t
-    -> ('s, field) Types.Run_state.t * 'a
+    -> ('s, field) Run_state.t
+    -> ('s, field) Run_state.t * 'a
 end
 
 module Unextend (Checked : Extended) :

--- a/src/checked_intf.ml
+++ b/src/checked_intf.ml
@@ -1,5 +1,7 @@
-module type Basic = sig
-  type ('a, 's, 'f) t
+module type Basic' = sig
+  module Types : Types.Types
+
+  open Types.Checked
 
   type 'f field
 
@@ -7,13 +9,14 @@ module type Basic = sig
 
   val add_constraint : 'f field Cvar.t Constraint.t -> (unit, 's, 'f field) t
 
-  val as_prover : (unit, 'f field, 's) As_prover0.t -> (unit, 's, 'f field) t
+  val as_prover :
+    (unit, 'f field, 's) Types.As_prover.t -> (unit, 's, 'f field) t
 
   val with_label : string -> ('a, 's, 'f field) t -> ('a, 's, 'f field) t
 
   val with_state :
-       ('s1, 'f field, 's) As_prover0.t
-    -> ('s1 -> (unit, 'f field, 's) As_prover0.t)
+       ('s1, 'f field, 's) Types.As_prover.t
+    -> ('s1 -> (unit, 'f field, 's) Types.As_prover.t)
     -> ('a, 's1, 'f field) t
     -> ('a, 's, 'f field) t
 
@@ -23,43 +26,52 @@ module type Basic = sig
   val clear_handler : ('a, 's, 'f field) t -> ('a, 's, 'f field) t
 
   val exists :
-       ('var, 'value, 'f field, (unit, unit, 'f field) t) Types.Typ.t
+       ('var, 'value, 'f field) Types.Typ.t
     -> ('value, 'f field, 's) Types.Provider.t
     -> (('var, 'value) Handle.t, 's, 'f field) t
 
   val next_auxiliary : (int, 's, 'f field) t
 end
 
-module type S = sig
-  type ('a, 's, 'f) t
+module type Basic = sig
+  include Basic'
+
+  type ('a, 's, 'f) t = ('a, 's, 'f) Types.Checked.t
+end
+
+module type S' = sig
+  module Types : Types.Types
+
+  open Types.Checked
 
   type 'f field
 
   include Monad_let.S3 with type ('a, 's, 'f) t := ('a, 's, 'f) t
 
-  val as_prover : (unit, 'f field, 's) As_prover0.t -> (unit, 's, 'f field) t
+  val as_prover :
+    (unit, 'f field, 's) Types.As_prover.t -> (unit, 's, 'f field) t
 
   val request_witness :
-       ('var, 'value, 'f field, (unit, unit, 'f field) t) Types.Typ.t
-    -> ('value Request.t, 'f field, 's) As_prover0.t
+       ('var, 'value, 'f field) Types.Typ.t
+    -> ('value Request.t, 'f field, 's) Types.As_prover.t
     -> ('var, 's, 'f field) t
 
   val request :
        ?such_that:('var -> (unit, 's, 'f field) t)
-    -> ('var, 'value, 'f field, (unit, unit, 'f field) t) Types.Typ.t
+    -> ('var, 'value, 'f field) Types.Typ.t
     -> 'value Request.t
     -> ('var, 's, 'f field) t
 
   val exists_handle :
-       ?request:('value Request.t, 'f field, 's) As_prover0.t
-    -> ?compute:('value, 'f field, 's) As_prover0.t
-    -> ('var, 'value, 'f field, (unit, unit, 'f field) t) Types.Typ.t
+       ?request:('value Request.t, 'f field, 's) Types.As_prover.t
+    -> ?compute:('value, 'f field, 's) Types.As_prover.t
+    -> ('var, 'value, 'f field) Types.Typ.t
     -> (('var, 'value) Handle.t, 's, 'f field) t
 
   val exists :
-       ?request:('value Request.t, 'f field, 's) As_prover0.t
-    -> ?compute:('value, 'f field, 's) As_prover0.t
-    -> ('var, 'value, 'f field, (unit, unit, 'f field) t) Types.Typ.t
+       ?request:('value Request.t, 'f field, 's) Types.As_prover.t
+    -> ?compute:('value, 'f field, 's) Types.As_prover.t
+    -> ('var, 'value, 'f field) Types.Typ.t
     -> ('var, 's, 'f field) t
 
   type response = Request.response
@@ -80,8 +92,8 @@ module type S = sig
   val with_label : string -> ('a, 's, 'f field) t -> ('a, 's, 'f field) t
 
   val with_state :
-       ?and_then:('s1 -> (unit, 'f field, 's) As_prover0.t)
-    -> ('s1, 'f field, 's) As_prover0.t
+       ?and_then:('s1 -> (unit, 'f field, 's) Types.As_prover.t)
+    -> ('s1, 'f field, 's) Types.As_prover.t
     -> ('a, 's1, 'f field) t
     -> ('a, 's, 'f field) t
 
@@ -115,26 +127,37 @@ module type S = sig
     -> (unit, 's, 'f field) t
 end
 
-module type Extended = sig
+module type S = sig
+  include S'
+
+  type ('a, 's, 'f) t = ('a, 's, 'f) Types.Checked.t
+end
+
+module type Extended' = sig
   type field
 
-  include S with type 'f field := field
+  include S' with type 'f field := field
 
   val run :
-       ('a, 's, field) t
+       ('a, 's, field) Types.Checked.t
     -> ('s, field) Run_state.t
     -> ('s, field) Run_state.t * 'a
 end
 
-module Unextend (Checked : Extended) :
-  S
-  with type 'f field = Checked.field
-   and type ('a, 's, 'f) t = ('a, 's, 'f) Checked.t = struct
+module type Extended = sig
+  include Extended'
+
+  type ('a, 's) t = ('a, 's, field) Types.Checked.t
+end
+
+module Unextend (Checked : Extended') :
+  S with type 'f field = Checked.field with module Types = Checked.Types =
+struct
   include (
     Checked :
-      S
-      with type 'f field := Checked.field
-       and type ('a, 's, 'f) t = ('a, 's, 'f) Checked.t )
+      S' with type 'f field := Checked.field with module Types = Checked.Types )
 
   type 'f field = Checked.field
+
+  type ('a, 's, 'f) t = ('a, 's, 'f) Types.Checked.t
 end

--- a/src/checked_intf.ml
+++ b/src/checked_intf.ml
@@ -24,7 +24,7 @@ module type Basic = sig
 
   val exists :
        ('var, 'value, 'f field, (unit, unit, 'f field) t) Types.Typ.t
-    -> ('value, 'f field, 's) Provider.t
+    -> ('value, 'f field, 's) Types.Provider.t
     -> (('var, 'value) Handle.t, 's, 'f field) t
 
   val next_auxiliary : (int, 's, 'f field) t

--- a/src/merkle_tree.ml
+++ b/src/merkle_tree.ml
@@ -469,7 +469,7 @@ struct
       exists (Path.typ ~depth)
         ~compute:
           As_prover.(
-            map2 ~f:get_path get_state (read (Address.typ ~depth) addr0))
+            map2 ~f:get_path (get_state ()) (read (Address.typ ~depth) addr0))
     in
     let%bind prev_root_hash = implied_root prev_entry_hash addr0 prev_path in
     let%bind () = Hash.assert_equal root prev_root_hash

--- a/src/provider.ml
+++ b/src/provider.ml
@@ -1,16 +1,10 @@
-type ('a, 'f, 's) t =
-  | Request of ('a Request.t, 'f, 's) As_prover0.t
-  | Compute of ('a, 'f, 's) As_prover0.t
-  | Both of ('a Request.t, 'f, 's) As_prover0.t * ('a, 'f, 's) As_prover0.t
+module T = struct
+  type ('request, 'compute) provider =
+    | Request of 'request
+    | Compute of 'compute
+    | Both of 'request * 'compute
+end
 
-let run t stack tbl s (handler : Request.Handler.t) =
-  match t with
-  | Request rc ->
-      let s', r = As_prover0.run rc tbl s in
-      (s', Request.Handler.run handler stack r)
-  | Compute c -> As_prover0.run c tbl s
-  | Both (rc, c) -> (
-      let s', r = As_prover0.run rc tbl s in
-      match Request.Handler.run handler stack r with
-      | exception _ -> As_prover0.run c tbl s
-      | x -> (s', x) )
+include T
+
+type ('request, 'compute) t = ('request, 'compute) provider

--- a/src/run_state.ml
+++ b/src/run_state.ml
@@ -1,0 +1,37 @@
+(** The internal state used to run a checked computation. *)
+type ('prover_state, 'field) t =
+  { system: 'field Backend_types.R1CS_constraint_system.t option
+  ; input: 'field Vector.t
+  ; aux: 'field Vector.t
+  ; eval_constraints: bool
+  ; num_inputs: int
+  ; next_auxiliary: int ref
+  ; prover_state: 'prover_state option
+  ; stack: string list
+  ; handler: Request.Handler.t
+  ; is_running: bool
+  ; as_prover: bool ref }
+
+let set_prover_state prover_state
+    { system
+    ; input
+    ; aux
+    ; eval_constraints
+    ; num_inputs
+    ; next_auxiliary
+    ; prover_state= _
+    ; stack
+    ; handler
+    ; is_running
+    ; as_prover } =
+  { system
+  ; input
+  ; aux
+  ; eval_constraints
+  ; num_inputs
+  ; next_auxiliary
+  ; prover_state
+  ; stack
+  ; handler
+  ; is_running
+  ; as_prover }

--- a/src/run_state.ml
+++ b/src/run_state.ml
@@ -35,3 +35,16 @@ let set_prover_state prover_state
   ; handler
   ; is_running
   ; as_prover }
+
+let dummy_state () =
+  { system= None
+  ; input= Vector.null
+  ; aux= Vector.null
+  ; eval_constraints= false
+  ; num_inputs= 0
+  ; next_auxiliary= ref 1
+  ; prover_state= None
+  ; stack= []
+  ; handler= Request.Handler.fail
+  ; is_running= true
+  ; as_prover= ref false }

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -280,7 +280,9 @@ end
 
 module Make_basic
     (Backend : Backend_extended.S)
-    (Checked : Checked_intf.Extended with type field = Backend.Field.t) =
+    (Checked : Checked_intf.Extended
+               with type field = Backend.Field.t
+               with module Types = Checked.Types) =
 struct
   open Backend
   module Checked_S = Checked_intf.Unextend (Checked)
@@ -335,7 +337,7 @@ struct
 
   module Typ = struct
     include Types.Typ.T
-    module T = Typ.Make (Checked_S)
+    module T = Typ.Make (Checked_S) (As_prover)
     include Typ_monads
     include T.T
 

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -96,7 +96,7 @@ module Runner = struct
       | Some ps ->
           let old = !(s.as_prover) in
           s.as_prover := true ;
-          let ps, value = As_prover0.Provider.run p s.stack (get_value s) ps s.handler in
+          let ps, value = As_prover.Provider.run p s.stack (get_value s) ps s.handler in
           s.as_prover := old ;
           let var = Typ_monads.Store.run (store value) (store_field_elt s) in
           (* TODO: Push a label onto the stack here *)
@@ -233,7 +233,7 @@ module Runner = struct
               let old = !(s.as_prover) in
               s.as_prover := true ;
               let ps, value =
-                As_prover0.Provider.run p s.stack (get_value s)
+                As_prover.Provider.run p s.stack (get_value s)
                   (Option.value_exn s.prover_state)
                   s.handler
               in

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -280,9 +280,10 @@ end
 
 module Make_basic
     (Backend : Backend_extended.S)
-    (Checked : Checked_intf.Extended
-               with type field = Backend.Field.t)
-    (As_prover : As_prover_intf.Extended with type field := Backend.Field.t with module Types := Checked.Types)
+    (Checked : Checked_intf.Extended with type field = Backend.Field.t)
+    (As_prover : As_prover_intf.Extended
+                 with type field := Backend.Field.t
+                 with module Types := Checked.Types)
     (Typ : Typ_intf.S
            with type 'f field := Checked.field
            with module Types := Checked.Types) =
@@ -359,7 +360,7 @@ struct
         Typ_intf.S'
         with type 'f field := Backend.Field.t
         with module Types := Checked.Types
-        and module Data_spec := Data_spec )
+         and module Data_spec := Data_spec )
 
     include Typ_monads
 
@@ -407,8 +408,7 @@ struct
   end
 
   module As_prover = As_prover
-
-  module Handle = Handle
+  module Handle = As_prover.Handle
 
   module Checked = struct
     open Run_state

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -96,7 +96,9 @@ module Runner = struct
       | Some ps ->
           let old = !(s.as_prover) in
           s.as_prover := true ;
-          let ps, value = As_prover.Provider.run p s.stack (get_value s) ps s.handler in
+          let ps, value =
+            As_prover.Provider.run p s.stack (get_value s) ps s.handler
+          in
           s.as_prover := old ;
           let var = Typ_monads.Store.run (store value) (store_field_elt s) in
           (* TODO: Push a label onto the stack here *)
@@ -391,13 +393,15 @@ struct
     include As_prover.Make_extended (struct
                 type field = Field.t
               end)
-              (As_prover.Make (Checked_S) (struct
-                include As_prover0
+              (As_prover.Make
+                 (Checked_S)
+                 (struct
+                   include As_prover0
 
-                type 'f field = Field.t
+                   type 'f field = Field.t
 
-                module Types = Checked_S.Types
-              end))
+                   module Types = Checked_S.Types
+                 end))
   end
 
   module Handle = Handle
@@ -828,8 +832,7 @@ struct
           type nonrec ('a, 's) t = ('a, 's) t
 
           include (
-            Checked_S :
-              Checked_intf.S' with module Types := Checked_S.Types)
+            Checked_S : Checked_intf.S' with module Types := Checked_S.Types )
         end)
         (struct
           type t = Boolean.var
@@ -1589,7 +1592,7 @@ module Make (Backend : Backend_intf.S) = struct
           Checked :
             Checked_intf.S'
             with type 'f field := 'f
-            and module Types = Checked.Types)
+             and module Types = Checked.Types )
 
         type field = Backend_extended.Field.t
 

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -388,13 +388,16 @@ struct
   end
 
   module As_prover = struct
-    include As_prover.Make (struct
+    include As_prover.Make_extended (struct
                 type field = Field.t
               end)
-              (Checked_S)
-              (As_prover.Make_basic (Checked_S))
+              (As_prover.Make (Checked_S) (struct
+                include As_prover0
 
-    type ('a, 'prover_state) as_prover = ('a, 'prover_state) t
+                type 'f field = Field.t
+
+                module Types = Checked_S.Types
+              end))
   end
 
   module Handle = Handle

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -1988,7 +1988,7 @@ module Run = struct
 
       let read_var var = eval_as_prover (As_prover.read_var var)
 
-      let get_state () = eval_as_prover As_prover.get_state
+      let get_state () = eval_as_prover (As_prover.get_state ())
 
       let set_state s = eval_as_prover (As_prover.set_state s)
 

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -281,8 +281,7 @@ end
 module Make_basic
     (Backend : Backend_extended.S)
     (Checked : Checked_intf.Extended
-               with type field = Backend.Field.t
-               with module Types = Checked.Types)
+               with type field = Backend.Field.t)
     (As_prover : As_prover_intf.Extended with type field := Backend.Field.t with module Types := Checked.Types)
     (Typ : Typ_intf.S
            with type 'f field := Checked.field

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -96,7 +96,7 @@ module Runner = struct
       | Some ps ->
           let old = !(s.as_prover) in
           s.as_prover := true ;
-          let ps, value = Provider.run p s.stack (get_value s) ps s.handler in
+          let ps, value = As_prover0.Provider.run p s.stack (get_value s) ps s.handler in
           s.as_prover := old ;
           let var = Typ_monads.Store.run (store value) (store_field_elt s) in
           (* TODO: Push a label onto the stack here *)
@@ -233,7 +233,7 @@ module Runner = struct
               let old = !(s.as_prover) in
               s.as_prover := true ;
               let ps, value =
-                Provider.run p s.stack (get_value s)
+                As_prover0.Provider.run p s.stack (get_value s)
                   (Option.value_exn s.prover_state)
                   s.handler
               in

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -340,7 +340,7 @@ struct
     type ('var, 'value) t = ('var, 'value, Field.t) T.t
 
     module Data_spec = struct
-      include Typ.Data_spec0
+      include Types.Data_spec.T
 
       type ('r_var, 'r_value, 'k_var, 'k_value) t =
         ('r_var, 'r_value, 'k_var, 'k_value, field) T.Data_spec.t

--- a/src/snark0.mli
+++ b/src/snark0.mli
@@ -19,6 +19,8 @@ module Make (Backend : Backend_intf.S) :
    and type Proving_key.t = Backend.Proving_key.t
    and type Proof.t = Backend.Proof.t
    and type Proof.message = Backend.Proof.message
+   and type ('a, 's) Checked.t = ('a, 's, Backend.Field.t) Checked.t
+   and type ('a, 's) As_prover.t = ('a, Backend.Field.t, 's) As_prover.t
 
 module Run : sig
   module Make (Backend : Backend_intf.S) :

--- a/src/snark_intf.ml
+++ b/src/snark_intf.ml
@@ -2,6 +2,7 @@ module Bignum_bigint = Bigint
 open Core_kernel
 module Constraint0 = Constraint
 module Boolean0 = Boolean
+module Checked_ast = Checked
 
 (** Yojson-compatible JSON type. *)
 type 'a json =
@@ -498,8 +499,7 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
 
     type 'prover_state run_state = ('prover_state, Field.t) Run_state.t
 
-    include
-      Monad_let.S2 with type ('a, 's) t = ('a, 's, Field.t) Types.Checked.t
+    include Monad_let.S2
 
     module List :
       Monad_sequence.S
@@ -794,7 +794,7 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
 
         This type specialises the {!type:As_prover.t} type for the backend's
         particular field and variable type. *)
-    type ('a, 'prover_state) t = ('a, field, 'prover_state) As_prover.t
+    type ('a, 'prover_state) t
 
     type ('a, 'prover_state) as_prover = ('a, 'prover_state) t
 
@@ -855,7 +855,7 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
   module Runner : sig
     type state
 
-    val run : ('a, unit) Checked.t -> state -> state * 'a
+    val run : ('a, unit, Field.t) Checked_ast.t -> state -> state * 'a
   end
 
   type response = Request.response
@@ -1219,7 +1219,11 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
   *)
 
   val reduce_to_prover :
-       ((unit, 's) Checked.t, Proof.t, 'k_var, 'k_value) Data_spec.t
+       ( (unit, 's, Field.t) Checked_ast.t
+       , Proof.t
+       , 'k_var
+       , 'k_value )
+       Data_spec.t
     -> 'k_var
     -> Proving_key.t
     -> ?handlers:Handler.t list
@@ -1254,7 +1258,9 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
   *)
 
   val constraint_count :
-    ?log:(?start:bool -> string -> int -> unit) -> (_, _) Checked.t -> int
+       ?log:(?start:bool -> string -> int -> unit)
+    -> (_, _, _) Checked_ast.t
+    -> int
   (** Returns the number of constraints in the constraint system.
 
       The optional [log] argument is called at the start and end of each

--- a/src/snark_intf.ml
+++ b/src/snark_intf.ml
@@ -173,7 +173,7 @@ module type Basic = sig
     (** [size [typ1; ...; typn]] returns the number of {!type:Var.t} variables
         allocated by allocating [typ1], followed by [typ2], etc. *)
 
-    include module type of Typ0.Data_spec0
+    include module type of Types.Data_spec.T
   end
   
   (** Mappings from OCaml types to R1CS variables and constraints. *)
@@ -1416,7 +1416,7 @@ module type Run = sig
     (** [size [typ1; ...; typn]] returns the number of {!type:Var.t} variables
         allocated by allocating [typ1], followed by [typ2], etc. *)
 
-    include module type of Typ0.Data_spec0
+    include module type of Types.Data_spec.T
   end
   
   (** Mappings from OCaml types to R1CS variables and constraints. *)

--- a/src/snark_intf.ml
+++ b/src/snark_intf.ml
@@ -2,7 +2,6 @@ module Bignum_bigint = Bigint
 open Core_kernel
 module Constraint0 = Constraint
 module Boolean0 = Boolean
-module Typ0 = Typ
 
 (** Yojson-compatible JSON type. *)
 type 'a json =
@@ -167,7 +166,13 @@ module type Basic = sig
         all function as you would expect.
     *)
     type ('r_var, 'r_value, 'k_var, 'k_value) t =
-      ('r_var, 'r_value, 'k_var, 'k_value, field) Typ0.Data_spec.t
+      ( 'r_var
+      , 'r_value
+      , 'k_var
+      , 'k_value
+      , field
+      , (unit, unit) Checked.t )
+      Types.Data_spec.t
 
     val size : (_, _, _, _) t -> int
     (** [size [typ1; ...; typn]] returns the number of {!type:Var.t} variables
@@ -1410,7 +1415,13 @@ module type Run = sig
         all function as you would expect.
     *)
     type ('r_var, 'r_value, 'k_var, 'k_value) t =
-      ('r_var, 'r_value, 'k_var, 'k_value, field) Typ0.Data_spec.t
+      ( 'r_var
+      , 'r_value
+      , 'k_var
+      , 'k_value
+      , field
+      , (unit, unit, Field.Constant.t) Checked.t )
+      Types.Data_spec.t
 
     val size : (_, _, _, _) t -> int
     (** [size [typ1; ...; typn]] returns the number of {!type:Var.t} variables

--- a/src/snark_intf.ml
+++ b/src/snark_intf.ml
@@ -491,7 +491,7 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
 ]}
     *)
 
-    type 'prover_state run_state = ('prover_state, Field.t) Types.Run_state.t
+    type 'prover_state run_state = ('prover_state, Field.t) Run_state.t
 
     include
       Monad_let.S2 with type ('a, 's) t = ('a, 's, Field.t) Types.Checked.t
@@ -851,14 +851,6 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
     type state
 
     val run : ('a, unit) Checked.t -> state -> state * 'a
-
-    val set_handler : Request.Handler.t -> state -> state
-
-    val get_handler : state -> Request.Handler.t
-
-    val set_stack : string list -> state -> state
-
-    val get_stack : state -> string list
   end
 
   type response = Request.response
@@ -1448,7 +1440,7 @@ module type Run = sig
     end
 
     type 'prover_state run_state =
-      ('prover_state, Field.Constant.t) Types.Run_state.t
+      ('prover_state, Field.Constant.t) Run_state.t
 
     type ('var, 'value) t =
       ('var, 'value, field, (unit, unit, field) Checked.t) Types.Typ.t

--- a/src/snark_intf.ml
+++ b/src/snark_intf.ml
@@ -816,7 +816,7 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
     (** Read the contents of a R1CS variable representing a single field
         element. *)
 
-    val get_state : ('prover_state, 'prover_state) t
+    val get_state : unit -> ('prover_state, 'prover_state) t
     (** Read the ['prover_state] carried by the {!type:As_prover.t} monad. *)
 
     val set_state : 'prover_state -> (unit, 'prover_state) t

--- a/src/typ.ml
+++ b/src/typ.ml
@@ -1,9 +1,15 @@
 open Core_kernel
 open Types.Typ
 
-module Make (Checked : Checked_intf.S) = struct
-  type ('var, 'value, 'field) t =
-    ('var, 'value, 'field, (unit, unit, 'field) Checked.t) Types.Typ.t
+module Make
+    (Checked : Checked_intf.S)
+    (As_prover : As_prover_intf.S
+                 with type 'f field := 'f Checked.field
+                 with module Types := Checked.Types) =
+struct
+  module Types = Checked.Types
+
+  type ('var, 'value, 'field) t = ('var, 'value, 'field) Types.Typ.t
 
   type ('var, 'value, 'field) typ = ('var, 'value, 'field) t
 
@@ -47,7 +53,7 @@ module Make (Checked : Checked_intf.S) = struct
 
     let check (type field) ({check; _} : ('var, 'value, field Checked.field) t)
         (v : 'var) : (unit, 's, field Checked.field) Checked.t =
-      Checked.with_state (As_prover0.return ()) (check v)
+      Checked.with_state (As_prover.return ()) (check v)
 
     let unit () : (unit, unit, 'field) t =
       let s = Store.return () in
@@ -264,5 +270,5 @@ module Make (Checked : Checked_intf.S) = struct
   end
 end
 
-include Make (Checked)
+include Make (Checked) (As_prover)
 include T

--- a/src/typ.ml
+++ b/src/typ.ml
@@ -264,4 +264,3 @@ struct
 end
 
 include Make (Checked) (As_prover)
-include T

--- a/src/typ.ml
+++ b/src/typ.ml
@@ -1,47 +1,6 @@
 open Core_kernel
 open Types.Typ
 
-module Data_spec0 = struct
-  (** A list of {!type:Type.Typ.t} values, describing the inputs to a checked
-      computation. The type [('r_var, 'r_value, 'k_var, 'k_value, 'field) t]
-      represents
-      - ['k_value] is the OCaml type of the computation
-      - ['r_value] is the OCaml type of the result
-      - ['k_var] is the type of the computation within the R1CS
-      - ['k_value] is the type of the result within the R1CS
-      - ['field] is the field over which the R1CS operates
-      - ['checked] is the type of checked computation that verifies the stored
-        contents as R1CS variables.
-
-      This functions the same as OCaml's default list type:
-{[
-  Data_spec.[typ1; typ2; typ3]
-
-  Data_spec.(typ1 :: typs)
-
-  let open Data_spec in
-  [typ1; typ2; typ3; typ4; typ5]
-
-  let open Data_spec in
-  typ1 :: typ2 :: typs
-
-]}
-      all function as you would expect.
-  *)
-  type ('r_var, 'r_value, 'k_var, 'k_value, 'f, 'checked) data_spec =
-    | ( :: ) :
-        ('var, 'value, 'f, 'checked) Types.Typ.t
-        * ('r_var, 'r_value, 'k_var, 'k_value, 'f, 'checked) data_spec
-        -> ( 'r_var
-           , 'r_value
-           , 'var -> 'k_var
-           , 'value -> 'k_value
-           , 'f
-           , 'checked )
-           data_spec
-    | [] : ('r_var, 'r_value, 'r_var, 'r_value, 'f, 'checked) data_spec
-end
-
 module Make (Checked : Checked_intf.S) = struct
   type ('var, 'value, 'field) t =
     ('var, 'value, 'field, (unit, unit, 'field) Checked.t) Types.Typ.t
@@ -49,7 +8,7 @@ module Make (Checked : Checked_intf.S) = struct
   type ('var, 'value, 'field) typ = ('var, 'value, 'field) t
 
   module Data_spec = struct
-    include Data_spec0
+    include Types.Data_spec.T
 
     type ('r_var, 'r_value, 'k_var, 'k_value, 'f) t =
       ( 'r_var

--- a/src/typ.ml
+++ b/src/typ.ml
@@ -7,23 +7,14 @@ module Make
                  with type 'f field := 'f Checked.field
                  with module Types := Checked.Types) =
 struct
+  type 'f field = 'f Checked.field
+
   module Types = Checked.Types
 
   type ('var, 'value, 'field) t = ('var, 'value, 'field) Types.Typ.t
 
-  type ('var, 'value, 'field) typ = ('var, 'value, 'field) t
-
   module Data_spec = struct
-    include Types.Data_spec.T
-
-    type ('r_var, 'r_value, 'k_var, 'k_value, 'f) t =
-      ( 'r_var
-      , 'r_value
-      , 'k_var
-      , 'k_value
-      , 'f
-      , (unit, unit, 'f) Checked.t )
-      data_spec
+    include Types.Data_spec
 
     let size t =
       let rec go : type r_var r_value k_var k_value.
@@ -268,6 +259,8 @@ struct
       ; alloc= Alloc.map ~f:var_of_hlist alloc
       ; check= (fun v -> check (var_to_hlist v)) }
   end
+
+  include T
 end
 
 include Make (Checked) (As_prover)

--- a/src/typ_intf.ml
+++ b/src/typ_intf.ml
@@ -8,76 +8,79 @@ module type S' = sig
   end
 
   val store :
-       ('var, 'value, 'field) Types.Typ.t
+       ('var, 'value, 'f field) Types.Typ.t
     -> 'value
-    -> ('var, 'field) Typ_monads.Store.t
+    -> ('var, 'f field) Typ_monads.Store.t
 
   val read :
-       ('var, 'value, 'field) Types.Typ.t
+       ('var, 'value, 'f field) Types.Typ.t
     -> 'var
-    -> ('value, 'field) Typ_monads.Read.t
+    -> ('value, 'f field) Typ_monads.Read.t
 
   val alloc :
-    ('var, 'value, 'field) Types.Typ.t -> ('var, 'field) Typ_monads.Alloc.t
+    ('var, 'value, 'f field) Types.Typ.t -> ('var, 'f field) Typ_monads.Alloc.t
 
   val check :
-       ('var, 'value, 'a field) Types.Typ.t
+       ('var, 'value, 'f field) Types.Typ.t
     -> 'var
-    -> (unit, 's, 'a field) Types.Checked.t
+    -> (unit, 's, 'f field) Types.Checked.t
 
-  val unit : unit -> (unit, unit, 'field) Types.Typ.t
+  val unit : unit -> (unit, unit, 'f field) Types.Typ.t
 
-  val field : unit -> ('field Cvar.t, 'field, 'field) Types.Typ.t
+  val field : unit -> ('f field Cvar.t, 'f field, 'f field) Types.Typ.t
 
   val transport :
-       ('var1, 'value1, 'field) Types.Typ.t
+       ('var1, 'value1, 'f field) Types.Typ.t
     -> there:('value2 -> 'value1)
     -> back:('value1 -> 'value2)
-    -> ('var1, 'value2, 'field) Types.Typ.t
+    -> ('var1, 'value2, 'f field) Types.Typ.t
 
   val transport_var :
-       ('var1, 'value, 'field) Types.Typ.t
+       ('var1, 'value, 'f field) Types.Typ.t
     -> there:('var2 -> 'var1)
     -> back:('var1 -> 'var2)
-    -> ('var2, 'value, 'field) Types.Typ.t
+    -> ('var2, 'value, 'f field) Types.Typ.t
 
   val list :
        length:int
-    -> ('elt_var, 'elt_value, 'field) Types.Typ.t
-    -> ('elt_var list, 'elt_value list, 'field) Types.Typ.t
+    -> ('elt_var, 'elt_value, 'f field) Types.Typ.t
+    -> ('elt_var list, 'elt_value list, 'f field) Types.Typ.t
 
   val array :
        length:int
-    -> ('elt_var, 'elt_value, 'field) Types.Typ.t
-    -> ('elt_var array, 'elt_value array, 'field) Types.Typ.t
+    -> ('elt_var, 'elt_value, 'f field) Types.Typ.t
+    -> ('elt_var array, 'elt_value array, 'f field) Types.Typ.t
 
   val tuple2 :
-       ('var1, 'value1, 'field) Types.Typ.t
-    -> ('var2, 'value2, 'field) Types.Typ.t
-    -> ('var1 * 'var2, 'value1 * 'value2, 'field) Types.Typ.t
+       ('var1, 'value1, 'f field) Types.Typ.t
+    -> ('var2, 'value2, 'f field) Types.Typ.t
+    -> ('var1 * 'var2, 'value1 * 'value2, 'f field) Types.Typ.t
 
   val ( * ) :
-       ('a, 'b, 'c) Types.Typ.t
-    -> ('d, 'e, 'c) Types.Typ.t
-    -> ('a * 'd, 'b * 'e, 'c) Types.Typ.t
+       ('var1, 'value1, 'f field) Types.Typ.t
+    -> ('var2, 'value2, 'f field) Types.Typ.t
+    -> ('var1 * 'var2, 'value1 * 'value2, 'f field) Types.Typ.t
 
   val tuple3 :
-       ('var1, 'value1, 'field) Types.Typ.t
-    -> ('var2, 'value2, 'field) Types.Typ.t
-    -> ('var3, 'value3, 'field) Types.Typ.t
-    -> ('var1 * 'var2 * 'var3, 'value1 * 'value2 * 'value3, 'field) Types.Typ.t
+       ('var1, 'value1, 'f field) Types.Typ.t
+    -> ('var2, 'value2, 'f field) Types.Typ.t
+    -> ('var3, 'value3, 'f field) Types.Typ.t
+    -> ( 'var1 * 'var2 * 'var3
+       , 'value1 * 'value2 * 'value3
+       , 'f field )
+       Types.Typ.t
 
   val hlist :
-       (unit, unit, 'a, 'b, 'c Checked.field) Types.Data_spec.t
-    -> ((unit, 'a) H_list.t, (unit, 'b) H_list.t, 'c Checked.field) Types.Typ.t
+       (unit, unit, 'vars, 'values, 'f field) Types.Data_spec.t
+    -> ((unit, 'vars) H_list.t, (unit, 'values) H_list.t, 'f field) Types.Typ.t
 
   val of_hlistable :
-       (unit, unit, 'k_var, 'k_value, 'a Checked.field) Types.Data_spec.t
+       (unit, unit, 'k_var, 'k_value, 'a field) Types.Data_spec.t
     -> var_to_hlist:('var -> (unit, 'k_var) H_list.t)
     -> var_of_hlist:((unit, 'k_var) H_list.t -> 'var)
     -> value_to_hlist:('value -> (unit, 'k_value) H_list.t)
     -> value_of_hlist:((unit, 'k_value) H_list.t -> 'value)
-    -> ('var, 'value, 'a Checked.field) Types.Typ.t
+    -> ('var, 'value, 'a field) Types.Typ.t
 end
 
 module type S = sig

--- a/src/typ_intf.ml
+++ b/src/typ_intf.ml
@@ -1,0 +1,95 @@
+module type S' = sig
+  type 'f field
+
+  module Types : Types.Types
+
+  module Data_spec : sig
+    val size : ('a, 'b, 'c, 'd, 'f) Types.Data_spec.t -> int
+  end
+
+  val store :
+       ('var, 'value, 'field) Types.Typ.t
+    -> 'value
+    -> ('var, 'field) Typ_monads.Store.t
+
+  val read :
+       ('var, 'value, 'field) Types.Typ.t
+    -> 'var
+    -> ('value, 'field) Typ_monads.Read.t
+
+  val alloc :
+    ('var, 'value, 'field) Types.Typ.t -> ('var, 'field) Typ_monads.Alloc.t
+
+  val check :
+       ('var, 'value, 'a field) Types.Typ.t
+    -> 'var
+    -> (unit, 's, 'a field) Types.Checked.t
+
+  val unit : unit -> (unit, unit, 'field) Types.Typ.t
+
+  val field : unit -> ('field Cvar.t, 'field, 'field) Types.Typ.t
+
+  val transport :
+       ('var1, 'value1, 'field) Types.Typ.t
+    -> there:('value2 -> 'value1)
+    -> back:('value1 -> 'value2)
+    -> ('var1, 'value2, 'field) Types.Typ.t
+
+  val transport_var :
+       ('var1, 'value, 'field) Types.Typ.t
+    -> there:('var2 -> 'var1)
+    -> back:('var1 -> 'var2)
+    -> ('var2, 'value, 'field) Types.Typ.t
+
+  val list :
+       length:int
+    -> ('elt_var, 'elt_value, 'field) Types.Typ.t
+    -> ('elt_var list, 'elt_value list, 'field) Types.Typ.t
+
+  val array :
+       length:int
+    -> ('elt_var, 'elt_value, 'field) Types.Typ.t
+    -> ('elt_var array, 'elt_value array, 'field) Types.Typ.t
+
+  val tuple2 :
+       ('var1, 'value1, 'field) Types.Typ.t
+    -> ('var2, 'value2, 'field) Types.Typ.t
+    -> ('var1 * 'var2, 'value1 * 'value2, 'field) Types.Typ.t
+
+  val ( * ) :
+       ('a, 'b, 'c) Types.Typ.t
+    -> ('d, 'e, 'c) Types.Typ.t
+    -> ('a * 'd, 'b * 'e, 'c) Types.Typ.t
+
+  val tuple3 :
+       ('var1, 'value1, 'field) Types.Typ.t
+    -> ('var2, 'value2, 'field) Types.Typ.t
+    -> ('var3, 'value3, 'field) Types.Typ.t
+    -> ('var1 * 'var2 * 'var3, 'value1 * 'value2 * 'value3, 'field) Types.Typ.t
+
+  val hlist :
+       (unit, unit, 'a, 'b, 'c Checked.field) Types.Data_spec.t
+    -> ((unit, 'a) H_list.t, (unit, 'b) H_list.t, 'c Checked.field) Types.Typ.t
+
+  val of_hlistable :
+       (unit, unit, 'k_var, 'k_value, 'a Checked.field) Types.Data_spec.t
+    -> var_to_hlist:('var -> (unit, 'k_var) H_list.t)
+    -> var_of_hlist:((unit, 'k_var) H_list.t -> 'var)
+    -> value_to_hlist:('value -> (unit, 'k_value) H_list.t)
+    -> value_of_hlist:((unit, 'k_value) H_list.t -> 'value)
+    -> ('var, 'value, 'a Checked.field) Types.Typ.t
+end
+
+module type S = sig
+  module Types : Types.Types
+
+  module Data_spec : sig
+    include module type of Types.Data_spec
+
+    val size : ('a, 'b, 'c, 'd, 'f) Types.Data_spec.t -> int
+  end
+
+  include S' with module Types := Types and module Data_spec := Data_spec
+
+  type ('var, 'value, 'field) t = ('var, 'value, 'field) Types.Typ.t
+end

--- a/src/types.ml
+++ b/src/types.ml
@@ -115,7 +115,13 @@ module type Types = sig
 
   module Data_spec : sig
     type ('r_var, 'r_value, 'k_var, 'k_value, 'f) t =
-      ('r_var, 'r_value,' k_var, 'k_value, 'f, (unit, unit, 'f) Checked.t) Data_spec.t
+      ( 'r_var
+      , 'r_value
+      , 'k_var
+      , 'k_value
+      , 'f
+      , (unit, unit, 'f) Checked.t )
+      Data_spec.t
 
     module T = Data_spec.T
 

--- a/src/types.ml
+++ b/src/types.ml
@@ -36,7 +36,7 @@ module Typ = struct
     ('var, 'value, 'field, 'checked) typ
 end
 
-module rec Checked : sig
+module Checked = struct
   (* TODO-someday: Consider having an "Assembly" type with only a store constructor for straight up Var.t's
     that this gets compiled into. *)
 
@@ -83,23 +83,4 @@ module rec Checked : sig
         * (('var, 'value) Handle.t -> ('a, 's, 'f) t)
         -> ('a, 's, 'f) t
     | Next_auxiliary : (int -> ('a, 's, 'f) t) -> ('a, 's, 'f) t
-end =
-  Checked
-
-and Run_state : sig
-  (** The internal state used to run a checked computation. *)
-  type ('prover_state, 'field) t =
-    { system: 'field Backend_types.R1CS_constraint_system.t option
-    ; input: 'field Vector.t
-    ; aux: 'field Vector.t
-    ; eval_constraints: bool
-    ; num_inputs: int
-    ; next_auxiliary: int ref
-    ; prover_state: 'prover_state option
-    ; stack: string list
-    ; handler: Request.Handler.t
-    ; is_running: bool
-    ; as_prover: bool ref
-    ; run_special: 'a 's. (('a, 's, 'field) Checked.t -> 'a) option }
-end =
-  Run_state
+end

--- a/src/types.ml
+++ b/src/types.ml
@@ -84,6 +84,14 @@ module Data_spec = struct
     ('r_var, 'r_value, 'k_var, 'k_value, 'f, 'checked) data_spec
 end
 
+module Provider = struct
+  type ('a, 'f, 's) t =
+    (('a Request.t, 'f, 's) As_prover0.t, ('a, 'f, 's) As_prover0.t) Provider.t
+
+  module T = Provider.T
+  include T
+end
+
 module Checked = struct
   (* TODO-someday: Consider having an "Assembly" type with only a store constructor for straight up Var.t's
     that this gets compiled into. *)

--- a/src/types.ml
+++ b/src/types.ml
@@ -114,7 +114,8 @@ module type Types = sig
   end
 
   module Data_spec : sig
-    type ('r_var, 'r_value, 'k_var, 'k_value, 'f) t = ('r_var, 'r_value, 'k_var, 'k_value, 'f, (unit, unit, 'f) Checked.t) Data_spec.t
+    type ('r_var, 'r_value, 'k_var, 'k_value, 'f) t =
+      ('r_var, 'r_value,' k_var, 'k_value, 'f, (unit, unit, 'f) Checked.t) Data_spec.t
 
     module T = Data_spec.T
 

--- a/src/types.ml
+++ b/src/types.ml
@@ -84,6 +84,44 @@ module Data_spec = struct
     ('r_var, 'r_value, 'k_var, 'k_value, 'f, 'checked) data_spec
 end
 
+module type Types = sig
+  module Checked : sig
+    type ('a, 's, 'f) t
+
+    type ('a, 's, 'f, 'arg) thunk
+  end
+
+  module As_prover : sig
+    type ('a, 'f, 's) t = ('a, 'f, 's) As_prover0.t
+  end
+
+  module Provider : sig
+    type ('a, 'f, 's) t =
+      (('a Request.t, 'f, 's) As_prover.t, ('a, 'f, 's) As_prover.t) Provider.t
+
+    module T = Provider.T
+
+    include module type of Provider.T
+  end
+
+  module Typ : sig
+    type ('var, 'value, 'f) t =
+      ('var, 'value, 'f, (unit, unit, 'f) Checked.t) Typ.t
+
+    module T = Typ.T
+
+    include module type of Typ.T
+  end
+
+  module Data_spec : sig
+    type ('r_var, 'r_value, 'k_var, 'k_value, 'f) t = ('r_var, 'r_value, 'k_var, 'k_value, 'f, (unit, unit, 'f) Checked.t) Data_spec.t
+
+    module T = Data_spec.T
+
+    include module type of Data_spec.T
+  end
+end
+
 module Provider = struct
   type ('a, 'f, 's) t =
     (('a Request.t, 'f, 's) As_prover0.t, ('a, 'f, 's) As_prover0.t) Provider.t

--- a/src/types.ml
+++ b/src/types.ml
@@ -92,7 +92,7 @@ module type Types = sig
   end
 
   module As_prover : sig
-    type ('a, 'f, 's) t = ('a, 'f, 's) As_prover0.t
+    type ('a, 'f, 's) t
   end
 
   module Provider : sig

--- a/src/types.ml
+++ b/src/types.ml
@@ -36,6 +36,54 @@ module Typ = struct
     ('var, 'value, 'field, 'checked) typ
 end
 
+module Data_spec = struct
+  module T = struct
+    (** A list of {!type:Type.Typ.t} values, describing the inputs to a checked
+        computation. The type [('r_var, 'r_value, 'k_var, 'k_value, 'field) t]
+        represents
+        - ['k_value] is the OCaml type of the computation
+        - ['r_value] is the OCaml type of the result
+        - ['k_var] is the type of the computation within the R1CS
+        - ['k_value] is the type of the result within the R1CS
+        - ['field] is the field over which the R1CS operates
+        - ['checked] is the type of checked computation that verifies the stored
+          contents as R1CS variables.
+
+        This functions the same as OCaml's default list type:
+{[
+  Data_spec.[typ1; typ2; typ3]
+
+  Data_spec.(typ1 :: typs)
+
+  let open Data_spec in
+  [typ1; typ2; typ3; typ4; typ5]
+
+  let open Data_spec in
+  typ1 :: typ2 :: typs
+
+]}
+        all function as you would expect.
+    *)
+    type ('r_var, 'r_value, 'k_var, 'k_value, 'f, 'checked) data_spec =
+      | ( :: ) :
+          ('var, 'value, 'f, 'checked) Typ.t
+          * ('r_var, 'r_value, 'k_var, 'k_value, 'f, 'checked) data_spec
+          -> ( 'r_var
+             , 'r_value
+             , 'var -> 'k_var
+             , 'value -> 'k_value
+             , 'f
+             , 'checked )
+             data_spec
+      | [] : ('r_var, 'r_value, 'r_var, 'r_value, 'f, 'checked) data_spec
+  end
+
+  include T
+
+  type ('r_var, 'r_value, 'k_var, 'k_value, 'f, 'checked) t =
+    ('r_var, 'r_value, 'k_var, 'k_value, 'f, 'checked) data_spec
+end
+
 module Checked = struct
   (* TODO-someday: Consider having an "Assembly" type with only a store constructor for straight up Var.t's
     that this gets compiled into. *)

--- a/src/vector.ml
+++ b/src/vector.ml
@@ -4,6 +4,8 @@ open Core
 
 type 'a t = unit ptr
 
+let null = null
+
 module type S = sig
   type elt
 

--- a/src/vector.mli
+++ b/src/vector.mli
@@ -2,6 +2,8 @@ open Core
 
 type 'a t
 
+val null : 'a t
+
 module type S = sig
   type elt
 


### PR DESCRIPTION
This PR
* constructs interfaces for `As_prover` to build a full instance from some utility functions, similar to what we did previously for `Checked`
* creates a `Types` module in each of these that carries around all the types necessary for the frontend
* generalises the interfaces over abstract `As_prover.t` and `Checked.t` in the `Types` module
* creates an interface and a `Make` functor for `Typ`
* functors `Snark0.Make_build` over these interfaces
* creates a `Make_full` to build a `Snark_intf.S` from generalised `Checked` and `As_prover`s
  - we will use this to pull the AST out of the imperative API, by replacing the standard `Checked.t` with a `type ('a, 's, 'f) t = ('s, 'f) Run_state.t -> ('s, 'f) Run_state.t * 'a`, for which `Snark0.Runner.Make` already builds the Checked interface
  - this will also let us implement a generalised `reduce_to_prover`, which should give us some extra compile time optimisations and make it easier to debug

The only breaking change at this stage should be that `As_prover.get_state` has changed type from `('s, 'f, 's) As_prover.t` to `unit -> ('s, 'f, 's) As_prover.t`.