### PR TITLE
fix the Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.merlin
+_build
+*.install
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ RUN sudo chown -R opam:opam /source
 VOLUME ["/source"]
 
 # Move to a newer version of OCaml and install dune/jbuilder.
+RUN git -C /home/opam/opam-repository pull
 RUN opam update -y && opam upgrade -y
 
 WORKDIR /source


### PR DESCRIPTION
rsync was having some issue copying either _build or website.
we don't need either in the container, so ignore them with
.dockerignore.

additionally, `opam upgrade` does nothing because it's not
using the http opam repo, but a git clone. the repo must be
updated manually.