### PR TITLE
Fix proving key serialization

### DIFF
--- a/src/backend_extended.ml
+++ b/src/backend_extended.ml
@@ -108,6 +108,8 @@ module type S = sig
 
     val report_statistics : t -> unit
 
+    val finalize : t -> unit
+
     val add_constraint : t -> R1CS_constraint.t -> unit
 
     val add_constraint_with_annotation :

--- a/src/backend_intf.ml
+++ b/src/backend_intf.ml
@@ -65,6 +65,8 @@ module type S = sig
 
     val report_statistics : t -> unit
 
+    val finalize : t -> unit
+
     val add_constraint : t -> R1CS_constraint.t -> unit
 
     val add_constraint_with_annotation :

--- a/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_bn128.cpp
+++ b/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_bn128.cpp
@@ -563,6 +563,10 @@ void camlsnark_bn128_r1cs_constraint_system_report_statistics(r1cs_constraint_sy
   sys->report_linear_constraint_statistics();
 }
 
+void camlsnark_bn128_r1cs_constraint_system_finalize(r1cs_constraint_system<FieldT>* sys) {
+  sys->swap_AB_if_beneficial();
+}
+
 void camlsnark_bn128_r1cs_constraint_system_add_constraint(
     r1cs_constraint_system<FieldT>* sys, 
     r1cs_constraint<FieldT>* c) {

--- a/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_mnt4.cpp
+++ b/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_mnt4.cpp
@@ -563,6 +563,10 @@ void camlsnark_mnt4_r1cs_constraint_system_report_statistics(r1cs_constraint_sys
   sys->report_linear_constraint_statistics();
 }
 
+void camlsnark_mnt4_r1cs_constraint_system_finalize(r1cs_constraint_system<FieldT>* sys) {
+  sys->swap_AB_if_beneficial();
+}
+
 void camlsnark_mnt4_r1cs_constraint_system_add_constraint(
     r1cs_constraint_system<FieldT>* sys, 
     r1cs_constraint<FieldT>* c) {

--- a/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_mnt4753.cpp
+++ b/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_mnt4753.cpp
@@ -563,6 +563,10 @@ void camlsnark_mnt4753_r1cs_constraint_system_report_statistics(r1cs_constraint_
   sys->report_linear_constraint_statistics();
 }
 
+void camlsnark_mnt4753_r1cs_constraint_system_finalize(r1cs_constraint_system<FieldT>* sys) {
+  sys->swap_AB_if_beneficial();
+}
+
 void camlsnark_mnt4753_r1cs_constraint_system_add_constraint(
     r1cs_constraint_system<FieldT>* sys, 
     r1cs_constraint<FieldT>* c) {

--- a/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_mnt6.cpp
+++ b/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_mnt6.cpp
@@ -563,6 +563,10 @@ void camlsnark_mnt6_r1cs_constraint_system_report_statistics(r1cs_constraint_sys
   sys->report_linear_constraint_statistics();
 }
 
+void camlsnark_mnt6_r1cs_constraint_system_finalize(r1cs_constraint_system<FieldT>* sys) {
+  sys->swap_AB_if_beneficial();
+}
+
 void camlsnark_mnt6_r1cs_constraint_system_add_constraint(
     r1cs_constraint_system<FieldT>* sys, 
     r1cs_constraint<FieldT>* c) {

--- a/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_mnt6753.cpp
+++ b/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_mnt6753.cpp
@@ -563,6 +563,10 @@ void camlsnark_mnt6753_r1cs_constraint_system_report_statistics(r1cs_constraint_
   sys->report_linear_constraint_statistics();
 }
 
+void camlsnark_mnt6753_r1cs_constraint_system_finalize(r1cs_constraint_system<FieldT>* sys) {
+  sys->swap_AB_if_beneficial();
+}
+
 void camlsnark_mnt6753_r1cs_constraint_system_add_constraint(
     r1cs_constraint_system<FieldT>* sys, 
     r1cs_constraint<FieldT>* c) {

--- a/src/libsnark.ml
+++ b/src/libsnark.ml
@@ -897,6 +897,8 @@ struct
 
     val report_statistics : t -> unit
 
+    val finalize : t -> unit
+
     val add_constraint : t -> R1CS_constraint.t -> unit
 
     val add_constraint_with_annotation :
@@ -933,6 +935,8 @@ struct
 
     let report_statistics =
       foreign (func_name "report_statistics") (typ @-> returning void)
+
+    let finalize = foreign (func_name "finalize") (typ @-> returning void)
 
     let check_exn =
       let stub = foreign (func_name "check") (typ @-> returning bool) in

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -2362,7 +2362,7 @@ let%test_module "snark0-test" =
 
     let swap b (x, y) = if b then (y, x) else (x, y)
 
-    let%test_unit "proving-key serialization" =
+    let%test_unit "key serialization" =
       let main x =
         let%bind y = exists Field.typ ~compute:(As_prover.return Field.zero) in
         let rec go b acc i =
@@ -2379,9 +2379,8 @@ let%test_module "snark0-test" =
         return ()
       in
       let kp = generate_keypair ~exposing:[Field.typ] main in
-      let vk = Keypair.vk kp in
-      let pk = Keypair.pk kp in
-      let pk = bin_io_id (module Proving_key) pk in
+      let vk = Keypair.vk kp |> bin_io_id (module Verification_key) in
+      let pk = Keypair.pk kp |> bin_io_id (module Proving_key) in
       let input = Field.one in
       let proof = prove pk [Field.typ] () main input in
       assert (verify proof vk [Field.typ] input)


### PR DESCRIPTION
Recall that an rank 1 constraint has the form A * B = C.

Proving key serialization was incorrect because the "generate keypair" function in libsnark swaps all A and B terms in a constraint system if a certain condition is met. We were not doing this when recreating the constraint system ourselves, which led to creating bad proofs. I have corrected this issue and added a test which failed previously and now passes. Thanks to @deepthiskumar for help debugging.