### PR TITLE
[Meja] Add support for nested comments

### DIFF
--- a/meja/src/lexer_impl.mll
+++ b/meja/src/lexer_impl.mll
@@ -16,6 +16,7 @@ let lexeme_loc lexbuf =
   mklocation (Lexing.lexeme_start_p lexbuf, Lexing.lexeme_end_p lexbuf)
 
 let comment_buffer = Buffer.create 256
+let comment_depth = ref 0
 let store_lexeme lexbuf =
   Buffer.add_string comment_buffer (Lexing.lexeme lexbuf)
 
@@ -84,8 +85,11 @@ rule token = parse
   | "//" ([^'\n']* as comment) eof
     { new_line lexbuf; COMMENT (comment) }
   | "/*"
-    { let comment = get_comment comment lexbuf in
+    { incr comment_depth ;
+      let comment = get_comment comment lexbuf in
       COMMENT (comment) }
+  | "/*/"
+    { COMMENT ("") }
 
   | "!" symbolchar * as op { PREFIXOP op }
   | ['~' '?'] symbolchar + as op { PREFIXOP op }
@@ -104,7 +108,10 @@ rule token = parse
 
 and comment = parse
   | "*/"
-    { store_lexeme lexbuf }
+    { decr comment_depth; store_lexeme lexbuf;
+      if !comment_depth > 0 then comment lexbuf }
+  | "/*"
+    { incr comment_depth ; store_lexeme lexbuf; comment lexbuf }
   | newline
     { new_line lexbuf; store_lexeme lexbuf; comment lexbuf }
   | _

--- a/meja/tests/comments.meja
+++ b/meja/tests/comments.meja
@@ -9,3 +9,31 @@ let y = { /* {
   let (i, j, k) = x;
   (i, j); // End of line comment
 };
+
+// Empty comment
+/*/
+
+let f = 1;
+
+/* Several /* layers /* of /* nested /* comment */
+   let f = (); */ */ */ */
+
+let g = f + 2;
+
+/* A
+   /* more
+      /* complicated */
+      nested
+      /*
+        comment
+         /* with */
+         multiple
+      */
+   */ layers
+*/
+
+let h = ();
+
+/****************************/
+
+let i = ();

--- a/meja/tests/comments.ml
+++ b/meja/tests/comments.ml
@@ -6,3 +6,11 @@ let x = (1, 2, 7)
 let y =
   let i, j, k = x in
   (i, j)
+
+let f = 1
+
+let g = f + 2
+
+let h = ()
+
+let i = ()


### PR DESCRIPTION
This PR adds support for nested comments.

Most importantly, this means that the output of `cmi_to_meja` is now always valid meja code: in some cases, most notably functors, we get nested comments which previously had to be tweaked by hand.

This matches ReasonML's behaviour for comments.