### PR TITLE
[Meja] Move the initial environment into its own module

### DIFF
--- a/meja/meja.ml
+++ b/meja/meja.ml
@@ -125,7 +125,7 @@ let main =
       | None ->
           file := Some filename )
     usage_text ;
-  let env = Envi.Core.env in
+  let env = Initial_env.env in
   try
     let env =
       if !stdlib then (

--- a/meja/src/envi.ml
+++ b/meja/src/envi.ml
@@ -356,13 +356,13 @@ module Scope = struct
         Some (Immediate (f (find_module ~loc lid2 resolve_env scopes)))
 end
 
-let empty_resolve_env () =
+type t =
+  {scope_stack: Scope.t list; depth: int; resolve_env: Scope.t resolve_env}
+
+let empty_resolve_env : Scope.t resolve_env =
   { type_env= TypeEnvi.empty
   ; external_modules= Map.empty (module String)
   ; predeclare_types= false }
-
-type t =
-  {scope_stack: Scope.t list; depth: int; resolve_env: Scope.t resolve_env}
 
 let empty resolve_env =
   {scope_stack= [Scope.empty Scope.Module]; depth= 0; resolve_env}

--- a/meja/src/envi.ml
+++ b/meja/src/envi.ml
@@ -356,7 +356,7 @@ module Scope = struct
         Some (Immediate (f (find_module ~loc lid2 resolve_env scopes)))
 end
 
-let empty_resolve_env =
+let empty_resolve_env () =
   { type_env= TypeEnvi.empty
   ; external_modules= Map.empty (module String)
   ; predeclare_types= false }
@@ -1335,113 +1335,6 @@ let find_name (lid : lid) env =
       Type.copy typ (Map.empty (module Int)) env
   | None ->
       raise (Error (lid.loc, Unbound_value lid.txt))
-
-module Core = struct
-  let mkloc s = Location.(mkloc s none)
-
-  let mk_type_decl ?(params = []) ?(implicit_params = []) name desc =
-    { tdec_ident= mkloc name
-    ; tdec_params= params
-    ; tdec_implicit_params= implicit_params
-    ; tdec_desc= desc
-    ; tdec_id= 0
-    ; tdec_loc= Location.none }
-
-  let mk_constructor ?(params = []) name =
-    { ctor_ident= mkloc name
-    ; ctor_args= Ctor_tuple params
-    ; ctor_ret= None
-    ; ctor_loc= Location.none }
-
-  let env = empty empty_resolve_env
-
-  let int, env = TypeDecl.import (mk_type_decl "int" TAbstract) env
-
-  let unit, env =
-    TypeDecl.import (mk_type_decl "unit" (TVariant [mk_constructor "()"])) env
-
-  let bool, env =
-    TypeDecl.import
-      (mk_type_decl "bool"
-         (TVariant [mk_constructor "true"; mk_constructor "false"]))
-      env
-
-  let char, env = TypeDecl.import (mk_type_decl "char" TAbstract) env
-
-  let string, env = TypeDecl.import (mk_type_decl "string" TAbstract) env
-
-  let float, env = TypeDecl.import (mk_type_decl "float" TAbstract) env
-
-  let exn, env = TypeDecl.import (mk_type_decl "exn" TOpen) env
-
-  let option, env =
-    let var = Type.mkvar ~loc:Location.none (Some (mkloc "a")) env in
-    TypeDecl.import
-      (mk_type_decl "option" ~params:[var]
-         (TVariant [mk_constructor "Some" ~params:[var]; mk_constructor "None"]))
-      env
-
-  let list, env =
-    let var = Type.mkvar ~loc:Location.none (Some (mkloc "a")) env in
-    let typ =
-      Type.mk ~loc:Location.none
-        (Tctor
-           { var_ident= mkloc (Lident "list")
-           ; var_params= [var]
-           ; var_implicit_params= []
-           ; var_decl_id= 0 })
-        env
-    in
-    TypeDecl.import
-      (mk_type_decl "list" ~params:[var]
-         (TVariant [mk_constructor "::" ~params:[var; typ]; mk_constructor "[]"]))
-      env
-
-  let env =
-    List.fold ~init:env
-      ~f:(fun env (name, vars) ->
-        let params =
-          List.init vars ~f:(fun _ -> Type.mkvar ~loc:Location.none None env)
-        in
-        snd (TypeDecl.import (mk_type_decl name ~params TAbstract) env) )
-      [("bytes", 0); ("int32", 0); ("int64", 0); ("nativeint", 0)]
-
-  let field, env =
-    let var =
-      Type.mkvar ~loc:Location.none ~explicitness:Implicit
-        (Some (mkloc "field"))
-        env
-    in
-    TypeDecl.import (mk_type_decl "field" (TUnfold var)) env
-
-  let lazy_t, env =
-    let var = Type.mkvar ~loc:Location.none (Some (mkloc "a")) env in
-    TypeDecl.import (mk_type_decl "lazy_t" ~params:[var] TAbstract) env
-
-  let array, env =
-    let var = Type.mkvar ~loc:Location.none (Some (mkloc "a")) env in
-    TypeDecl.import (mk_type_decl "array" ~params:[var] TAbstract) env
-
-  module Type = struct
-    let int = TypeDecl.mk_typ int ~params:[] env
-
-    let unit = TypeDecl.mk_typ unit ~params:[] env
-
-    let bool = TypeDecl.mk_typ bool ~params:[] env
-
-    let char = TypeDecl.mk_typ char ~params:[] env
-
-    let string = TypeDecl.mk_typ string ~params:[] env
-
-    let float = TypeDecl.mk_typ float ~params:[] env
-
-    let exn = TypeDecl.mk_typ exn ~params:[] env
-
-    let option a = TypeDecl.mk_typ option ~params:[a] env
-
-    let list a = TypeDecl.mk_typ list ~params:[a] env
-  end
-end
 
 (* Error handling *)
 

--- a/meja/src/envi.ml
+++ b/meja/src/envi.ml
@@ -356,13 +356,13 @@ module Scope = struct
         Some (Immediate (f (find_module ~loc lid2 resolve_env scopes)))
 end
 
-type t =
-  {scope_stack: Scope.t list; depth: int; resolve_env: Scope.t resolve_env}
-
 let empty_resolve_env : Scope.t resolve_env =
   { type_env= TypeEnvi.empty
   ; external_modules= Map.empty (module String)
   ; predeclare_types= false }
+
+type t =
+  {scope_stack: Scope.t list; depth: int; resolve_env: Scope.t resolve_env}
 
 let empty resolve_env =
   {scope_stack= [Scope.empty Scope.Module]; depth= 0; resolve_env}

--- a/meja/src/initial_env.ml
+++ b/meja/src/initial_env.ml
@@ -2,12 +2,11 @@
 open Envi
 
 open TypeDecl
-open Ast_build
 
 (** The built-in types. These match the OCaml built-ins. *)
 module TypeDecls = struct
-  open Type
-  open Type_decl
+  open Ast_build.Type
+  open Ast_build.Type_decl
 
   let int = abstract "int"
 

--- a/meja/src/initial_env.ml
+++ b/meja/src/initial_env.ml
@@ -1,10 +1,13 @@
+(** The default initial environment. *)
 open Envi
+
 open TypeDecl
 open Ast_build
 open Type
 open Type_decl
 
 module TypeDecls = struct
+  (** The built-in types. These match the OCaml built-ins. *)
   let int = abstract "int"
 
   let unit = variant "unit" [Ctor.with_args "()" []]
@@ -38,16 +41,23 @@ module TypeDecls = struct
 
   let nativeint = abstract "nativeint"
 
-  let field = unfold "field" (var ~explicit:Implicit "field")
-
   let lazy_t = abstract "lazy_t" ~params:[var "a"]
 
   let array = abstract "array" ~params:[var "a"]
+
+  (** Meja-specific built-ins. *)
+
+  let field = unfold "field" (var ~explicit:Implicit "field")
 end
 
+(** Empty environment. *)
 let env = Envi.(empty (empty_resolve_env ()))
 
 open TypeDecls
+
+(** Import the built-in type definitions, overriding the previous definition of
+    the environment [env] each time.
+*)
 
 let int, env = import int env
 
@@ -81,6 +91,9 @@ let lazy_t, env = import lazy_t env
 
 let array, env = import array env
 
+(** Canonical references for each of the built-in types that the typechecker
+    refers to.
+*)
 module Type = struct
   open Envi
 

--- a/meja/src/initial_env.ml
+++ b/meja/src/initial_env.ml
@@ -52,7 +52,7 @@ module TypeDecls = struct
 end
 
 (** Empty environment. *)
-let env = Envi.(empty (empty_resolve_env ()))
+let env = Envi.(empty empty_resolve_env)
 
 open TypeDecls
 

--- a/meja/src/initial_env.ml
+++ b/meja/src/initial_env.ml
@@ -5,8 +5,6 @@ open Type
 open Type_decl
 
 module TypeDecls = struct
-  let var_a = Type.var "a"
-
   let int = abstract "int"
 
   let unit = variant "unit" [Ctor.with_args "()" []]
@@ -24,7 +22,7 @@ module TypeDecls = struct
 
   let option =
     variant "option" ~params:[var "a"]
-      [Ctor.with_args "None" []; Ctor.with_args "Some" [Type.var "a"]]
+      [Ctor.with_args "None" []; Ctor.with_args "Some" [var "a"]]
 
   let list =
     variant "list" ~params:[var "a"]
@@ -40,7 +38,7 @@ module TypeDecls = struct
 
   let nativeint = abstract "nativeint"
 
-  let field = unfold "field" (Type.var ~explicit:Implicit "field")
+  let field = unfold "field" (var ~explicit:Implicit "field")
 
   let lazy_t = abstract "lazy_t" ~params:[var "a"]
 

--- a/meja/src/initial_env.ml
+++ b/meja/src/initial_env.ml
@@ -1,0 +1,109 @@
+open Core_kernel
+open Parsetypes
+open Envi
+open Longident
+
+let mkloc s = Location.(mkloc s none)
+
+let mk_type_decl ?(params = []) ?(implicit_params = []) name desc =
+  { tdec_ident= mkloc name
+  ; tdec_params= params
+  ; tdec_implicit_params= implicit_params
+  ; tdec_desc= desc
+  ; tdec_id= 0
+  ; tdec_loc= Location.none }
+
+let mk_constructor ?(params = []) name =
+  { ctor_ident= mkloc name
+  ; ctor_args= Ctor_tuple params
+  ; ctor_ret= None
+  ; ctor_loc= Location.none }
+
+let env = empty (empty_resolve_env ())
+
+let int, env = TypeDecl.import (mk_type_decl "int" TAbstract) env
+
+let unit, env =
+  TypeDecl.import (mk_type_decl "unit" (TVariant [mk_constructor "()"])) env
+
+let bool, env =
+  TypeDecl.import
+    (mk_type_decl "bool"
+       (TVariant [mk_constructor "true"; mk_constructor "false"]))
+    env
+
+let char, env = TypeDecl.import (mk_type_decl "char" TAbstract) env
+
+let string, env = TypeDecl.import (mk_type_decl "string" TAbstract) env
+
+let float, env = TypeDecl.import (mk_type_decl "float" TAbstract) env
+
+let exn, env = TypeDecl.import (mk_type_decl "exn" TOpen) env
+
+let option, env =
+  let var = Type.mkvar ~loc:Location.none (Some (mkloc "a")) env in
+  TypeDecl.import
+    (mk_type_decl "option" ~params:[var]
+       (TVariant [mk_constructor "Some" ~params:[var]; mk_constructor "None"]))
+    env
+
+let list, env =
+  let var = Type.mkvar ~loc:Location.none (Some (mkloc "a")) env in
+  let typ =
+    Type.mk ~loc:Location.none
+      (Tctor
+         { var_ident= mkloc (Lident "list")
+         ; var_params= [var]
+         ; var_implicit_params= []
+         ; var_decl_id= 0 })
+      env
+  in
+  TypeDecl.import
+    (mk_type_decl "list" ~params:[var]
+       (TVariant [mk_constructor "::" ~params:[var; typ]; mk_constructor "[]"]))
+    env
+
+let env =
+  List.fold ~init:env
+    ~f:(fun env (name, vars) ->
+      let params =
+        List.init vars ~f:(fun _ -> Type.mkvar ~loc:Location.none None env)
+      in
+      snd (TypeDecl.import (mk_type_decl name ~params TAbstract) env) )
+    [("bytes", 0); ("int32", 0); ("int64", 0); ("nativeint", 0)]
+
+let field, env =
+  let var =
+    Type.mkvar ~loc:Location.none ~explicitness:Implicit
+      (Some (mkloc "field"))
+      env
+  in
+  TypeDecl.import (mk_type_decl "field" (TUnfold var)) env
+
+let lazy_t, env =
+  let var = Type.mkvar ~loc:Location.none (Some (mkloc "a")) env in
+  TypeDecl.import (mk_type_decl "lazy_t" ~params:[var] TAbstract) env
+
+let array, env =
+  let var = Type.mkvar ~loc:Location.none (Some (mkloc "a")) env in
+  TypeDecl.import (mk_type_decl "array" ~params:[var] TAbstract) env
+
+module Type = struct
+  let int = TypeDecl.mk_typ int ~params:[] env
+
+  let unit = TypeDecl.mk_typ unit ~params:[] env
+
+  let bool = TypeDecl.mk_typ bool ~params:[] env
+
+  let char = TypeDecl.mk_typ char ~params:[] env
+
+  let string = TypeDecl.mk_typ string ~params:[] env
+
+  let float = TypeDecl.mk_typ float ~params:[] env
+
+  let exn = TypeDecl.mk_typ exn ~params:[] env
+
+  let option a = TypeDecl.mk_typ option ~params:[a] env
+
+  let list a = TypeDecl.mk_typ list ~params:[a] env
+end

--- a/meja/src/initial_env.ml
+++ b/meja/src/initial_env.ml
@@ -3,11 +3,12 @@ open Envi
 
 open TypeDecl
 open Ast_build
-open Type
-open Type_decl
 
+(** The built-in types. These match the OCaml built-ins. *)
 module TypeDecls = struct
-  (** The built-in types. These match the OCaml built-ins. *)
+  open Type
+  open Type_decl
+
   let int = abstract "int"
 
   let unit = variant "unit" [Ctor.with_args "()" []]

--- a/meja/src/loader.ml
+++ b/meja/src/loader.ml
@@ -5,7 +5,7 @@ let load ~loc ~name:_ resolve_env filename =
   (*Format.(fprintf err_formatter "Loading %s from %s...@." name filename) ;*)
   let cmi_info = read_cmi filename in
   let signature = Of_ocaml.to_signature cmi_info.cmi_sign in
-  let env = {Envi.Core.env with resolve_env} in
+  let env = {Initial_env.env with resolve_env} in
   let env = Typechecker.check_signature env signature in
   (*Format.(fprintf err_formatter "Loaded@.") ;*)
   let m, _ = Envi.pop_module ~loc env in

--- a/meja/src/typechecker.ml
+++ b/meja/src/typechecker.ml
@@ -366,7 +366,7 @@ let rec check_pattern ~add env typ pat =
       let env = Envi.push_scope scope2 env in
       ({pat_loc= loc; pat_type= typ; pat_desc= POr (p1, p2)}, env)
   | PInt i ->
-      check_type ~loc env typ Envi.Core.Type.int ;
+      check_type ~loc env typ Initial_env.Type.int ;
       ({pat_loc= loc; pat_type= typ; pat_desc= PInt i}, env)
   | PRecord [] ->
       raise (Error (loc, Empty_record))
@@ -470,7 +470,7 @@ let rec get_expression env expected exp =
             let e_typ =
               match label with
               | Optional _ ->
-                  Envi.Core.Type.option e_typ
+                  Initial_env.Type.option e_typ
               | _ ->
                   e_typ
             in
@@ -488,7 +488,7 @@ let rec get_expression env expected exp =
       let e = {exp_loc= loc; exp_type= typ; exp_desc= Variable name} in
       (Envi.Type.generate_implicits e env, env)
   | Int i ->
-      let typ = Envi.Core.Type.int in
+      let typ = Initial_env.Type.int in
       check_type ~loc env expected typ ;
       ({exp_loc= loc; exp_type= typ; exp_desc= Int i}, env)
   | Fun (label, p, body, explicit) ->
@@ -502,7 +502,7 @@ let rec get_expression env expected exp =
       let add_name =
         match label with
         | Optional _ ->
-            fun name typ -> Envi.add_name name (Envi.Core.Type.option typ)
+            fun name typ -> Envi.add_name name (Initial_env.Type.option typ)
         | _ ->
             Envi.add_name
       in
@@ -514,7 +514,7 @@ let rec get_expression env expected exp =
       ( {exp_loc= loc; exp_type= typ; exp_desc= Fun (label, p, body, explicit)}
       , env )
   | Seq (e1, e2) ->
-      let e1, env = get_expression env Envi.Core.Type.unit e1 in
+      let e1, env = get_expression env Initial_env.Type.unit e1 in
       let e2, env = get_expression env expected e2 in
       ({exp_loc= loc; exp_type= e2.exp_type; exp_desc= Seq (e1, e2)}, env)
   | Let (p, e1, e2) ->


### PR DESCRIPTION
This PR
* moves `Initial_env` into its own module
* re-implements `Initial_env` using `Ast_build`

This makes the initial environment stable under changes to the types in `Parsetypes` by using the `Ast_build` wrapper.