### PR TITLE
Use the message argument to verify proofs

### DIFF
--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -1218,8 +1218,7 @@ struct
         let {input; aux; _} = state in
         Proof.create ?message proving_key ~primary:input ~auxiliary:aux
 
-      let verify ~run ~public_input ?verification_key ?message proof_system
-          proof =
+      let verify ~public_input ?verification_key ?message proof_system proof =
         let input =
           proof_system.provide_inputs (Field.Vector.create ()) public_input
         in
@@ -1675,8 +1674,7 @@ struct
         proof_system
 
     let verify ~public_input ?verification_key ?message (proof_system : _ t) =
-      verify ~run:Checked.run ~public_input ?verification_key ?message
-        proof_system
+      verify ~public_input ?verification_key ?message proof_system
   end
 
   module Perform = struct
@@ -2225,7 +2223,7 @@ module Run = struct
 
       let verify ~public_input ?verification_key ?message (proof_system : _ t)
           =
-        verify ~run:as_stateful ~public_input ?verification_key proof_system
+        verify ~public_input ?verification_key ?message proof_system
     end
 
     let assert_ ?label c = run (assert_ ?label c)


### PR DESCRIPTION
This PR
* fixes the error where the `message` parameter wasn't passed through the `Proof_system.verify` API
* removes the unused internal `run` parameter to `Proof_system.verify`