### PR TITLE
Integrate reduce_to_prover with Proof_system

### DIFF
--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -1666,10 +1666,9 @@ struct
 
     let create ?proving_key ?verification_key ?proving_key_path
         ?verification_key_path ?handlers ?reduce ~public_input checked =
-      create
-        ~reduce_to_prover:Runner.reduce_to_prover
-        ?proving_key ?verification_key ?proving_key_path ?verification_key_path
-        ?handlers ?reduce ~public_input checked
+      create ~reduce_to_prover:Runner.reduce_to_prover ?proving_key
+        ?verification_key ?proving_key_path ?verification_key_path ?handlers
+        ?reduce ~public_input checked
 
     let digest (proof_system : _ t) = digest ~run:Checked.run proof_system
 
@@ -1677,7 +1676,8 @@ struct
       generate_keypair ~run:Checked.run proof_system
 
     let run_unchecked ~public_input ?handlers ?reduce (proof_system : _ t) =
-      run_unchecked ~run:Checked.run ~public_input ?handlers ?reduce proof_system
+      run_unchecked ~run:Checked.run ~public_input ?handlers ?reduce
+        proof_system
 
     let run_checked ~public_input ?handlers ?reduce (proof_system : _ t) =
       run_checked ~run:Checked.run ~public_input ?handlers ?reduce proof_system
@@ -1687,8 +1687,8 @@ struct
 
     let prove ~public_input ?proving_key ?handlers ?reduce ?message
         (proof_system : _ t) =
-      prove ~run:Checked.run ~public_input ?proving_key ?handlers ?reduce ?message
-        proof_system
+      prove ~run:Checked.run ~public_input ?proving_key ?handlers ?reduce
+        ?message proof_system
 
     let verify ~public_input ?verification_key ?message (proof_system : _ t) =
       verify ~run:Checked.run ~public_input ?verification_key ?message
@@ -2227,24 +2227,21 @@ module Run = struct
         generate_keypair ~run proof_system
 
       let run_unchecked ~public_input ?handlers (proof_system : _ t) =
-        snd
-          (run_unchecked ~run ~public_input ?handlers proof_system
-             ())
+        snd (run_unchecked ~run ~public_input ?handlers proof_system ())
 
       let run_checked ~public_input ?handlers (proof_system : _ t) =
         Or_error.map
-          (run_checked' ~run ~public_input ?handlers proof_system
-             ()) ~f:(fun (s, x, state) -> x)
+          (run_checked' ~run ~public_input ?handlers proof_system ())
+          ~f:(fun (s, x, state) -> x)
 
       let check ~public_input ?handlers (proof_system : _ t) =
         Or_error.map ~f:(Fn.const ())
-          (run_checked' ~run ~public_input ?handlers proof_system
-             ())
+          (run_checked' ~run ~public_input ?handlers proof_system ())
 
       let prove ~public_input ?proving_key ?handlers ?message
           (proof_system : _ t) =
-        prove ~run ~public_input ?proving_key ?handlers ?message
-          proof_system ()
+        prove ~run ~public_input ?proving_key ?handlers ?message proof_system
+          ()
 
       let verify ~public_input ?verification_key ?message (proof_system : _ t)
           =

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -1184,8 +1184,8 @@ struct
 
       let run_checked' ~run ~public_input ?handlers ?reduce proof_system s =
         match
-          run_with_input ~run ?reduce ~public_input
-            ~eval_constraints:true ?handlers proof_system s
+          run_with_input ~run ?reduce ~public_input ~eval_constraints:true
+            ?handlers proof_system s
         with
         | exception e ->
             Or_error.of_exn e

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -1207,13 +1207,8 @@ struct
             ; (fun () -> read_proving_key proof_system)
             ; (fun () -> Some (generate_keypair ~run proof_system).pk) ]
         in
-        let system =
-          let s = Proving_key.r1cs_constraint_system proving_key in
-          if R1CS_constraint_system.get_primary_input_size s = 0 then Some s
-          else None
-        in
         let _, _, state =
-          run_with_input ~run ~public_input ?system ?handlers proof_system s
+          run_with_input ~run ~public_input ?handlers proof_system s
         in
         let {input; aux; _} = state in
         Proof.create ?message proving_key ~primary:input ~auxiliary:aux
@@ -1343,13 +1338,8 @@ struct
      fun ~run ?message key t ?handlers s k ->
       conv
         (fun c primary ->
-          let system =
-            let s = Proving_key.r1cs_constraint_system key in
-            if R1CS_constraint_system.get_primary_input_size s = 0 then Some s
-            else None
-          in
           let auxiliary =
-            Checked.auxiliary_input ?system ~run ?handlers
+            Checked.auxiliary_input ~run ?handlers
               ~num_inputs:(Field.Vector.length primary)
               c s primary
           in

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -1183,9 +1183,8 @@ struct
         (s, a)
 
       let run_checked' ~run ~public_input ?handlers ?reduce proof_system s =
-        let system = R1CS_constraint_system.create () in
         match
-          run_with_input ~run ?reduce ~public_input ~system
+          run_with_input ~run ?reduce ~public_input
             ~eval_constraints:true ?handlers proof_system s
         with
         | exception e ->

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -1228,8 +1228,14 @@ struct
             ; (fun () -> read_proving_key proof_system)
             ; (fun () -> Some (generate_keypair ~run proof_system).pk) ]
         in
+        let system =
+          let s = Proving_key.r1cs_constraint_system proving_key in
+          if R1CS_constraint_system.get_primary_input_size s = 0 then Some s
+          else None
+        in
         let _, _, state =
-          run_with_input ~run ?reduce ~public_input ?handlers proof_system s
+          run_with_input ~run ?reduce ~public_input ?system ?handlers
+            proof_system s
         in
         let {input; aux; _} = state in
         Proof.create ?message proving_key ~primary:input ~auxiliary:aux
@@ -1359,8 +1365,13 @@ struct
      fun ~run ?message key t ?handlers s k ->
       conv
         (fun c primary ->
+          let system =
+            let s = Proving_key.r1cs_constraint_system key in
+            if R1CS_constraint_system.get_primary_input_size s = 0 then Some s
+            else None
+          in
           let auxiliary =
-            Checked.auxiliary_input ~run ?handlers
+            Checked.auxiliary_input ?system ~run ?handlers
               ~num_inputs:(Field.Vector.length primary)
               c s primary
           in

--- a/src/snark0.mli
+++ b/src/snark0.mli
@@ -8,6 +8,14 @@ val set_eval_constraints : bool -> unit
     {!const:Types.Checked.With_constraint_system}). For these, you should
     modify your code to use the normal {!val:run_and_check} function. *)
 
+val set_reduce_to_prover : bool -> unit
+(** Sets the [reduce_to_prover] state. If [true], the [Proof_system] interface
+    will run optimised versions of the checked computations whenever possible.
+
+    Note: This optimisation pre-evaluates and caches some parts of the checked
+    computation, to speed up subsequent calls. *DO NOT USE* if your checked
+    computation uses mutability outside of [As_prover] blocks. *)
+
 module Make (Backend : Backend_intf.S) :
   Snark_intf.S
   with type field = Backend.Field.t

--- a/src/snark_intf.ml
+++ b/src/snark_intf.ml
@@ -903,6 +903,7 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
       -> ?proving_key_path:string
       -> ?verification_key_path:string
       -> ?handlers:Handler.t list
+      -> ?reduce:bool
       -> public_input:( ('a, 's) Checked.t
                       , unit
                       , 'computation
@@ -928,6 +929,8 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
           written to this file.
         - [handlers] -- optional, the list of handlers that should be used to
           handle requests made from the checked computation
+        - [reduce] -- optional, default [false], whether to perform the
+          [reduce_to_caller] optimisation while creating the proof system
         - [public_input] -- the {!type:Data_spec.t} that describes the form
           that the public inputs must take
         - ['computation] -- a checked computation that takes as arguments
@@ -945,6 +948,7 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
     val run_unchecked :
          public_input:(unit, 'public_input) H_list.t
       -> ?handlers:Handler.t list
+      -> ?reduce:bool
       -> ('a, 's, 'public_input) t
       -> 's
       -> 's * 'a
@@ -955,6 +959,7 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
     val run_checked :
          public_input:(unit, 'public_input) H_list.t
       -> ?handlers:Handler.t list
+      -> ?reduce:bool
       -> (('a, 's) As_prover.t, 's, 'public_input) t
       -> 's
       -> ('s * 'a) Or_error.t
@@ -963,6 +968,7 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
     val check :
          public_input:(unit, 'public_input) H_list.t
       -> ?handlers:Handler.t list
+      -> ?reduce:bool
       -> ('a, 's, 'public_input) t
       -> 's
       -> unit Or_error.t
@@ -975,6 +981,7 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
          public_input:(unit, 'public_input) H_list.t
       -> ?proving_key:Proving_key.t
       -> ?handlers:Handler.t list
+      -> ?reduce:bool
       -> ?message:Proof.message
       -> ('a, 's, 'public_input) t
       -> 's
@@ -986,6 +993,9 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
         - The [handlers] argument adds handlers to those already given to
           {!val:create}. If handlers for the same requests were provided to
           both, the ones passed here are given priority.
+        - The [reduce] argument determines whether to run use the
+          [reduce_to_prover]-optimised checked computation. The default value
+          may be changed with {!val:Snark0.set_reduce_to_prover}.
         - The [message] argument specifies the message to associate with the
           proof, if any.
     *)


### PR DESCRIPTION
This PR
* adds support for `reduced_to_prover` to the `Proof_system.run_unchecked`/`run_checked`/`check`/`prove` functions via the optional `reduce` parameter
* adds a `reduce` parameter to `Proof_system.create` to generate the reduced version eagerly
* adds a global `set_reduce_to_prover` function, to override default behaviour