### PR TITLE
[Meja] Add parsing for bare function unit argument

### DIFF
--- a/meja/tests/test.meja
+++ b/meja/tests/test.meja
@@ -42,3 +42,7 @@ let h = fun (ignore : int -> unit) => {
   let f = fun (x, y) => {x;};
   f (a, f (b, f (c, f (d, e))));
 };
+
+let i = fun () => { (); };
+
+let j = i ();

--- a/meja/tests/test.ml
+++ b/meja/tests/test.ml
@@ -43,3 +43,7 @@ let h (ignore : int -> unit) =
   ignore e ;
   let f x y = x in
   f a (f b (f c (f d e)))
+
+let i () = ()
+
+let j = i ()


### PR DESCRIPTION
This PR adds parsing for the syntax `fun () => {...}` and `f()`.