### PR TITLE
[Meja] GADT tweaks

### DIFF
--- a/meja/src/parser_impl.mly
+++ b/meja/src/parser_impl.mly
@@ -306,7 +306,7 @@ simpl_expr:
     { mkexp ~pos:$loc (Int x) }
   | LPAREN e = expr_or_bare_tuple RPAREN
     { e }
-  | LBRACKET es = list_maybe_empty(expr, COMMA, RBRACKET)
+  | LBRACKET es = list(expr, COMMA) RBRACKET
     { List.fold
         ~init:(mkexp ~pos:$loc (Ctor (mkloc ~pos:$loc (Lident "[]"), None)))
         es ~f:(fun acc e -> consexp ~pos:$loc e acc) }
@@ -477,7 +477,7 @@ pat_no_bar:
     { mkpat ~pos:$loc PAny }
   | LPAREN p = pat_or_bare_tuple RPAREN
     { p }
-  | LBRACKET ps = list_maybe_empty(pat, COMMA, RBRACKET)
+  | LBRACKET ps = list(pat, COMMA) RBRACKET
     { List.fold
         ~init:(mkpat ~pos:$loc (PCtor (mkloc ~pos:$loc (Lident "[]"), None)))
         ps ~f:(fun acc p -> conspat ~pos:$loc p acc) }
@@ -539,12 +539,6 @@ list(X, SEP):
     { x :: xs }
   | x = X
     { [ x ] }
-
-list_maybe_empty(X, SEP, TERMINATOR):
-  | TERMINATOR
-    { [] }
-  | xs = list(X, SEP) TERMINATOR
-    { xs }
 
 tuple(X):
   | xs = tuple(X) COMMA x = X

--- a/meja/src/parser_impl.mly
+++ b/meja/src/parser_impl.mly
@@ -242,7 +242,7 @@ ctor_decl_args:
   | m = longident(UIDENT, UIDENT) DOT id = lident
     { Ldot (m, id) }
 
-ctor_ident:
+%inline ctor_ident:
   | id = UIDENT
     { id }
   | LPAREN RPAREN
@@ -251,6 +251,10 @@ ctor_ident:
     { "true" }
   | FALSE
     { "false" }
+  | LBRACKET RBRACKET
+    { "[]" }
+  | LPAREN COLONCOLON RPAREN
+    { "::" }
 
 infix_operator:
   | op = INFIXOP0 { op }

--- a/meja/src/typechecker.ml
+++ b/meja/src/typechecker.ml
@@ -281,8 +281,12 @@ let get_ctor (name : lid) env =
         | Ctor_tuple typs ->
             Envi.Type.mk ~loc (Ttuple typs) env
       in
+      let bound_vars =
+        Set.to_list
+          (Set.union (Envi.Type.type_vars typ) (Envi.Type.type_vars args_typ))
+      in
       let _, bound_vars, _ =
-        Envi.Type.refresh_vars params (Map.empty (module Int)) env
+        Envi.Type.refresh_vars bound_vars (Map.empty (module Int)) env
       in
       let args_typ = Envi.Type.copy args_typ bound_vars env in
       let typ = Envi.Type.copy typ bound_vars env in

--- a/meja/tests/list_constructor_override.meja
+++ b/meja/tests/list_constructor_override.meja
@@ -1,0 +1,17 @@
+type nil;
+
+type t('a) = [] : t(nil) | ( :: ) ('hd, t('tl)) : t('hd -> 'tl);
+
+let x = [];
+
+let y = ( :: ) (12, []);
+
+let z = 1 :: true :: () :: [];
+
+let z = [1, true, ()];
+
+module A = {
+  type u('a, 'b) = [] ('a, 'b);
+
+  let x = [] (12, true);
+};

--- a/meja/tests/list_constructor_override.ml
+++ b/meja/tests/list_constructor_override.ml
@@ -1,0 +1,20 @@
+module Impl = Snarky.Snark.Make (Snarky.Backends.Mnt4.Default)
+open Impl
+
+type nil
+
+type 'a t = [] : nil t | ( :: ) : 'hd * 'tl t -> ('hd -> 'tl) t
+
+let x = []
+
+let y = [12]
+
+let z = [1; true; ()]
+
+let z = [1; true; ()]
+
+module A = struct
+  type ('a, 'b) u = [] of 'a * 'b
+
+  let x = []
+end


### PR DESCRIPTION
This PR
* treats the list constructors `[]` and `::` as first-class constructors
* fixes the type unification for GADTs with free parameters in their constructors
* adds a test

Note that the last line in the `.ml` test output looks wrong, but the problem lies on the OCaml compiler's pretty printer's side.