### PR TITLE
Override printf in libsnark, add hooks for updating the destination

### DIFF
--- a/src/camlsnark_c/libsnark-caml/depends/libff/libff/common/utils.hpp
+++ b/src/camlsnark_c/libsnark-caml/depends/libff/libff/common/utils.hpp
@@ -62,5 +62,9 @@ size_t size_in_bits(const std::vector<T> &v);
 
 } // libff
 
+int snarky_printf (const char* format, ...);
+
+#define printf(...) snarky_printf(__VA_ARGS__)
+
 #include <libff/common/utils.tcc> /* note that utils has a templatized part (utils.tcc) and non-templatized part (utils.cpp) */
 #endif // UTILS_HPP_

--- a/src/libsnark.ml
+++ b/src/libsnark.ml
@@ -28,6 +28,17 @@ let set_printing_stdout =
 let set_printing_file =
   foreign "camlsnark_set_printing_file" (string @-> returning void)
 
+let set_printing_fun =
+  let stub =
+    foreign "camlsnark_set_printing_fun"
+      (funptr (string @-> returning void) @-> returning void)
+  in
+  let f_ref = ref (fun _ -> ()) in
+  let dispatch str = Sys.opaque_identity (!f_ref str) in
+  fun f ->
+    f_ref := f ;
+    stub dispatch
+
 let () = set_no_profiling true
 
 module Make_group_coefficients (P : sig

--- a/src/libsnark.ml
+++ b/src/libsnark.ml
@@ -19,6 +19,15 @@ end
 let set_no_profiling =
   foreign "camlsnark_set_profiling" (bool @-> returning void)
 
+let set_printing_off =
+  foreign "camlsnark_set_printing_off" (void @-> returning void)
+
+let set_printing_stdout =
+  foreign "camlsnark_set_printing_stdout" (void @-> returning void)
+
+let set_printing_file =
+  foreign "camlsnark_set_printing_file" (string @-> returning void)
+
 let () = set_no_profiling true
 
 module Make_group_coefficients (P : sig

--- a/src/libsnark.ml
+++ b/src/libsnark.ml
@@ -28,16 +28,20 @@ let set_printing_stdout =
 let set_printing_file =
   foreign "camlsnark_set_printing_file" (string @-> returning void)
 
+module Print_func = struct
+  let print = ref (fun _ -> ())
+
+  let dispatch str = Sys.opaque_identity (!print str)
+end
+
 let set_printing_fun =
   let stub =
     foreign "camlsnark_set_printing_fun"
       (funptr (string @-> returning void) @-> returning void)
   in
-  let f_ref = ref (fun _ -> ()) in
-  let dispatch str = Sys.opaque_identity (!f_ref str) in
   fun f ->
-    f_ref := f ;
-    stub dispatch
+    Print_func.print := f ;
+    stub Print_func.dispatch
 
 let () = set_no_profiling true
 


### PR DESCRIPTION
This PR
* overrides `printf` in the libsnark code using a preprocessor macro
* calls into our own function for printing
* adds some setters to change the destination of the logging

Currently the hooks are:
* `Snarky.Libsnark.set_printing_stdout ()` - default, print to stdout
* `Snarky.Libsnark.set_printing_off ()` - don't print anything
* `Snarky.Libsnark.set_printing_file "filename.log"` - log to `filename.log`

~~I'm working on a way to pipe the `printf`s through to the coda logger, but the memory story is a bit more complicated there.~~

Edit: added `Snarky.Libsnark.set_printing_fun (fun str -> _)` - passes the string libsnark was trying to print (up to length 1023 characters) to the given function for printing.