### PR TITLE
[Meja] Print meja-style types in error messages

### DIFF
--- a/meja/src/envi.ml
+++ b/meja/src/envi.ml
@@ -1467,41 +1467,46 @@ let report_error ppf = function
       fprintf ppf
         "Internal error: Expected the current scope to be a %s scope." kind
   | Multiple_definition (kind, name) ->
-      fprintf ppf "Multiple definition of the %s name %s" kind name
+      fprintf ppf "@[<hov>Multiple definition of the %s name@ %s@]" kind name
   | Unbound_type_var var ->
-      fprintf ppf "Unbound type parameter %a." pp_typ var
+      fprintf ppf "@[<hov>Unbound type parameter@ @[<h>%a@].@]" pp_typ var
   | Unbound_type lid ->
-      fprintf ppf "Unbound type constructor %a." Longident.pp lid
+      fprintf ppf "@[<hov>Unbound type constructor@ @[<h>%a@].@]" Longident.pp
+        lid
   | Unbound_module lid ->
-      fprintf ppf "Unbound module %a." Longident.pp lid
+      fprintf ppf "@[<hov>Unbound module @[<h>%a@].@]" Longident.pp lid
   | Unbound_value lid ->
-      fprintf ppf "Unbound value %a." Longident.pp lid
+      fprintf ppf "@[<hov>Unbound value @[<h>%a@].@]" Longident.pp lid
   | Wrong_number_args (lid, given, expected) ->
       fprintf ppf
-        "@[The type constructor %a expects %d argument(s)@ but is here \
+        "@[The type constructor @[<h>%a@] expects %d argument(s)@ but is here \
          applied to %d argument(s).@]"
         Longident.pp lid expected given
   | Expected_type_var typ ->
-      fprintf ppf "Syntax error: Expected a type parameter, but got %a." pp_typ
-        typ
+      fprintf ppf
+        "@[<hov>Syntax error: Expected a type parameter, but got @[<h>%a@].@]"
+        pp_typ typ
   | Lident_unhandled (kind, lid) ->
-      fprintf ppf "Don't know how to find %s %a" kind Longident.pp lid
+      fprintf ppf "@[<hov>Don't know how to find %s @[<h>%a@].@]" kind
+        Longident.pp lid
   | Constraints_not_satisfied (typ, decl) ->
       fprintf ppf
-        "@[Constraints are not satisfied in this type.@ Type %a should be an \
-         instance of %a"
+        "@[<hov>Constraints are not satisfied in this type.@ Type @[<h>%a@] \
+         should be an instance of @[<h>%a@].@]"
         pp_typ typ pp_decl_typ decl
   | No_unifiable_implicit ->
       fprintf ppf "Internal error: Implicit variable is not unifiable."
   | Multiple_instances typ ->
       fprintf ppf
-        "Multiple instances were found satisfying %a, could not decide \
-         between them."
+        "@[<hov>Multiple instances were found satisfying @[<h>%a@],@ could \
+         not decide between them.@]"
         pp_typ typ
   | Recursive_load filename ->
-      fprintf ppf "Circular dependency found; tried to re-load %s" filename
+      fprintf ppf
+        "@[<hov>Circular dependency found; tried to re-load @[<h>%s@]@]"
+        filename
   | Predeclared_types types ->
-      fprintf ppf "Could not find declarations for some types:@.%a"
+      fprintf ppf "@[<hov>Could not find declarations for some types:@]@;%a@"
         (pp_print_list ~pp_sep:pp_print_space pp_print_string)
         types
   | Functor_in_module_sig ->

--- a/meja/src/envi.ml
+++ b/meja/src/envi.ml
@@ -1447,7 +1447,7 @@ end
 
 open Format
 
-let pp_typ ppf typ = Pprintast.core_type ppf (To_ocaml.of_type_expr typ)
+let pp_typ = Pprint.type_expr
 
 let pp_decl_typ ppf decl =
   pp_typ ppf

--- a/meja/src/parser_errors.ml
+++ b/meja/src/parser_errors.ml
@@ -8,8 +8,6 @@ exception Error of Location.t * error
 
 open Format
 
-let pp_typ ppf typ = Pprintast.core_type ppf (To_ocaml.of_type_expr typ)
-
 let report_error ppf = function
   | Fun_no_fat_arrow ->
       fprintf ppf "Expected => before {@."

--- a/meja/src/typechecker.ml
+++ b/meja/src/typechecker.ml
@@ -1101,42 +1101,47 @@ let pp_typ = Pprint.type_expr
 
 let rec report_error ppf = function
   | Check_failed (typ, constr_typ, err) ->
-      fprintf ppf "Incompatable types @[%a@] and @[%a@]:@.%a" pp_typ typ
-        pp_typ constr_typ report_error err
+      fprintf ppf
+        "@[<v>@[<hov>Incompatable types@ @[<h>%a@] and@ @[<h>%a@]:@]@;%a@]"
+        pp_typ typ pp_typ constr_typ report_error err
   | Cannot_unify (typ, constr_typ) ->
-      fprintf ppf "Cannot unify @[%a@] and @[%a@].@." pp_typ typ pp_typ
-        constr_typ
+      fprintf ppf "@[<hov>Cannot unify@ @[<h>%a@] and@ @[<h>%a@]@]" pp_typ typ
+        pp_typ constr_typ
   | Recursive_variable typ ->
       fprintf ppf
-        "The variable @[%a@](%d) would have an instance that contains itself."
+        "@[<hov>The variable@ @[<h>%a@](%d) would have an instance that \
+         contains itself.@]"
         pp_typ typ typ.type_id
   | Unbound (kind, value) ->
-      fprintf ppf "Unbound %s %a." kind Longident.pp value.txt
+      fprintf ppf "@[<hov>Unbound %s@ %a.@]" kind Longident.pp value.txt
   | Unbound_value value ->
       fprintf ppf "Unbound value %s." value.txt
   | Variable_on_one_side name ->
-      fprintf ppf "Variable %s must occur on both sides of this '|' pattern."
+      fprintf ppf
+        "@[<hov>Variable@ %s@ must@ occur@ on@ both@ sides@ of@ this@ '|'@ \
+         pattern.@]"
         name
   | Pattern_declaration (kind, name) ->
-      fprintf ppf "Unexpected %s declaration for %s within a pattern." kind
-        name
+      fprintf ppf "@[<hov>Unexpected %s declaration for %s within a pattern.@]"
+        kind name
   | Empty_record ->
       fprintf ppf "Unexpected empty record."
   | Wrong_record_field (field, typ) ->
       fprintf ppf
-        "This record expression is expected to have type %a@.The field %a \
-         does not belong to type %a."
+        "@[<hov>This record expression is expected to have type@ \
+         @[<h>%a@]@;The field %a does not belong to type@ @[<h>%a@].@]"
         pp_typ typ Longident.pp field pp_typ typ
   | Repeated_field field ->
-      fprintf ppf "The record field %s is defined several times." field
+      fprintf ppf "@[<hov>The record field %s is defined several times.@]"
+        field
   | Missing_fields fields ->
-      fprintf ppf "Some record fields are undefined: %a"
-        (pp_print_list pp_print_string)
+      fprintf ppf "@[<hov>Some record fields are undefined:@ %a@]"
+        (pp_print_list ~pp_sep:pp_print_space pp_print_string)
         fields
   | Wrong_type_description (kind, name) ->
       fprintf ppf
-        "Internal error: Expected a type declaration of kind %s, but instead \
-         got %s"
+        "@[<hov>Internal error: Expected a type declaration of kind %s, but \
+         instead got %s@]"
         kind name.txt
   | Unifiable_expr ->
       fprintf ppf "Internal error: Unexpected implicit variable."
@@ -1144,17 +1149,19 @@ let rec report_error ppf = function
       fprintf ppf "Internal error: Expected an unresolved implicit variable."
   | No_instance typ ->
       fprintf ppf
-        "Could not find an instance for an implicit variable of type @[%a@]."
+        "@[<hov>Could not find an instance for an implicit variable of type@ \
+         @[<h>%a@].@]"
         pp_typ typ
   | Argument_expected lid ->
-      fprintf ppf "@[The constructor %a expects an argument.@]" Longident.pp
-        lid
+      fprintf ppf "@[<hov>The constructor %a expects an argument.@]"
+        Longident.pp lid
   | Not_extensible lid ->
-      fprintf ppf "@[Type definition %a is not extensible.@]" Longident.pp lid
+      fprintf ppf "@[<hov>Type definition %a is not extensible.@]" Longident.pp
+        lid
   | Extension_different_arity lid ->
       fprintf ppf
-        "@[This extension does not match the definition of type %a@.They have \
-         different arities.@]"
+        "@[<hov>This extension does not match the definition of type %a@;They \
+         have different arities.@]"
         Longident.pp lid
 
 let () =

--- a/meja/src/typechecker.ml
+++ b/meja/src/typechecker.ml
@@ -1101,10 +1101,10 @@ let pp_typ = Pprint.type_expr
 
 let rec report_error ppf = function
   | Check_failed (typ, constr_typ, err) ->
-      fprintf ppf "Incompatable types @['%a'@] and @['%a'@]:@.%a" pp_typ typ
+      fprintf ppf "Incompatable types @[%a@] and @[%a@]:@.%a" pp_typ typ
         pp_typ constr_typ report_error err
   | Cannot_unify (typ, constr_typ) ->
-      fprintf ppf "Cannot unify @['%a'@] and @['%a'@].@." pp_typ typ pp_typ
+      fprintf ppf "Cannot unify @[%a@] and @[%a@].@." pp_typ typ pp_typ
         constr_typ
   | Recursive_variable typ ->
       fprintf ppf

--- a/meja/src/typechecker.ml
+++ b/meja/src/typechecker.ml
@@ -1097,7 +1097,7 @@ let check (ast : statement list) (env : Envi.t) =
 
 open Format
 
-let pp_typ ppf typ = Pprintast.core_type ppf (To_ocaml.of_type_expr typ)
+let pp_typ = Pprint.type_expr
 
 let rec report_error ppf = function
   | Check_failed (typ, constr_typ, err) ->

--- a/meja/tests/apply-fail.stderr
+++ b/meja/tests/apply-fail.stderr
@@ -1,4 +1,3 @@
 File "tests/apply-fail.meja", line 3, characters 5-6:
-Error: Incompatable types '_' and 'unit':
-Cannot unify 'int' and 'unit'.
-
+Error: Incompatable types _ and unit:
+       Cannot unify int and unit

--- a/meja/tests/implicits-fail.stderr
+++ b/meja/tests/implicits-fail.stderr
@@ -1,3 +1,3 @@
 File "tests/implicits-fail.meja", line 5, characters 14-36:
-Error: Could not find an instance for an implicit variable of type int
-                                                                    showable.
+Error: Could not find an instance for an implicit variable of type
+       showable(int).

--- a/meja/tests/list_weak_variable.stderr
+++ b/meja/tests/list_weak_variable.stderr
@@ -1,4 +1,3 @@
 File "tests/list_weak_variable.meja", line 5, characters 13-14:
-Error: Incompatable types '_' and ''a list':
-Cannot unify 'int' and 'bool'.
-
+Error: Incompatable types _ and list('a):
+       Cannot unify int and bool

--- a/meja/tests/list_wrong_type.stderr
+++ b/meja/tests/list_wrong_type.stderr
@@ -1,4 +1,3 @@
 File "tests/list_wrong_type.meja", line 3, characters 16-17:
-Error: Incompatable types '_' and 'int list':
-Cannot unify 'bool' and 'int'.
-
+Error: Incompatable types _ and list(int):
+       Cannot unify bool and int

--- a/meja/tests/record_wrong_accessor.stderr
+++ b/meja/tests/record_wrong_accessor.stderr
@@ -1,4 +1,3 @@
 File "tests/record_wrong_accessor.meja", line 9, characters 8-9:
-Error: Incompatable types '_ X.t' and '(int, int, int) t':
-Cannot unify ''a X.t' and '(int, int, int) t'.
-
+Error: Incompatable types X.t(_) and t(int, int, int):
+       Cannot unify X.t('a) and t(int, int, int)

--- a/meja/tests/wrong_labelled_arg.stderr
+++ b/meja/tests/wrong_labelled_arg.stderr
@@ -1,4 +1,3 @@
 File "tests/wrong_labelled_arg.meja", line 3, characters 27-31:
-Error: Incompatable types 'a:_ -> _' and 'b:_ -> _':
-Cannot unify 'a:_ -> _' and 'b:_ -> _'.
-
+Error: Incompatable types a:_ -> _ and b:_ -> _:
+       Cannot unify a:_ -> _ and b:_ -> _

--- a/meja/tests/wrong_optional_arg.stderr
+++ b/meja/tests/wrong_optional_arg.stderr
@@ -1,4 +1,3 @@
 File "tests/wrong_optional_arg.meja", line 5, characters 27-35:
-Error: Incompatable types 'a:_ -> _' and '?a:_ -> _':
-Cannot unify 'a:_ -> _' and '?a:_ -> _'.
-
+Error: Incompatable types a:_ -> _ and ?a:_ -> _:
+       Cannot unify a:_ -> _ and ?a:_ -> _


### PR DESCRIPTION
This PR
* adds a pretty-printing module
* uses the type pretty-printer for error messages instead of the OCaml pretty-printer
* uses boxes and break hints to better control the formatting of error messages

This will be needed for row-subtyping: if the types do not match, they will need to be printed with the row information added, which we can't do by piping through OCaml.