### PR TITLE
staged for reduce_to_prover

### DIFF
--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -1267,10 +1267,8 @@ module Make_basic (Backend : Backend_intf.S) = struct
     let reduce_to_prover : type a s r_value.
            ((a, s) Checked.t, Proof.t, 'k_var, 'k_value) t
         -> 'k_var
-        -> Proving_key.t
-        -> ?handlers:Handler.t list
-        -> s
-        -> 'k_value =
+        -> (Proving_key.t -> ?handlers:Handler.t list -> s -> 'k_value)
+           Staged.t =
      fun t0 k0 ->
       let next_input = ref 1 in
       let alloc_var () =
@@ -1288,8 +1286,8 @@ module Make_basic (Backend : Backend_intf.S) = struct
             fun _ -> ret
       in
       let reduced = go t0 k0 in
-      fun key ?handlers s ->
-        prove ~run:Checked.Runner.run key t0 ?handlers s reduced
+      stage (fun key ?handlers s ->
+          prove ~run:Checked.Runner.run key t0 ?handlers s reduced )
   end
 
   module Cvar1 = struct

--- a/src/snark_intf.ml
+++ b/src/snark_intf.ml
@@ -1212,10 +1212,7 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
   val reduce_to_prover :
        ((unit, 's) Checked.t, Proof.t, 'k_var, 'k_value) Data_spec.t
     -> 'k_var
-    -> Proving_key.t
-    -> ?handlers:Handler.t list
-    -> 's
-    -> 'k_value
+    -> (Proving_key.t -> ?handlers:Handler.t list -> 's -> 'k_value) Staged.t
   (** Reduce a checked computation, then generate a proof.
 
       [reduce_to_prover public_input computation] evaluates all parts of the


### PR DESCRIPTION
Just adds a 'staged' for reduce to prover to make it obvious how many arguments you have to pass in to get caching.