### PR TITLE
[Meja] Add support for bare handlers

### DIFF
--- a/meja/src/parser_errors.ml
+++ b/meja/src/parser_errors.ml
@@ -3,6 +3,7 @@ type error =
   | Missing_semi
   | Unexpected_character of string
   | Expecting of string
+  | Dangling_handler
 
 exception Error of Location.t * error
 
@@ -17,6 +18,8 @@ let report_error ppf = function
       fprintf ppf "Unexpected character '%s'" x
   | Expecting desc ->
       fprintf ppf "Syntax error: %s expected" desc
+  | Dangling_handler ->
+      fprintf ppf "A handler expression cannot finish a block."
 
 let () =
   Location.register_error_of_exn (function

--- a/meja/src/parser_impl.mly
+++ b/meja/src/parser_impl.mly
@@ -153,6 +153,8 @@ structure_item:
         , ctors)) }
   | REQUEST LPAREN arg = type_expr RPAREN x = ctor_decl handler = maybe(default_request_handler)
     { mkstmt ~pos:$loc (Request (arg, x, handler)) }
+  | HANDLER p = pat EQUALGT LBRACE body = block RBRACE
+    { mkstmt ~pos:$loc (Handler (p, body)) }
 
 signature_item:
   | LET x = as_loc(val_ident) COLON typ = type_expr
@@ -451,6 +453,10 @@ block:
     { mkexp ~pos:$loc (Let (x, lhs, rhs)) }
   | LET pat EQUAL expr err = err
     { raise (Error (err, Missing_semi)) }
+  | HANDLER p = pat EQUALGT LBRACE body = block RBRACE SEMI rest = block
+    { mkexp ~pos:$loc (Handler (p, body, rest)) }
+  | HANDLER pat EQUALGT LBRACE block RBRACE err = err
+    { raise (Error (err, Dangling_handler)) }
   | expr err = err
     { raise (Error (err, Missing_semi)) }
 

--- a/meja/src/parsetypes.ml
+++ b/meja/src/parsetypes.ml
@@ -157,6 +157,7 @@ and expression_desc =
   | Record of (lid * expression) list * expression option
   | Ctor of lid * expression option
   | Unifiable of {mutable expression: expression option; name: str; id: int}
+  | Handler of pattern * expression * expression
 
 type signature_item = {sig_desc: signature_desc; sig_loc: Location.t}
 
@@ -185,6 +186,7 @@ and statement_desc =
   | Open of lid
   | TypeExtension of variant * ctor_decl list
   | Request of type_expr * ctor_decl * (pattern option * expression) option
+  | Handler of pattern * expression
   | Multiple of statement list
 
 and module_expr = {mod_desc: module_desc; mod_loc: Location.t}

--- a/meja/tests/handler.meja
+++ b/meja/tests/handler.meja
@@ -1,0 +1,14 @@
+request('a) A;
+
+handler A => {
+  unhandled;
+};
+
+request('a) B('a);
+
+let x = {
+  handler B(y) => {
+    y;
+  };
+  ();
+};

--- a/meja/tests/handler.ml
+++ b/meja/tests/handler.ml
@@ -1,0 +1,27 @@
+module Impl = Snarky.Snark.Make (Snarky.Backends.Mnt4.Default)
+open Impl
+
+include struct
+  type _ Snarky.Request.t += A : 'a Snarky.Request.t
+end
+
+let handle_A = function
+  | With {request= A; respond} ->
+      let unhandled = Snarky.Request.unhandled in
+      unhandled
+  | _ ->
+      Snarky.Request.unhandled
+
+include struct
+  type _ Snarky.Request.t += B : 'a -> 'a Snarky.Request.t
+end
+
+let x =
+  let handle_B = function
+    | With {request= B y; respond} ->
+        let unhandled = Snarky.Request.unhandled in
+        y
+    | _ ->
+        Snarky.Request.unhandled
+  in
+  ()


### PR DESCRIPTION
This PR
* adds parsing support for `handler _ => { _ }` in statements and in expressions
  - a handler at the end of an expression block is a parse error, since it de-sugars to a let
* generalises the request handler code and moves it into `Codegen`
* generalises the OCaml code generation for handlers
* adds typechecker support

Note: generating instances for these is currently disabled, pending row subtyping and PR #224.