### PR TITLE
Fix mac build

### DIFF
--- a/src/camlsnark_c/dune
+++ b/src/camlsnark_c/dune
@@ -71,7 +71,7 @@
    pushd libsnark-caml
      mkdir -p build
      pushd build
-       BOOST_ROOT=/usr/local/Cellar/boost/1.68.0_1 BOOST_INCLUDEDIR=/usr/local/Cellar/boost/1.68.0_1/include CPPFLAGS='-I/usr/local/opt/openssl/include -I/usr/local/opt/boost/include -I/usr/local/opt/gmp/include -I/usr/local/include -L/usr/local/lib -I/usr/local/include/gmp.h' CFLAGS='-I/usr/local/include' CXXFLAGS='-I/usr/local/include' LDFLAGS='-L/usr/local/opt/openssl/lib -L/usr/local/opt/boost/lib -L/usr/local/opt/gmp/lib' PKG_CONFIG_PATH=/usr/local/opt/openssl/lib/pkgconfig cmake -DSNARKY_PERFORMANCE=$PERFORMANCE -DMULTICORE=ON -DUSE_PT_COMPRESSION=OFF -DWITH_SUPERCOP=OFF -DWITH_PROCPS=OFF -DCMAKE_LIBRARY_PATH=/usr/local/opt/gmp/lib -DCMAKE_RULE_MESSAGES:BOOL=OFF -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON ..
+       BOOST_ROOT=/usr/local/Cellar/boost/1.68.0_1 BOOST_INCLUDEDIR=/usr/local/Cellar/boost/1.68.0_1/include CPPFLAGS='-I/usr/local/opt/openssl/include -I/usr/local/opt/boost/include -I/usr/local/opt/gmp/include -I/usr/local/include -L/usr/local/lib -I/usr/local/include/gmp.h' CFLAGS='-I/usr/local/include' CXXFLAGS='-I/usr/local/include' LDFLAGS='-L/usr/local/opt/openssl/lib -L/usr/local/opt/boost/lib -L/usr/local/opt/gmp/lib' PKG_CONFIG_PATH=/usr/local/opt/openssl/lib/pkgconfig cmake -DPERFORMANCE=$SNARKY_PERFORMANCE -DMULTICORE=ON -DUSE_PT_COMPRESSION=OFF -DWITH_SUPERCOP=OFF -DWITH_PROCPS=OFF -DCMAKE_LIBRARY_PATH=/usr/local/opt/gmp/lib -DCMAKE_RULE_MESSAGES:BOOL=OFF -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON ..
        make -j$(sysctl -n hw.ncpu)
    
        mkdir _stubs_build


### PR DESCRIPTION
Libsnark fails to build on mac currently. This change makes it succeed. We should probably get a mac build on CI soon.