### PR TITLE
Make lines shorter in dune shell

### DIFF
--- a/src/camlsnark_c/dune
+++ b/src/camlsnark_c/dune
@@ -71,20 +71,35 @@
    pushd libsnark-caml
      mkdir -p build
      pushd build
-       BOOST_ROOT=/usr/local/Cellar/boost/1.68.0_1 BOOST_INCLUDEDIR=/usr/local/Cellar/boost/1.68.0_1/include CPPFLAGS='-I/usr/local/opt/openssl/include -I/usr/local/opt/boost/include -I/usr/local/opt/gmp/include -I/usr/local/include -L/usr/local/lib -I/usr/local/include/gmp.h' CFLAGS='-I/usr/local/include' CXXFLAGS='-I/usr/local/include' LDFLAGS='-L/usr/local/opt/openssl/lib -L/usr/local/opt/boost/lib -L/usr/local/opt/gmp/lib' PKG_CONFIG_PATH=/usr/local/opt/openssl/lib/pkgconfig cmake -DPERFORMANCE=$SNARKY_PERFORMANCE -DMULTICORE=ON -DUSE_PT_COMPRESSION=OFF -DWITH_SUPERCOP=OFF -DWITH_PROCPS=OFF -DCMAKE_LIBRARY_PATH=/usr/local/opt/gmp/lib -DCMAKE_RULE_MESSAGES:BOOL=OFF -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON ..
+       BOOST_ROOT=/usr/local/Cellar/boost/1.68.0_1 \\
+       BOOST_INCLUDEDIR=/usr/local/Cellar/boost/1.68.0_1/include \\
+       CPPFLAGS='-I/usr/local/opt/openssl/include-I/usr/local/opt/boost/include -I/usr/local/opt/gmp/include -I/usr/local/include -L/usr/local/lib -I/usr/local/include/gmp.h' \\
+       CFLAGS='-I/usr/local/include' \\
+       CXXFLAGS='-I/usr/local/include' \\
+       LDFLAGS='-L/usr/local/opt/openssl/lib -L/usr/local/opt/boost/lib -L/usr/local/opt/gmp/lib' \\
+       PKG_CONFIG_PATH=/usr/local/opt/openssl/lib/pkgconfig \\
+       cmake \\
+         -DPERFORMANCE=$SNARKY_PERFORMANCE \\
+         -DMULTICORE=ON \\
+         -DUSE_PT_COMPRESSION=OFF \\
+         -DWITH_SUPERCOP=OFF \\
+         -DWITH_PROCPS=OFF \\
+         -DCMAKE_LIBRARY_PATH=/usr/local/opt/gmp/lib \\
+         -DCMAKE_RULE_MESSAGES:BOOL=OFF \\
+         -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON ..
        make -j$(sysctl -n hw.ncpu)
-   
+
        mkdir _stubs_build
-   
+
        mkdir _stubs_build/libff
        pushd _stubs_build/libff/; ar -xv ../../depends/libff/libff/libff.a; popd
-   
+
        mkdir _stubs_build/libzm
        pushd _stubs_build/libzm/; ar -xv ../../depends/libzm.a; popd
-   
+
        mkdir _stubs_build/libsnark
        pushd _stubs_build/libsnark/; ar -xv ../../libsnark/libsnark.a; popd
-   
+
        libtool -static -o libcamlsnark_c_stubs.a _stubs_build/libff/*.o _stubs_build/libzm/*.o _stubs_build/libsnark/*.o
      popd
    popd


### PR DESCRIPTION
We need to double escape once for dune -> shell and onces for newlines.