### PR TITLE
[Meja] Load the OCaml standard library by default

### DIFF
--- a/meja/envi.ml
+++ b/meja/envi.ml
@@ -270,7 +270,10 @@ module Scope = struct
       match Map.find resolve_env.external_modules name with
       | Some (Immediate m) -> Some m
       | Some (Deferred filename) ->
-          Some (!load_module ~loc ~name resolve_env filename)
+          let m = !load_module ~loc ~name resolve_env filename in
+          resolve_env.external_modules
+          <- Map.set resolve_env.external_modules ~key:name ~data:(Immediate m) ;
+          Some m
       | Some (In_flight filename) ->
           raise (Error (loc, Recursive_load filename))
       | None -> None

--- a/meja/envi.ml
+++ b/meja/envi.ml
@@ -1169,6 +1169,14 @@ module Core = struct
     in
     TypeDecl.import (mk_type_decl "field" (TUnfold var)) env
 
+  let lazy_t, env =
+    let var = Type.mkvar ~loc:Location.none (Some (mkloc "a")) env in
+    TypeDecl.import (mk_type_decl "lazy_t" ~params:[var] TAbstract) env
+
+  let array, env =
+    let var = Type.mkvar ~loc:Location.none (Some (mkloc "a")) env in
+    TypeDecl.import (mk_type_decl "array" ~params:[var] TAbstract) env
+
   module Type = struct
     let int = TypeDecl.mk_typ int ~params:[] env
 

--- a/meja/envi.ml
+++ b/meja/envi.ml
@@ -270,6 +270,9 @@ module Scope = struct
       match Map.find resolve_env.external_modules name with
       | Some (Immediate m) -> Some m
       | Some (Deferred filename) ->
+          resolve_env.external_modules
+          <- Map.set resolve_env.external_modules ~key:name
+               ~data:(In_flight filename) ;
           let m = !load_module ~loc ~name resolve_env filename in
           resolve_env.external_modules
           <- Map.set resolve_env.external_modules ~key:name ~data:(Immediate m) ;

--- a/meja/envi.ml
+++ b/meja/envi.ml
@@ -17,6 +17,7 @@ type error =
   | No_unifiable_implicit
   | Multiple_instances of type_expr
   | Recursive_load of string
+  | Predeclared_types of string list
 
 exception Error of Location.t * error
 
@@ -35,7 +36,10 @@ module TypeEnvi = struct
     ; implicit_vars: expression list
     ; implicit_id: int
     ; type_decls: type_decl int_map
-    ; instances: (int * type_expr) list }
+    ; instances: (int * type_expr) list
+    ; predeclared_types:
+        (int (* id *) * int option ref (* num. args *) * Location.t) name_map
+    }
 
   let empty =
     { type_id= 1
@@ -45,7 +49,8 @@ module TypeEnvi = struct
     ; implicit_id= 1
     ; implicit_vars= []
     ; type_decls= Map.empty (module Int)
-    ; instances= [] }
+    ; instances= []
+    ; predeclared_types= Map.empty (module String) }
 
   let instance env (typ : type_expr) =
     Map.find env.variable_instances typ.type_id
@@ -82,7 +87,8 @@ type 'a or_deferred =
 
 type 'a resolve_env =
   { mutable type_env: TypeEnvi.t
-  ; mutable external_modules: 'a or_deferred name_map }
+  ; mutable external_modules: 'a or_deferred name_map
+  ; mutable predeclare_types: bool }
 
 module Scope = struct
   type kind = Module | Expr | Open | Continue
@@ -154,7 +160,7 @@ module Scope = struct
         type_decls= Map.set type_decls ~key:decl.tdec_ident.txt ~data:decl }
     in
     match decl.tdec_desc with
-    | TAbstract | TAlias _ | TUnfold _ | TOpen -> scope
+    | TAbstract | TAlias _ | TUnfold _ | TOpen | TForward _ -> scope
     | TRecord fields -> List.foldi ~f:(add_field decl) ~init:scope fields
     | TVariant ctors -> List.foldi ~f:(add_ctor decl) ~init:scope ctors
     | TExtend (_, _, ctors) ->
@@ -291,7 +297,9 @@ module Scope = struct
 end
 
 let empty_resolve_env =
-  {type_env= TypeEnvi.empty; external_modules= Map.empty (module String)}
+  { type_env= TypeEnvi.empty
+  ; external_modules= Map.empty (module String)
+  ; predeclare_types= false }
 
 type t =
   {scope_stack: Scope.t list; depth: int; resolve_env: Scope.t resolve_env}
@@ -344,6 +352,18 @@ let pop_module ~loc env =
   (m, env)
 
 let close_expr_scope env = snd (pop_expr_scope env)
+
+let set_type_predeclaring env = (env.resolve_env).predeclare_types <- true
+
+let unset_type_predeclaring env =
+  if Map.is_empty env.resolve_env.type_env.predeclared_types then
+    (env.resolve_env).predeclare_types <- false
+  else
+    let _, (_, _, loc) =
+      Map.min_elt_exn env.resolve_env.type_env.predeclared_types
+    in
+    let predeclared = Map.keys env.resolve_env.type_env.predeclared_types in
+    raise (Error (loc, Predeclared_types predeclared))
 
 let map_current_scope ~f env =
   match env.scope_stack with
@@ -425,7 +445,33 @@ let raw_find_type_declaration (lid : lid) env =
     find_of_lident ~kind:"type" ~get_name:Scope.get_type_declaration lid env
   with
   | Some v -> v
-  | None -> raise (Error (lid.loc, Unbound_type lid.txt))
+  | None -> (
+    match lid.txt with
+    | Lident name when env.resolve_env.predeclare_types ->
+        let {type_env; _} = env.resolve_env in
+        let id, num_args =
+          match Map.find type_env.predeclared_types name with
+          | Some (id, num_args, _loc) -> (id, num_args)
+          | None ->
+              let id, type_env = TypeEnvi.next_decl_id type_env in
+              let num_args = ref None in
+              let type_env =
+                { type_env with
+                  predeclared_types=
+                    Map.add_exn ~key:name
+                      ~data:(id, ref None, lid.loc)
+                      type_env.predeclared_types }
+              in
+              (env.resolve_env).type_env <- type_env ;
+              (id, num_args)
+        in
+        { tdec_ident= Location.mkloc name lid.loc
+        ; tdec_params= []
+        ; tdec_implicit_params= []
+        ; tdec_desc= TForward num_args
+        ; tdec_id= id
+        ; tdec_loc= lid.loc }
+    | _ -> raise (Error (lid.loc, Unbound_type lid.txt)) )
 
 module Type = struct
   type env = t
@@ -492,7 +538,16 @@ module Type = struct
               ; var_implicit_params= decl.tdec_implicit_params }
             in
             let given_args_length = List.length var_params in
-            let expected_args_length = List.length decl.tdec_params in
+            let expected_args_length =
+              match decl.tdec_desc with
+              | TForward num_args -> (
+                match !num_args with
+                | Some l -> l
+                | None ->
+                    num_args := Some given_args_length ;
+                    given_args_length )
+              | _ -> List.length decl.tdec_params
+            in
             if not (Int.equal given_args_length expected_args_length) then
               raise
                 (Error
@@ -768,12 +823,15 @@ module Type = struct
     | Tarrow (typ1, typ2, _) ->
         Set.union (implicit_params typ1) (implicit_params typ2)
     | Tctor variant ->
+        let {predeclare_types; _} = env.resolve_env in
+        env.resolve_env.predeclare_types <- false;
         let ctor_params =
           try
             let decl = raw_find_type_declaration variant.var_ident env in
             Set.of_list (module Comparator) decl.tdec_implicit_params
           with Error (_, Unbound_type _) -> Set.empty (module Comparator)
         in
+        env.resolve_env.predeclare_types <- predeclare_types;
         Set.union_list
           (module Comparator)
           (ctor_params :: List.map ~f:implicit_params variant.var_params)
@@ -797,7 +855,29 @@ module TypeDecl = struct
     ; tdec_loc= loc }
 
   let import decl env =
-    let tdec_id = next_id env in
+    let tdec_id =
+      match
+        Map.find env.resolve_env.type_env.predeclared_types decl.tdec_ident.txt
+      with
+      | Some (id, num_args, loc) ->
+          ( match !num_args with
+          | Some num_args ->
+              let given = List.length decl.tdec_params in
+              if not (Int.equal given num_args) then
+                raise
+                  (Error
+                     ( loc
+                     , Wrong_number_args
+                         (Lident decl.tdec_ident.txt, given, num_args) ))
+          | None -> () ) ;
+          let {type_env; _} = env.resolve_env in
+          (env.resolve_env).type_env
+          <- { type_env with
+               predeclared_types=
+                 Map.remove type_env.predeclared_types decl.tdec_ident.txt } ;
+          id
+      | None -> next_id env
+    in
     let env = open_expr_scope env in
     let env, tdec_params =
       List.fold_map ~init:env decl.tdec_params ~f:(fun env param ->
@@ -834,6 +914,7 @@ module TypeDecl = struct
                  Set.union_list
                    (module Type)
                    (List.map typs ~f:(Type.implicit_params env)) ))
+      | TForward _ -> failwith "Cannot import a forward type declaration"
     in
     let tdec_implicit_params = Set.to_list tdec_implicit_params in
     (* Make sure the declaration is available to lookup for recursive types. *)
@@ -847,8 +928,7 @@ module TypeDecl = struct
     let env = push_scope scope env in
     let tdec_desc, env =
       match decl.tdec_desc with
-      | TAbstract -> (TAbstract, env)
-      | TOpen -> (TOpen, env)
+      | (TAbstract | TOpen | TForward _) as desc -> (desc, env)
       | TAlias typ ->
           let typ, env = Type.import ~must_find:true typ env in
           (TAlias typ, env)
@@ -1158,6 +1238,10 @@ let report_error ppf = function
         pp_typ typ
   | Recursive_load filename ->
       fprintf ppf "Circular dependency found; tried to re-load %s" filename
+  | Predeclared_types types ->
+      fprintf ppf "Could not find declarations for some types:@.%a"
+        (pp_print_list ~pp_sep:pp_print_space pp_print_string)
+        types
 
 let () =
   Location.register_error_of_exn (function

--- a/meja/envi.ml
+++ b/meja/envi.ml
@@ -824,14 +824,14 @@ module Type = struct
         Set.union (implicit_params typ1) (implicit_params typ2)
     | Tctor variant ->
         let {predeclare_types; _} = env.resolve_env in
-        env.resolve_env.predeclare_types <- false;
+        (env.resolve_env).predeclare_types <- false ;
         let ctor_params =
           try
             let decl = raw_find_type_declaration variant.var_ident env in
             Set.of_list (module Comparator) decl.tdec_implicit_params
           with Error (_, Unbound_type _) -> Set.empty (module Comparator)
         in
-        env.resolve_env.predeclare_types <- predeclare_types;
+        (env.resolve_env).predeclare_types <- predeclare_types ;
         Set.union_list
           (module Comparator)
           (ctor_params :: List.map ~f:implicit_params variant.var_params)

--- a/meja/loader.ml
+++ b/meja/loader.ml
@@ -1,13 +1,13 @@
 open Core_kernel
 open Cmi_format
 
-let load ~loc ~name resolve_env filename =
-  Format.(fprintf err_formatter "Loading %s from %s...@." name filename) ;
+let load ~loc ~name:_ resolve_env filename =
+  (*Format.(fprintf err_formatter "Loading %s from %s...@." name filename) ;*)
   let cmi_info = read_cmi filename in
   let signature = Of_ocaml.to_signature cmi_info.cmi_sign in
   let env = {Envi.Core.env with resolve_env} in
   let env = Typechecker.check_signature env signature in
-  Format.(fprintf err_formatter "Loaded@.") ;
+  (*Format.(fprintf err_formatter "Loaded@.") ;*)
   let m, _ = Envi.pop_module ~loc env in
   m
 

--- a/meja/meja.ml
+++ b/meja/meja.ml
@@ -36,6 +36,7 @@ let main =
   let ast_file = ref None in
   let binml_file = ref None in
   let default = ref true in
+  let stdlib = ref true in
   let set_and_clear_default opt name =
     default := false ;
     opt := Some name
@@ -61,10 +62,35 @@ let main =
       , "load a .cmi file" )
     ; ( "-I"
       , Arg.String (fun dirname -> cmi_dirs := dirname :: !cmi_dirs)
-      , "add a directory to the list of paths to search for .cmi files" ) ]
+      , "add a directory to the list of paths to search for .cmi files" )
+    ; ( "--stdlib"
+      , Arg.Set stdlib
+      , "load the OCaml standard library \x1B[4mdefault\x1B[24m" )
+    ; ( "--no-stdlib"
+      , Arg.Clear stdlib
+      , "do not load the OCaml standard library" ) ]
   in
   Arg.parse arg_spec (fun filename -> file := Some filename) "" ;
   let env = Envi.Core.env in
+  let env =
+    if !stdlib then (
+      match Sys.getenv_opt "OPAM_SWITCH_PREFIX" with
+      | Some opam_path ->
+          let ocaml_path = Filename.concat opam_path "lib/ocaml" in
+          Loader.load_directory env ocaml_path ;
+          let stdlib_scope =
+            Loader.load ~loc:Location.none ~name:"Stdlib" env.Envi.resolve_env
+              (Filename.concat ocaml_path "stdlib.cmi")
+          in
+          Envi.open_namespace_scope stdlib_scope env
+      | None ->
+          Format.(
+            fprintf err_formatter
+              "Warning: OPAM_SWITCH_PREFIX environment variable is not set. \
+               Not loading the standard library.") ;
+          env )
+    else env
+  in
   List.iter !cmi_dirs ~f:(Loader.load_directory env) ;
   try
     let cmi_files = List.rev !cmi_files in

--- a/meja/parsetypes.ml
+++ b/meja/parsetypes.ml
@@ -99,6 +99,8 @@ and type_decl_desc =
   | TOpen
   | TExtend of lid * type_decl * ctor_decl list
       (** Internal; this should never be present in the AST. *)
+  | TForward of int option ref
+      (** Forward declaration for types loaded from cmi files. *)
 
 type pattern =
   {pat_desc: pattern_desc; pat_loc: Location.t; pat_type: type_expr}

--- a/meja/scripts/run-tests.sh
+++ b/meja/scripts/run-tests.sh
@@ -36,7 +36,7 @@ check_diff() {
 }
 
 run_test() {
-  run_dune exec meja/meja.exe -- -I ../_build/default/src/.snarky.objs/byte --ml "tests/out/$1.ml" --stderr "tests/out/$1.stderr" "tests/$1.meja" 2> /dev/null
+  run_dune exec meja/meja.exe -- -I $OPAM_SWITCH_PREFIX/lib/ocaml --load-cmi $OPAM_SWITCH_PREFIX/lib/ocaml/stdlib.cmi -I ../_build/default/src/.snarky.objs/byte --ml "tests/out/$1.ml" --stderr "tests/out/$1.stderr" "tests/$1.meja" 2> /dev/null
   if [ $? -ne 0 ]; then
     if [ -e "tests/$1.fail" ]; then
       if [[ "$update_output" -eq 0 ]]; then

--- a/meja/scripts/run-tests.sh
+++ b/meja/scripts/run-tests.sh
@@ -36,7 +36,7 @@ check_diff() {
 }
 
 run_test() {
-  run_dune exec meja/meja.exe -- -I $OPAM_SWITCH_PREFIX/lib/ocaml --load-cmi $OPAM_SWITCH_PREFIX/lib/ocaml/stdlib.cmi -I ../_build/default/src/.snarky.objs/byte --ml "tests/out/$1.ml" --stderr "tests/out/$1.stderr" "tests/$1.meja" 2> /dev/null
+  run_dune exec meja/meja.exe -- -I ../_build/default/src/.snarky.objs/byte --ml "tests/out/$1.ml" --stderr "tests/out/$1.stderr" "tests/$1.meja" 2> /dev/null
   if [ $? -ne 0 ]; then
     if [ -e "tests/$1.fail" ]; then
       if [[ "$update_output" -eq 0 ]]; then

--- a/meja/tests/stdlib.meja
+++ b/meja/tests/stdlib.meja
@@ -1,0 +1,9 @@
+let test_plus = 1 + 2;
+
+let test_times = 3 * 4;
+
+let test_print_int = print_int(15);
+
+let fold_list = fun (l : list(bool)) => {
+  List.fold_left ((fun (x, y) => {x && y;}), true, l);
+};

--- a/meja/tests/stdlib.ml
+++ b/meja/tests/stdlib.ml
@@ -1,0 +1,7 @@
+let test_plus = 1 + 2
+
+let test_times = 3 * 4
+
+let test_print_int = print_int 15
+
+let fold_list (l : bool list) = List.fold_left (fun x y -> x && y) true l

--- a/meja/to_ocaml.ml
+++ b/meja/to_ocaml.ml
@@ -51,6 +51,7 @@ let of_type_decl decl =
   | TOpen -> Type.mk name ~loc ~params ~kind:Parsetree.Ptype_open
   | TExtend _ -> failwith "Cannot convert TExtend to OCaml"
   | TUnfold _ -> failwith "Cannot convert TUnfold to OCaml"
+  | TForward _ -> failwith "Cannot convert TForward to OCaml"
 
 let rec of_pattern_desc ?loc = function
   | PAny -> Pat.any ?loc ()

--- a/meja/typechecker.ml
+++ b/meja/typechecker.ml
@@ -772,10 +772,14 @@ let rec check_signature_item env item =
   let loc = item.sig_loc in
   match item.sig_desc with
   | SValue (name, typ) ->
+      let env = Envi.open_expr_scope env in
       let typ, env = Envi.Type.import ~must_find:false typ env in
+      let env = Envi.close_expr_scope env in
       add_polymorphised name typ env
   | SInstance (name, typ) ->
+      let env = Envi.open_expr_scope env in
       let typ, env = Envi.Type.import ~must_find:false typ env in
+      let env = Envi.close_expr_scope env in
       let env = add_polymorphised name typ env in
       Envi.add_implicit_instance name.txt typ env
   | STypeDecl decl ->

--- a/meja/typechecker.ml
+++ b/meja/typechecker.ml
@@ -799,6 +799,12 @@ let rec check_signature_item env item =
 and check_signature env signature =
   List.fold ~init:env signature ~f:check_signature_item
 
+let check_signature env signature =
+  Envi.set_type_predeclaring env ;
+  let ret = check_signature env signature in
+  Envi.unset_type_predeclaring env ;
+  ret
+
 let check (ast : statement list) (env : Envi.t) =
   List.fold_map ast ~init:env ~f:check_statement
 


### PR DESCRIPTION
This PR
* adds type predeclarations when an as-yet undeclared type shows up in an `.cmi` file
  - this happens with co-recursive types (ie. `type t = ... and u = ...`), which the stdlib includes (notably in `camlinternalFormatBasics.mli`)
* fixes a bug where type variables leak between value declarations loaded from `.cmi` files
* loads the OCaml standard library by default
* adds some tests

Edit:
* fixes caching and recursive loads in the loader
* adds the `lazy_t` and `array` primitive types to the initial environment.