### PR TITLE
Run checked functions as the prover/outside checked computations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,10 +21,10 @@ publish-website : website
 
 examples :
 	dune exec --root=. ./examples/election/election_main.exe
-	# TODO: Re-enable when fixed, see #41
 	dune exec --root=. ./examples/merkle_update/merkle_update.exe
 	# tutorial.exe intentionally is unimplemented, but it should still compile
 	dune build --root=. ./examples/tutorial/tutorial.exe
+	dune exec --root=. ./examples/toplevel_test/toplevel_test.exe
 
 reformat:
 	dune exec --root=. app/reformat-snarky/reformat.exe -- -path .

--- a/examples/toplevel_test/dune
+++ b/examples/toplevel_test/dune
@@ -1,0 +1,4 @@
+(executables
+ (names toplevel_test)
+ (modes native)
+ (libraries snarky core_kernel))

--- a/examples/toplevel_test/toplevel_test.ml
+++ b/examples/toplevel_test/toplevel_test.ml
@@ -1,0 +1,132 @@
+open Core_kernel
+open Snarky
+module Impl = Snark.Run.Make (Backends.Mnt4.GM)
+open Impl
+
+let () = Printexc.record_backtrace true
+
+let read = As_prover.read Field.typ
+
+let x = Field.of_int 15
+
+let y = Field.of_int 25
+
+let z = Field.(x * y)
+
+let () = Field.Constant.print (read z)
+
+let test_function x y z = Field.(x * y * z)
+
+let assertion x y z expected () =
+  let res = test_function x y z in
+  Field.Assert.equal res expected ;
+  res
+
+let proof_system =
+  Proof_system.create
+    ~public_input:[Field.typ; Field.typ; Field.typ; Field.typ]
+    assertion
+
+let expected = test_function x y z
+
+let proof =
+  Proof_system.prove
+    ~public_input:[read x; read y; read z; read expected]
+    proof_system
+
+let () =
+  Format.printf "Created proof that test_function %s %s %s = %s@."
+    (Field.Constant.to_string (read x))
+    (Field.Constant.to_string (read y))
+    (Field.Constant.to_string (read z))
+    (Field.Constant.to_string (read expected))
+
+let verified =
+  Proof_system.verify
+    ~public_input:[read x; read y; read z; read expected]
+    proof_system proof
+
+let () =
+  if verified then
+    Format.printf "Verified proof that test_function %s %s %s = %s@."
+      (Field.Constant.to_string (read x))
+      (Field.Constant.to_string (read y))
+      (Field.Constant.to_string (read z))
+      (Field.Constant.to_string (read expected))
+  else
+    Format.printf
+      "Could not verify the proof that test_function %s %s %s = %s@."
+      (Field.Constant.to_string (read x))
+      (Field.Constant.to_string (read y))
+      (Field.Constant.to_string (read z))
+      (Field.Constant.to_string (read expected))
+
+let res =
+  Or_error.ok_exn
+  @@ Proof_system.run_checked
+       ~public_input:[read x; read y; read z; read expected]
+       proof_system
+
+let () =
+  let res = read res in
+  let expected = read expected in
+  if Field.Constant.equal res expected then
+    Format.printf "Ran successfully and got %s = %s as expected@."
+      (Field.Constant.to_string res)
+      (Field.Constant.to_string expected)
+  else
+    Format.printf "Unexpected failure: got %s <> %s@."
+      (Field.Constant.to_string res)
+      (Field.Constant.to_string expected)
+
+let constraint_system = Proof_system.constraint_system proof_system
+
+let () =
+  Format.printf
+    "Generated the constraint system correctly and still read expected=%s@."
+    (Field.Constant.to_string (read expected))
+
+let keys = Proof_system.generate_keypair proof_system
+
+let () =
+  Format.printf "Generated a keypair and still read expected=%s@."
+    (Field.Constant.to_string (read expected))
+
+let exists_test x y z () =
+  let expected =
+    exists Field.typ ~compute:(fun () ->
+        let var = test_function x y z in
+        As_prover.read Field.typ var )
+  in
+  assertion x y z expected ()
+
+let proof_system2 =
+  Proof_system.create
+    ~public_input:[Field.typ; Field.typ; Field.typ]
+    exists_test
+
+let proof2 =
+  Proof_system.prove ~public_input:[read x; read y; read z] proof_system2
+
+let () =
+  Format.printf "Created proof that test_function %s %s %s = ?@."
+    (Field.Constant.to_string (read x))
+    (Field.Constant.to_string (read y))
+    (Field.Constant.to_string (read z))
+
+let verified2 =
+  Proof_system.verify ~public_input:[read x; read y; read z] proof_system2
+    proof2
+
+let () =
+  if verified2 then
+    Format.printf "Verified proof that test_function %s %s %s = ?@."
+      (Field.Constant.to_string (read x))
+      (Field.Constant.to_string (read y))
+      (Field.Constant.to_string (read z))
+  else
+    Format.printf
+      "Could not verify the proof that test_function %s %s %s = ?@."
+      (Field.Constant.to_string (read x))
+      (Field.Constant.to_string (read y))
+      (Field.Constant.to_string (read z))

--- a/src/run_state.ml
+++ b/src/run_state.ml
@@ -9,7 +9,6 @@ type ('prover_state, 'field) t =
   ; prover_state: 'prover_state option
   ; stack: string list
   ; handler: Request.Handler.t
-  ; is_running: bool
   ; as_prover: bool ref
   ; log_constraint: ('field Cvar.t Constraint.t -> unit) option }
 
@@ -23,7 +22,6 @@ let set_prover_state prover_state
     ; prover_state= _
     ; stack
     ; handler
-    ; is_running
     ; as_prover
     ; log_constraint } =
   { system
@@ -35,6 +33,5 @@ let set_prover_state prover_state
   ; prover_state
   ; stack
   ; handler
-  ; is_running
   ; as_prover
   ; log_constraint }

--- a/src/run_state.ml
+++ b/src/run_state.ml
@@ -9,6 +9,7 @@ type ('prover_state, 'field) t =
   ; prover_state: 'prover_state option
   ; stack: string list
   ; handler: Request.Handler.t
+  ; is_running: bool
   ; as_prover: bool ref
   ; log_constraint: ('field Cvar.t Constraint.t -> unit) option }
 
@@ -22,6 +23,7 @@ let set_prover_state prover_state
     ; prover_state= _
     ; stack
     ; handler
+    ; is_running
     ; as_prover
     ; log_constraint } =
   { system
@@ -33,5 +35,6 @@ let set_prover_state prover_state
   ; prover_state
   ; stack
   ; handler
+  ; is_running
   ; as_prover
   ; log_constraint }

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -606,6 +606,20 @@ struct
               (As_prover.Make_basic (Checked_S))
 
     type ('a, 'prover_state) as_prover = ('a, 'prover_state) t
+
+    let run_checked (t : ('a, 's, Field.t) Checked.t) tbl s =
+      let rs =
+        Runner.State.make ~num_inputs:0 ~input:Vector.null ~aux:Vector.null
+          ~next_auxiliary:(ref 1) ~eval_constraints:false (Some s)
+      in
+      rs.as_prover := true ;
+      let rs, a = Checked.run t rs in
+      let s =
+        Option.value_exn
+          ~message:"Prover state was cleared by the checked computation"
+          rs.prover_state
+      in
+      (s, a)
   end
 
   module Handle = Handle

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -1992,7 +1992,10 @@ module Run = struct
 
     let run checked =
       if not !state.is_running then
-        failwith "This function can't be run outside of a checked computation." ;
+        failwith
+          "This function can't be run outside of a checked computation. \
+           Please check that all parts of the checked computation are wrapped \
+           in the same 'fun () ->'" ;
       let state', x = Runner.run checked !state in
       state := state' ;
       x

--- a/src/snark_intf.ml
+++ b/src/snark_intf.ml
@@ -831,6 +831,15 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
         an OCaml variable of type ['value], according to the description given
         by [typ].
     *)
+
+    val run_checked : ('a, 's) Checked.t -> ('a, 's) t
+    (** Run a checked computation as the prover.
+
+        Any new constraints that would be normally be added by the checked
+        computation are ignored, and no new variables are allocated. This is
+        roughly equivalent to running the inner [As_prover] blocks and any
+        other non-checked parts of the computation.
+    *)
   end
 
   (** Representation of an R1CS value and an OCaml value (if running as the


### PR DESCRIPTION
This PR
* replaces writes (via `exists`) made outside the checked part of checked computations with fake writes, returning a constant `Cvar.t` containing the value
* disables constraint additions (via `add_constraint`) outside the checked part of checked computations
* sets the state to be in `as_prover` mode by default, so checked computations can be run at toplevel and between proofs/checks/etc.
* adds an example/test to check that this is working correctly, set to run on the CI during `make examples`
* tweaks the semantics of the `is_running` flag to catch errors of the form below
  - the typechecker can't catch this because it has the right type (`input1 -> input2 -> ... -> inputn -> unit -> output`)
  - this also clarifies the error message and makes sure the error is thrown at a useful point (ie. the first invalid call)

```ocaml
let checked1 x y () = Field.(x * y)

let checked x y z =
  let a = Field.(x * y) in (* error at this call to Field.( * ) *)
  checked1 z a

let checked x y z () =
  let a = Field.(x * y) in (* no error: the whole computation is after the () argument *)
  checked1 z a ()
```