### PR TITLE
Move constraint_count out of Snark0

### DIFF
--- a/src/checked.ml
+++ b/src/checked.ml
@@ -91,6 +91,71 @@ module Basic :
   let exists typ p = Exists (typ, p, return)
 
   let next_auxiliary = Next_auxiliary return
+
+  let rec constraint_count_aux : type a s.
+         log:(?start:_ -> _)
+      -> auxc:_
+      -> int
+      -> (a, s, _) Types.Checked.t
+      -> int * a =
+   fun ~log ~auxc count t0 ->
+    match t0 with
+    | Pure x ->
+        (count, x)
+    | Direct (d, k) ->
+        let count = ref count in
+        let log_constraint c = count := !count + List.length c in
+        let state =
+          Run_state.
+            { system= None
+            ; input= Vector.null
+            ; aux= Vector.null
+            ; eval_constraints= false
+            ; num_inputs= 0
+            ; next_auxiliary= ref 1
+            ; prover_state= None
+            ; stack= []
+            ; handler= Request.Handler.fail
+            ; is_running= true
+            ; as_prover= ref false
+            ; log_constraint= Some log_constraint }
+        in
+        let _, x = d state in
+        constraint_count_aux ~log ~auxc !count (k x)
+    | Reduced (t, _, _, k) ->
+        let count, y = constraint_count_aux ~log ~auxc count t in
+        constraint_count_aux ~log ~auxc count (k y)
+    | As_prover (_x, k) ->
+        constraint_count_aux ~log ~auxc count k
+    | Add_constraint (c, t) ->
+        constraint_count_aux ~log ~auxc (count + List.length c) t
+    | Next_auxiliary k ->
+        constraint_count_aux ~log ~auxc count (k !auxc)
+    | With_label (s, t, k) ->
+        log ~start:true s count ;
+        let count', y = constraint_count_aux ~log ~auxc count t in
+        log s count' ;
+        constraint_count_aux ~log ~auxc count' (k y)
+    | With_state (_p, _and_then, t_sub, k) ->
+        let count', y = constraint_count_aux ~log ~auxc count t_sub in
+        constraint_count_aux ~log ~auxc count' (k y)
+    | With_handler (_h, t, k) ->
+        let count, x = constraint_count_aux ~log ~auxc count t in
+        constraint_count_aux ~log ~auxc count (k x)
+    | Clear_handler (t, k) ->
+        let count, x = constraint_count_aux ~log ~auxc count t in
+        constraint_count_aux ~log ~auxc count (k x)
+    | Exists ({alloc; check; _}, _c, k) ->
+        let alloc_var () = Cvar.Var 1 in
+        let var = Typ_monads.Alloc.run alloc alloc_var in
+        (* TODO: Push a label onto the stack here *)
+        let count, () = constraint_count_aux ~log ~auxc count (check var) in
+        constraint_count_aux ~log ~auxc count (k {Handle.var; value= None})
+
+  let constraint_count ?(log = fun ?start:_ _ _ -> ())
+      (t : (_, _, _) Types.Checked.t) : int =
+    let next_auxiliary = ref 1 in
+    fst (constraint_count_aux ~log ~auxc:next_auxiliary 0 t)
 end
 
 module Make (Basic : Checked_intf.Basic) :

--- a/src/checked_intf.ml
+++ b/src/checked_intf.ml
@@ -28,6 +28,9 @@ module type Basic = sig
     -> (('var, 'value) Handle.t, 's, 'f field) t
 
   val next_auxiliary : (int, 's, 'f field) t
+
+  val constraint_count :
+    ?log:(?start:bool -> string -> int -> unit) -> ('a, 's, 'f field) t -> int
 end
 
 module type S = sig
@@ -113,6 +116,9 @@ module type S = sig
     -> 'f field Cvar.t
     -> 'f field Cvar.t
     -> (unit, 's, 'f field) t
+
+  val constraint_count :
+    ?log:(?start:bool -> string -> int -> unit) -> ('a, 's, 'f field) t -> int
 end
 
 module type Extended = sig


### PR DESCRIPTION
This PR
- moves `constraint_count` out of `Snark0` and into `Checked`
- adds `constraint_count` to `Checked_intf.*`, so that the constraints are always counted for the instance of `Checked.t` that is passed to the functor