### PR TITLE
Set warning 34 (unused type) to be an error, remove unused types

### DIFF
--- a/src/curves.ml
+++ b/src/curves.ml
@@ -742,7 +742,7 @@ module Make_weierstrass_checked
       end
     end
 
-    let create (type shifted) () : ((module S), _) Checked.t =
+    let create () : ((module S), _) Checked.t =
       let%map shift =
         exists typ ~compute:As_prover.(map (return ()) ~f:Curve.random)
       in

--- a/src/dune
+++ b/src/dune
@@ -1,7 +1,7 @@
 (library
  (name snarky)
  (public_name snarky)
- (flags :standard -short-paths -safe-string -warn-error -27-32-9-39-6-34)
+ (flags :standard -short-paths -safe-string -warn-error -27-32-9-39-6)
  (inline_tests)
  (libraries core_kernel fold_lib tuple_lib bitstring_lib interval_union
    bignum camlsnark_c)

--- a/src/libsnark.ml
+++ b/src/libsnark.ml
@@ -1213,8 +1213,6 @@ module Make_proof_system_keys (M : Proof_system_inputs_intf) = struct
   end = struct
     include Proving_key.Make (struct
       let prefix = with_prefix M.prefix "proving_key"
-
-      type field = M.Field.t
     end)
 
     let r1cs_constraint_system =
@@ -1337,8 +1335,6 @@ module Make_proof_system_keys (M : Proof_system_inputs_intf) = struct
   end = struct
     include Verification_key.Make (struct
       let prefix = with_prefix M.prefix "verification_key"
-
-      type field = M.Field.t
     end)
 
     let size_in_bits =
@@ -1406,8 +1402,6 @@ module Make_proof_system_keys (M : Proof_system_inputs_intf) = struct
   end = struct
     include Keypair.Make (struct
       let prefix = with_prefix M.prefix "keypair"
-
-      type field = M.Field.t
     end)
 
     let pk =
@@ -1484,8 +1478,6 @@ struct
   end = struct
     include Proof.Make (struct
       let prefix = with_prefix M.prefix "proof"
-
-      type field = M.Field.t
     end)
 
     type message = unit

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -459,7 +459,7 @@ struct
 
     type 'prover_state run_state = 'prover_state Runner.run_state
 
-    let rec constraint_count_aux : type a s s1.
+    let rec constraint_count_aux : type a s.
            log:(?start:_ -> _)
         -> auxc:_
         -> int
@@ -477,7 +477,7 @@ struct
               None
           in
           let count = ref count in
-          let run_special (type a s s1) (x : (a, s, _) Types.Checked.t) =
+          let run_special (type a s) (x : (a, s, _) Types.Checked.t) =
             let count', a = constraint_count_aux ~log ~auxc !count x in
             count := count' ;
             a
@@ -1000,7 +1000,7 @@ struct
         ; proving_key_path: string option
         ; verification_key_path: string option }
 
-      let rec allocate_inputs : type checked r2 k1 k2.
+      let rec allocate_inputs : type checked k1 k2.
              (unit, 's) Checked.t
           -> int ref
           -> (checked, unit, k1, k2) t
@@ -1265,10 +1265,10 @@ struct
       in
       Checked.constraint_system ~run:run_in_run ~num_inputs:(!next_input - 1) r
 
-    let constraint_system (type a s checked k_var k_val) :
+    let constraint_system (type a s checked k_var) :
            run:(a, s, checked) Checked.Runner.run
-        -> exposing:(checked, _, 'k_var, _) t
-        -> 'k_var
+        -> exposing:(checked, _, k_var, _) t
+        -> k_var
         -> R1CS_constraint_system.t =
      fun ~run ~exposing k -> r1cs_h ~run (ref 1) exposing k
 
@@ -1374,7 +1374,7 @@ struct
           ignore auxiliary )
         t k
 
-    let reduce_to_prover : type a s r_value.
+    let reduce_to_prover : type a s.
            ((a, s, Field.t) Checked_ast.t, Proof.t, 'k_var, 'k_value) t
         -> 'k_var
         -> (Proving_key.t -> ?handlers:Handler.t list -> s -> 'k_value)


### PR DESCRIPTION
This PR makes unused types a compile-time error, fixes up the places where we have unused types.

This accounts for 11 of the compile-time warnings that flood the output every time we compile snarky.