### PR TITLE
Stop exposing old reduce_to_prover interface

### DIFF
--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -1720,8 +1720,6 @@ struct
 
   let check t s = check ~run:Checked.run t s
 
-  let reduce_to_prover = Run.reduce_to_prover
-
   module Test = struct
     let checked_to_unchecked typ1 typ2 checked input =
       let (), checked_result =

--- a/src/snark_intf.ml
+++ b/src/snark_intf.ml
@@ -1221,38 +1221,6 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
       Returns [unit]; this is for testing only.
   *)
 
-  val reduce_to_prover :
-       ((unit, 's) Checked.t, Proof.t, 'k_var, 'k_value) Data_spec.t
-    -> 'k_var
-    -> (Proving_key.t -> ?handlers:Handler.t list -> 's -> 'k_value) Staged.t
-  (** Reduce a checked computation, then generate a proof.
-
-      [reduce_to_prover public_input computation] evaluates all parts of the
-      {!type:Checked.t} [computation] except {!module:As_prover} blocks, and
-      generates a program that can be used to generate proofs more quickly with
-      different inputs.
-
-      For example, for a checked computation [main] with inputs [inputs] and
-      proving key [pk],
-{[
-  let prove_main = reduce_to_prover inputs main
-
-  let proof1 = prove_main pk s1 input1a input1b input1c
-  let proof2 = prove_main pk s2 input2a input2b input2c
-  let proof3 = prove_main pk s3 input3a input3b input3c
-}]
-      is equivalent to
-{[
-  let proof1 = prove pk inputs s1 main input1a input1b input1c
-  let proof2 = prove pk inputs s2 main input2a input2b input2c
-  let proof3 = prove pk inputs s3 main input3a input3b input3c
-}]
-
-      **WARNING**: Any code inside a [Checked.t] that isn't inside an
-      [As_prover] block will only be run once. DO NOT USE if you use mutation
-      inside [Checked.t].
-  *)
-
   val constraint_count :
     ?log:(?start:bool -> string -> int -> unit) -> (_, _) Checked.t -> int
   (** Returns the number of constraints in the constraint system.


### PR DESCRIPTION
The new interface in #200 (using `Proof_system`) makes it much safer and easier to use `reduce_to_prover`, as well as giving us much more granularity in where/when we use it.