### PR TITLE
[Meja] Extend Ast_build to support all types and type_decls

### DIFF
--- a/meja/src/ast_build.ml
+++ b/meja/src/ast_build.ml
@@ -2,7 +2,7 @@ open Core_kernel
 open Parsetypes
 
 module Loc = struct
-  let mk ?(loc = Location.none) x = Location.mkloc x loc
+  let mk ?(loc = Location.none) x : Location.t = Location.mkloc x loc
 
   let map x ~f = {Location.loc= x.Location.loc; txt= f x.Location.txt}
 end
@@ -26,7 +26,8 @@ module Lid = struct
 end
 
 module Type = struct
-  let mk ?(loc = Location.none) d = {type_desc= d; type_id= -1; type_loc= loc}
+  let mk ?(loc = Location.none) d : Parsetypes.type_expr =
+    {type_desc= d; type_id= -1; type_loc= loc}
 
   let variant ?loc ?(params = []) ?(implicits = []) ident =
     { var_ident= Loc.mk ident ?loc
@@ -51,7 +52,8 @@ module Type = struct
 end
 
 module Type_decl = struct
-  let mk ?(loc = Location.none) ?(params = []) ?(implicits = []) name d =
+  let mk ?(loc = Location.none) ?(params = []) ?(implicits = []) name d :
+      Parsetypes.type_decl =
     { tdec_ident= Loc.mk ~loc name
     ; tdec_params= params
     ; tdec_implicit_params= implicits
@@ -81,12 +83,12 @@ module Type_decl = struct
     mk ?loc ?params ?implicits name (TForward (ref None))
 
   module Field = struct
-    let mk ?(loc = Location.none) name typ =
+    let mk ?(loc = Location.none) name typ : Parsetypes.field_decl =
       {fld_ident= Loc.mk ~loc name; fld_type= typ; fld_id= -1; fld_loc= loc}
   end
 
   module Ctor = struct
-    let mk ?(loc = Location.none) ?ret name d =
+    let mk ?(loc = Location.none) ?ret name d : Parsetypes.ctor_decl =
       {ctor_ident= Loc.mk ~loc name; ctor_args= d; ctor_ret= ret; ctor_loc= loc}
 
     let with_args ?loc ?ret name args = mk ?loc ?ret name (Ctor_tuple args)
@@ -97,7 +99,7 @@ module Type_decl = struct
 end
 
 module Pat = struct
-  let mk ?(loc = Location.none) d =
+  let mk ?(loc = Location.none) d : Parsetypes.pattern =
     {pat_desc= d; pat_loc= loc; pat_type= Type.none ~loc ()}
 
   let any ?loc () = mk ?loc PAny
@@ -116,7 +118,7 @@ module Pat = struct
 end
 
 module Exp = struct
-  let mk ?(loc = Location.none) d =
+  let mk ?(loc = Location.none) d : Parsetypes.expression =
     {exp_desc= d; exp_loc= loc; exp_type= Type.none ~loc ()}
 
   let fun_ ?loc ?(explicit = Explicit) ?(label = Asttypes.Nolabel) p body =

--- a/meja/src/ast_build.ml
+++ b/meja/src/ast_build.ml
@@ -34,7 +34,7 @@ module Type = struct
     ; var_implicit_params= implicits
     ; var_decl_id= -1 }
 
-  let none ?loc () = mk ?loc (Tvar (None, -1, Explicit))
+  let none ?loc ?(explicit = Explicit) () = mk ?loc (Tvar (None, -1, explicit))
 
   let var ?loc ?(explicit = Explicit) name =
     mk ?loc (Tvar (Some (Loc.mk ?loc name), -1, explicit))

--- a/meja/src/ast_build.ml
+++ b/meja/src/ast_build.ml
@@ -50,6 +50,52 @@ module Type = struct
   let poly ?loc vars var = mk ?loc (Tpoly (vars, var))
 end
 
+module Type_decl = struct
+  let mk ?(loc = Location.none) ?(params = []) ?(implicits = []) ~name d =
+    { tdec_ident= Loc.mk ~loc name
+    ; tdec_params= params
+    ; tdec_implicit_params= implicits
+    ; tdec_desc= d
+    ; tdec_id= -1
+    ; tdec_loc= loc }
+
+  let abstract ?loc ?params ?implicits ~name =
+    mk ?loc ?params ?implicits ~name TAbstract
+
+  let alias ?loc ?params ?implicits ~name typ =
+    mk ?loc ?params ?implicits ~name (TAlias typ)
+
+  let unfold ?loc ?params ?implicits ~name typ =
+    mk ?loc ?params ?implicits ~name (TUnfold typ)
+
+  let record ?loc ?params ?implicits ~name fields =
+    mk ?loc ?params ?implicits ~name (TRecord fields)
+
+  let variant ?loc ?params ?implicits ~name ctors =
+    mk ?loc ?params ?implicits ~name (TVariant ctors)
+
+  let open_ ?loc ?params ?implicits ~name =
+    mk ?loc ?params ?implicits ~name TOpen
+
+  let forward ?loc ?params ?implicits ~name =
+    mk ?loc ?params ?implicits ~name (TForward (ref None))
+
+  module Field = struct
+    let mk ?(loc = Location.none) ~name typ =
+      {fld_ident= Loc.mk ~loc name; fld_type= typ; fld_id= -1; fld_loc= loc}
+  end
+
+  module Ctor = struct
+    let mk ?(loc = Location.none) ?ret ~name d =
+      {ctor_ident= Loc.mk ~loc name; ctor_args= d; ctor_ret= ret; ctor_loc= loc}
+
+    let with_args ?loc ?ret ~name args = mk ?loc ?ret ~name (Ctor_tuple args)
+
+    let with_record ?loc ?ret ~name fields =
+      mk ?loc ?ret ~name (Ctor_record (-1, fields))
+  end
+end
+
 module Pat = struct
   let mk ?(loc = Location.none) d =
     {pat_desc= d; pat_loc= loc; pat_type= Type.none ~loc ()}

--- a/meja/src/ast_build.ml
+++ b/meja/src/ast_build.ml
@@ -41,6 +41,13 @@ module Type = struct
 
   let constr ?loc ?params ?implicits ident =
     mk ?loc (Tctor (variant ?loc ?params ?implicits ident))
+
+  let tuple ?loc typs = mk ?loc (Ttuple typs)
+
+  let arrow ?loc ?(explicit = Explicit) ?(label = Asttypes.Nolabel) typ1 typ2 =
+    mk ?loc (Tarrow (typ1, typ2, explicit, label))
+
+  let poly ?loc vars var = mk ?loc (Tpoly (vars, var))
 end
 
 module Pat = struct

--- a/meja/src/ast_build.ml
+++ b/meja/src/ast_build.ml
@@ -51,7 +51,7 @@ module Type = struct
 end
 
 module Type_decl = struct
-  let mk ?(loc = Location.none) ?(params = []) ?(implicits = []) ~name d =
+  let mk ?(loc = Location.none) ?(params = []) ?(implicits = []) name d =
     { tdec_ident= Loc.mk ~loc name
     ; tdec_params= params
     ; tdec_implicit_params= implicits
@@ -59,40 +59,40 @@ module Type_decl = struct
     ; tdec_id= -1
     ; tdec_loc= loc }
 
-  let abstract ?loc ?params ?implicits ~name =
-    mk ?loc ?params ?implicits ~name TAbstract
+  let abstract ?loc ?params ?implicits name =
+    mk ?loc ?params ?implicits name TAbstract
 
-  let alias ?loc ?params ?implicits ~name typ =
-    mk ?loc ?params ?implicits ~name (TAlias typ)
+  let alias ?loc ?params ?implicits name typ =
+    mk ?loc ?params ?implicits name (TAlias typ)
 
-  let unfold ?loc ?params ?implicits ~name typ =
-    mk ?loc ?params ?implicits ~name (TUnfold typ)
+  let unfold ?loc ?params ?implicits name typ =
+    mk ?loc ?params ?implicits name (TUnfold typ)
 
-  let record ?loc ?params ?implicits ~name fields =
-    mk ?loc ?params ?implicits ~name (TRecord fields)
+  let record ?loc ?params ?implicits name fields =
+    mk ?loc ?params ?implicits name (TRecord fields)
 
-  let variant ?loc ?params ?implicits ~name ctors =
-    mk ?loc ?params ?implicits ~name (TVariant ctors)
+  let variant ?loc ?params ?implicits name ctors =
+    mk ?loc ?params ?implicits name (TVariant ctors)
 
-  let open_ ?loc ?params ?implicits ~name =
-    mk ?loc ?params ?implicits ~name TOpen
+  let open_ ?loc ?params ?implicits name =
+    mk ?loc ?params ?implicits name TOpen
 
-  let forward ?loc ?params ?implicits ~name =
-    mk ?loc ?params ?implicits ~name (TForward (ref None))
+  let forward ?loc ?params ?implicits name =
+    mk ?loc ?params ?implicits name (TForward (ref None))
 
   module Field = struct
-    let mk ?(loc = Location.none) ~name typ =
+    let mk ?(loc = Location.none) name typ =
       {fld_ident= Loc.mk ~loc name; fld_type= typ; fld_id= -1; fld_loc= loc}
   end
 
   module Ctor = struct
-    let mk ?(loc = Location.none) ?ret ~name d =
+    let mk ?(loc = Location.none) ?ret name d =
       {ctor_ident= Loc.mk ~loc name; ctor_args= d; ctor_ret= ret; ctor_loc= loc}
 
-    let with_args ?loc ?ret ~name args = mk ?loc ?ret ~name (Ctor_tuple args)
+    let with_args ?loc ?ret name args = mk ?loc ?ret name (Ctor_tuple args)
 
-    let with_record ?loc ?ret ~name fields =
-      mk ?loc ?ret ~name (Ctor_record (-1, fields))
+    let with_record ?loc ?ret name fields =
+      mk ?loc ?ret name (Ctor_record (-1, fields))
   end
 end
 

--- a/meja/src/ast_build.ml
+++ b/meja/src/ast_build.ml
@@ -2,7 +2,8 @@ open Core_kernel
 open Parsetypes
 
 module Loc = struct
-  let mk ?(loc = Location.none) x : Location.t = Location.mkloc x loc
+  let mk ?(loc = Location.none) (x : 'a) : 'a Location.loc =
+    Location.mkloc x loc
 
   let map x ~f = {Location.loc= x.Location.loc; txt= f x.Location.txt}
 end


### PR DESCRIPTION
This PR cherry-picks some commits from #224, committing only the changes to `Ast_build`, and only when they don't depend on other changes.

Changes are:
* functions for the building remaining types that weren't previously supported
* functions for building type declarations