### PR TITLE
[Meja] Add JS-style comments

### DIFF
--- a/meja/lexer_impl.mll
+++ b/meja/lexer_impl.mll
@@ -14,6 +14,17 @@ let mklocation (loc_start, loc_end) = {loc_start; loc_end; loc_ghost= false}
 
 let lexeme_loc lexbuf =
   mklocation (Lexing.lexeme_start_p lexbuf, Lexing.lexeme_end_p lexbuf)
+
+let comment_buffer = Buffer.create 256
+let store_lexeme lexbuf =
+  Buffer.add_string comment_buffer (Lexing.lexeme lexbuf)
+
+let get_comment comment lexbuf =
+  Buffer.reset comment_buffer;
+  comment lexbuf;
+  let s = Buffer.contents comment_buffer in
+  Buffer.reset comment_buffer;
+  s
 }
 
 let newline = ('\r'* '\n')
@@ -59,6 +70,13 @@ rule token = parse
   | "..." { DOTDOTDOT }
   | ".." { DOTDOT }
   | '.' { DOT }
+  | "//" ([^'\n']* as comment) newline
+    { new_line lexbuf; COMMENT (comment) }
+  | "//" ([^'\n']* as comment) eof
+    { new_line lexbuf; COMMENT (comment) }
+  | "/*"
+    { let comment = get_comment comment lexbuf in
+      COMMENT (comment) }
 
   | "!" symbolchar * as op { PREFIXOP op }
   | ['~' '?'] symbolchar + as op { PREFIXOP op }
@@ -71,3 +89,21 @@ rule token = parse
   | uppercase_alpha ident* { UIDENT(Lexing.lexeme lexbuf) }
   | _ { raise (Error (lexeme_loc lexbuf, Unexpected_character (Lexing.lexeme lexbuf))) }
   | eof { EOF }
+
+and comment = parse
+  | "*/"
+    { store_lexeme lexbuf }
+  | newline
+    { new_line lexbuf; store_lexeme lexbuf; comment lexbuf }
+  | _
+    { store_lexeme lexbuf; comment lexbuf }
+
+{
+  let token lexbuf =
+    let rec go () =
+      match token lexbuf with
+      | COMMENT _ -> go ()
+      | tok -> tok
+    in
+    go ()
+}

--- a/meja/parser_impl.mly
+++ b/meja/parser_impl.mly
@@ -44,6 +44,7 @@ let mkmod ~pos d = {mod_desc= d; mod_loc= mklocation pos}
 %token DOTDOTDOT
 %token DOTDOT
 %token DOT
+%token <string> COMMENT
 %token <string> PREFIXOP
 %token <string> INFIXOP0
 %token <string> INFIXOP1


### PR DESCRIPTION
This PR adds support for comments to the lexer. At present, these are discarded immediately, and never even reach the parser.