### PR TITLE
Move Of_traversable out of Snark0

### DIFF
--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -556,42 +556,6 @@ struct
     let unit : (unit, unit) t = unit ()
 
     let field : (Cvar.t, Field.t) t = field ()
-
-    (* TODO: Assert that a stored value has the same shape as the template. *)
-    module Of_traversable (T : Traversable.S) = struct
-      let typ ~template
-          ({read; store; alloc; check} : ('elt_var, 'elt_value) t) :
-          ('elt_var T.t, 'elt_value T.t) t =
-        let traverse_store =
-          let module M = T.Traverse (Store) in
-          M.f
-        in
-        let traverse_read =
-          let module M = T.Traverse (Read) in
-          M.f
-        in
-        let traverse_alloc =
-          let module M = T.Traverse (Alloc) in
-          M.f
-        in
-        let traverse_checked =
-          let module M =
-            T.Traverse
-              (Restrict_monad.Make3
-                 (Checked)
-                 (struct
-                   type t1 = unit
-
-                   type t2 = Field.t
-                 end)) in
-          M.f
-        in
-        let read var = traverse_read var ~f:read in
-        let store value = traverse_store value ~f:store in
-        let alloc = traverse_alloc template ~f:(fun () -> alloc) in
-        let check t = Checked.map (traverse_checked t ~f:check) ~f:ignore in
-        {read; store; alloc; check}
-    end
   end
 
   module As_prover = struct

--- a/src/traversable.ml
+++ b/src/traversable.ml
@@ -1,6 +1,6 @@
 open Core_kernel
 
-module type Basic = sig
+module type S = sig
   type 'a t
 
   (* TODO-someday: Should be applicative, it's anonying because Applicative.S is not a subsignature
@@ -10,8 +10,8 @@ module type Basic = sig
   end
 end
 
-module type S = sig
-  include Basic
+module type Full = sig
+  include S
 
   module Traverse2 (A : Monad.S2) : sig
     val f : 'a t -> f:('a -> ('b, 'c) A.t) -> ('b t, 'c) A.t
@@ -22,14 +22,14 @@ module type S = sig
   end
 end
 
-module type Res = sig
-  type result
-
-  val result : result
-end
-
-module Make (Basic : Basic) = struct
+module Make (Basic : S) : Full with type 'a t = 'a Basic.t = struct
   include Basic
+
+  module type Res = sig
+    type result
+
+    val result : result
+  end
 
   module Traverse2 (A : Monad.S2) = struct
     let f (type b c) (x : 'a t) ~(f : 'a -> (b, c) A.t) =

--- a/src/traversable.ml
+++ b/src/traversable.ml
@@ -1,9 +1,69 @@
-module type S = sig
+open Core_kernel
+
+module type Basic = sig
   type 'a t
 
   (* TODO-someday: Should be applicative, it's anonying because Applicative.S is not a subsignature
    of Monad.S, but Monad.S is more common so we go with that. *)
-  module Traverse (A : Monad_let.S) : sig
+  module Traverse (A : Monad.S) : sig
     val f : 'a t -> f:('a -> 'b A.t) -> 'b t A.t
+  end
+end
+
+module type S = sig
+  include Basic
+
+  module Traverse2 (A : Monad.S2) : sig
+    val f : 'a t -> f:('a -> ('b, 'c) A.t) -> ('b t, 'c) A.t
+  end
+
+  module Traverse3 (A : Monad.S3) : sig
+    val f : 'a t -> f:('a -> ('b, 'c, 'd) A.t) -> ('b t, 'c, 'd) A.t
+  end
+end
+
+module type Res = sig
+  type result
+
+  val result : result
+end
+
+module Make (Basic : Basic) = struct
+  include Basic
+
+  module Traverse2 (A : Monad.S2) = struct
+    let f (type b c) (x : 'a t) ~(f : 'a -> (b, c) A.t) =
+      let (module Res : Res with type result = (b t, c) A.t) =
+        ( module struct
+          module Traverse = Traverse (struct
+            type 'a t = ('a, c) A.t
+
+            include (A : Monad.S with type 'a t := 'a t)
+          end)
+
+          type result = (b t, c) A.t
+
+          let result = Traverse.f x ~f
+        end )
+      in
+      Res.result
+  end
+
+  module Traverse3 (A : Monad.S3) = struct
+    let f (type b c d) (x : 'a t) ~(f : 'a -> (b, c, d) A.t) =
+      let (module Res : Res with type result = (b t, c, d) A.t) =
+        ( module struct
+          module Traverse = Traverse (struct
+            type 'a t = ('a, c, d) A.t
+
+            include (A : Monad.S with type 'a t := 'a t)
+          end)
+
+          type result = (b t, c, d) A.t
+
+          let result = Traverse.f x ~f
+        end )
+      in
+      Res.result
   end
 end

--- a/src/typ.ml
+++ b/src/typ.ml
@@ -310,7 +310,7 @@ module Make (Checked : Checked_intf.S) = struct
       ; check= (fun v -> check (var_to_hlist v)) }
 
     (* TODO: Assert that a stored value has the same shape as the template. *)
-    module Of_traversable (T : Traversable.Basic) = struct
+    module Of_traversable (T : Traversable.S) = struct
       module T = Traversable.Make (T)
 
       let typ (type f) ~template

--- a/src/typ.ml
+++ b/src/typ.ml
@@ -308,6 +308,45 @@ module Make (Checked : Checked_intf.S) = struct
       ; store= (fun x -> Store.map ~f:var_of_hlist (store (value_to_hlist x)))
       ; alloc= Alloc.map ~f:var_of_hlist alloc
       ; check= (fun v -> check (var_to_hlist v)) }
+
+    (* TODO: Assert that a stored value has the same shape as the template. *)
+    module Of_traversable (T : Traversable.Basic) = struct
+      module T = Traversable.Make (T)
+
+      let typ (type f) ~template
+          ({read; store; alloc; check} :
+            ('elt_var, 'elt_value, f Checked.field) t) :
+          ('elt_var T.t, 'elt_value T.t, f Checked.field) t =
+        let traverse_store =
+          let module M = T.Traverse2 (Store) in
+          M.f
+        in
+        let traverse_read =
+          let module M = T.Traverse2 (Read) in
+          M.f
+        in
+        let traverse_alloc =
+          let module M = T.Traverse2 (Alloc) in
+          M.f
+        in
+        let traverse_checked =
+          let module M =
+            T.Traverse
+              (Restrict_monad.Make3
+                 (Checked)
+                 (struct
+                   type t1 = unit
+
+                   type t2 = f Checked.field
+                 end)) in
+          M.f
+        in
+        let read var = traverse_read var ~f:read in
+        let store value = traverse_store value ~f:store in
+        let alloc = traverse_alloc template ~f:(fun () -> alloc) in
+        let check t = Checked.map (traverse_checked t ~f:check) ~f:ignore in
+        {read; store; alloc; check}
+    end
   end
 end
 


### PR DESCRIPTION
This PR
- adds higher arity constructors to Traversable
- moves `Typ.Of_traversable` out of `Snark0` and into the `Typ` functor