### PR TITLE
added a modify_or_get function to merkle tree

### DIFF
--- a/src/merkle_tree.ml
+++ b/src/merkle_tree.ml
@@ -456,6 +456,32 @@ struct
     in
     implied_root next_entry_hash addr0 prev_path
 
+  let%snarkydef_ modify_or_get_req ~(depth : int) root addr0 ~f :
+      (Hash.var * Elt.var, 's) Checked.t =
+    let open Let_syntax in
+    let%bind prev, prev_path =
+      request_witness
+        Typ.(Elt.typ * Path.typ ~depth)
+        As_prover.(
+          map (read (Address.typ ~depth) addr0) ~f:(fun a -> Get_element a))
+    in
+    let%bind () =
+      let%bind prev_entry_hash = Elt.hash prev in
+      implied_root prev_entry_hash addr0 prev_path >>= Hash.assert_equal root
+    in
+    let%bind next = f prev in
+    let%bind next_entry_hash = Elt.hash next in
+    let%bind () =
+      perform
+        (let open As_prover in
+        let open Let_syntax in
+        let%map addr = read (Address.typ ~depth) addr0
+        and next = read Elt.typ next in
+        Set (addr, next))
+    in
+    let%map new_root = implied_root next_entry_hash addr0 prev_path in
+    (new_root, prev)
+
   (* addr0 should have least significant bit first *)
   let%snarkydef_ get_req ~(depth : int) root addr0 : (Elt.var, 's) Checked.t =
     let open Let_syntax in

--- a/src/merkle_tree.mli
+++ b/src/merkle_tree.mli
@@ -118,6 +118,13 @@ module Checked
     -> f:(Elt.var -> (Elt.var, 's) Checked.t)
     -> (Hash.var, 's) Checked.t
 
+  val modify_or_get_req :
+       depth:int
+    -> Hash.var
+    -> Address.var
+    -> f:(Elt.var -> (Elt.var, 's) Checked.t)
+    -> (Hash.var * Elt.var, 's) Checked.t
+
   val get_req : depth:int -> Hash.var -> Address.var -> (Elt.var, 's) Checked.t
 
   (* TODO: Change [prev] to be [prev_hash : Hash.var] since there may be no need


### PR DESCRIPTION
In this PR, I added a `modify_or_get function` to Merkle Tree. The implementation basically is the same as `modify`, but it would also return the old value back.