### PR TITLE
[Meja] Don't carry a location with types in the environment

### DIFF
--- a/meja/src/codegen.ml
+++ b/meja/src/codegen.ml
@@ -111,7 +111,7 @@ let typ_of_decl env decl =
                 { decl with
                   tdec_desc=
                     TAlias
-                      (Envi.TypeDecl.mk_typ ~loc
+                      (Envi.TypeDecl.mk_typ
                          ~params:(decl.tdec_params @ params)
                          poly_decl_content env) } }
         in
@@ -119,7 +119,7 @@ let typ_of_decl env decl =
           let params =
             Map.fold !constr_map ~init:[]
               ~f:(fun ~key:_ ~data:(_, variant) l ->
-                Envi.Type.mk ~loc (Tctor variant) env :: l )
+                Envi.Type.mk (Tctor variant) env :: l )
           in
           mk_decl params
         in
@@ -133,7 +133,7 @@ let typ_of_decl env decl =
                     var_ident=
                       Location.mkloc (var_type_lident name.txt) name.loc }
                 in
-                Envi.Type.mk ~loc (Tctor variant) env :: l )
+                Envi.Type.mk (Tctor variant) env :: l )
           in
           mk_decl params
         in

--- a/meja/src/envi.ml
+++ b/meja/src/envi.ml
@@ -558,13 +558,13 @@ let raw_find_type_declaration (lid : lid) env =
 module Type = struct
   type env = t
 
-  let mk ~loc type_desc env =
+  let mk type_desc env =
     let type_id, type_env = TypeEnvi.next_type_id env.resolve_env.type_env in
     env.resolve_env.type_env <- type_env ;
-    {type_desc; type_id; type_loc= loc}
+    {type_desc; type_id; type_loc= Location.none}
 
-  let mkvar ~loc ?(explicitness = Explicit) name env =
-    mk ~loc (Tvar (name, env.depth, explicitness)) env
+  let mkvar ?(explicitness = Explicit) name env =
+    mk (Tvar (name, env.depth, explicitness)) env
 
   let instance env typ = TypeEnvi.instance env.resolve_env.type_env typ
 
@@ -574,24 +574,23 @@ module Type = struct
 
   let clear_instance typ = map_env ~f:(TypeEnvi.clear_instance typ)
 
-  let rec import ?must_find typ env =
-    let import' = import in
-    let import = import ?must_find in
-    let loc = typ.type_loc in
+  let rec import ~loc ?must_find typ env =
+    let import' = import ~loc in
+    let import = import ~loc ?must_find in
     match typ.type_desc with
     | Tvar (None, _, explicitness) -> (
       match must_find with
       | Some true ->
-          raise (Error (typ.type_loc, Unbound_type_var typ))
+          raise (Error (loc, Unbound_type_var typ))
       | _ ->
-          (mkvar ~loc ~explicitness None env, env) )
+          (mkvar ~explicitness None env, env) )
     | Tvar ((Some {txt= x; _} as name), _, explicitness) -> (
         let var =
           match must_find with
           | Some true ->
               let var = find_type_variable x env in
               if not (Option.is_some var) then
-                raise (Error (typ.type_loc, Unbound_type_var typ)) ;
+                raise (Error (loc, Unbound_type_var typ)) ;
               var
           | Some false ->
               None
@@ -602,7 +601,7 @@ module Type = struct
         | Some var ->
             (var, env)
         | None ->
-            let var = mkvar ~loc ~explicitness name env in
+            let var = mkvar ~explicitness name env in
             (var, add_type_variable x var env) )
     | Tpoly (vars, typ) ->
         let env = open_expr_scope env in
@@ -613,7 +612,7 @@ module Type = struct
         in
         let typ, env = import typ env in
         let env = close_expr_scope env in
-        (mk ~loc (Tpoly (vars, typ)) env, env)
+        (mk (Tpoly (vars, typ)) env, env)
     | Tctor variant -> (
         let {var_ident; var_params; _} = variant in
         match raw_find_type_declaration var_ident env with
@@ -641,7 +640,7 @@ module Type = struct
             if not (Int.equal given_args_length expected_args_length) then
               raise
                 (Error
-                   ( typ.type_loc
+                   ( loc
                    , Wrong_number_args
                        (var_ident.txt, given_args_length, expected_args_length)
                    )) ;
@@ -650,23 +649,23 @@ module Type = struct
                   let param, env = import param env in
                   (env, param) )
             in
-            (mk ~loc (Tctor {variant with var_params}) env, env) )
+            (mk (Tctor {variant with var_params}) env, env) )
     | Ttuple typs ->
         let env, typs =
           List.fold_map typs ~init:env ~f:(fun e t ->
               let t, e = import t e in
               (e, t) )
         in
-        (mk ~loc (Ttuple typs) env, env)
+        (mk (Ttuple typs) env, env)
     | Tarrow (typ1, typ2, explicit, label) ->
         let typ1, env = import typ1 env in
         let typ2, env = import typ2 env in
-        (mk ~loc (Tarrow (typ1, typ2, explicit, label)) env, env)
+        (mk (Tarrow (typ1, typ2, explicit, label)) env, env)
 
-  let refresh_vars vars new_vars_map env =
+  let refresh_vars ~loc vars new_vars_map env =
     let env, new_vars =
       List.fold_map vars ~init:env ~f:(fun e t ->
-          let t, e = import ~must_find:false t e in
+          let t, e = import ~loc ~must_find:false t e in
           (e, t) )
     in
     let new_vars_map =
@@ -676,8 +675,7 @@ module Type = struct
     in
     (new_vars, new_vars_map, env)
 
-  let rec copy typ new_vars_map env =
-    let loc = typ.type_loc in
+  let rec copy ~loc typ new_vars_map env =
     match typ.type_desc with
     | Tvar _ -> (
       match Map.find new_vars_map typ.type_id with
@@ -686,20 +684,22 @@ module Type = struct
       | None ->
           typ )
     | Tpoly (vars, typ) ->
-        let _vars, new_vars_map, env = refresh_vars vars new_vars_map env in
-        copy typ new_vars_map env
+        let _vars, new_vars_map, env =
+          refresh_vars ~loc vars new_vars_map env
+        in
+        copy ~loc typ new_vars_map env
     | Tctor ({var_params; _} as variant) ->
         let var_params =
-          List.map var_params ~f:(fun t -> copy t new_vars_map env)
+          List.map var_params ~f:(fun t -> copy ~loc t new_vars_map env)
         in
-        mk ~loc (Tctor {variant with var_params}) env
+        mk (Tctor {variant with var_params}) env
     | Ttuple typs ->
-        let typs = List.map typs ~f:(fun t -> copy t new_vars_map env) in
-        mk ~loc (Ttuple typs) env
+        let typs = List.map typs ~f:(fun t -> copy ~loc t new_vars_map env) in
+        mk (Ttuple typs) env
     | Tarrow (typ1, typ2, explicit, label) ->
-        let typ1 = copy typ1 new_vars_map env in
-        let typ2 = copy typ2 new_vars_map env in
-        mk ~loc (Tarrow (typ1, typ2, explicit, label)) env
+        let typ1 = copy ~loc typ1 new_vars_map env in
+        let typ2 = copy ~loc typ2 new_vars_map env in
+        mk (Tarrow (typ1, typ2, explicit, label)) env
 
   module T = struct
     type t = type_expr
@@ -740,7 +740,6 @@ module Type = struct
         Set.union (type_vars typ1) (type_vars typ2)
 
   let rec flatten typ env =
-    let loc = typ.type_loc in
     match typ.type_desc with
     | Tvar _ -> (
       match instance env typ with
@@ -757,19 +756,19 @@ module Type = struct
             (List.map vars ~f:(type_vars ~depth:env.depth))
         in
         let typ = flatten typ env in
-        mk ~loc (Tpoly (Set.to_list var_set, typ)) env
+        mk (Tpoly (Set.to_list var_set, typ)) env
     | Tctor variant ->
         let var_params =
           List.map variant.var_params ~f:(fun typ -> flatten typ env)
         in
-        mk ~loc (Tctor {variant with var_params}) env
+        mk (Tctor {variant with var_params}) env
     | Ttuple typs ->
         let typs = List.map typs ~f:(fun typ -> flatten typ env) in
-        mk ~loc (Ttuple typs) env
+        mk (Ttuple typs) env
     | Tarrow (typ1, typ2, explicit, label) ->
         let typ1 = flatten typ1 env in
         let typ2 = flatten typ2 env in
-        mk ~loc (Tarrow (typ1, typ2, explicit, label)) env
+        mk (Tarrow (typ1, typ2, explicit, label)) env
 
   let or_compare cmp ~f = if Int.equal cmp 0 then f () else cmp
 
@@ -861,11 +860,13 @@ module Type = struct
        ; implicit_id= implicit_id + 1 } ;
     new_exp
 
-  let implicit_instances ~(unify : env -> type_expr -> type_expr -> 'a)
+  let implicit_instances ~loc ~(unify : env -> type_expr -> type_expr -> 'a)
       (typ : type_expr) env =
     List.filter_map env.resolve_env.type_env.instances
       ~f:(fun (id, instance_typ) ->
-        let instance_typ = copy instance_typ (Map.empty (module Int)) env in
+        let instance_typ =
+          copy ~loc instance_typ (Map.empty (module Int)) env
+        in
         match unify env typ instance_typ with
         | _ ->
             List.find_map env.scope_stack ~f:(fun {instances; _} ->
@@ -897,10 +898,10 @@ module Type = struct
     <- {env.resolve_env.type_env with implicit_vars= []} ;
     let implicit_vars =
       List.filter implicit_vars ~f:(fun ({exp_loc; exp_type; _} as exp) ->
-          match implicit_instances ~unify exp_type env with
+          match implicit_instances ~loc:exp_loc ~unify exp_type env with
           | [(name, instance_typ)] ->
               let instance_typ =
-                copy instance_typ (Map.empty (module Int)) env
+                copy ~loc:exp_loc instance_typ (Map.empty (module Int)) env
               in
               let name = Location.mkloc name exp_loc in
               unify env exp_type instance_typ ;
@@ -984,21 +985,20 @@ module Type = struct
         implicit_params typ
 
   let rec constr_map env ~f typ =
-    let loc = typ.type_loc in
     match typ.type_desc with
     | Tvar _ ->
         typ
     | Ttuple typs ->
         let typs = List.map ~f:(constr_map env ~f) typs in
-        mk ~loc (Ttuple typs) env
+        mk (Ttuple typs) env
     | Tarrow (typ1, typ2, explicit, label) ->
         let typ1 = constr_map env ~f typ1 in
         let typ2 = constr_map env ~f typ2 in
-        mk ~loc (Tarrow (typ1, typ2, explicit, label)) env
+        mk (Tarrow (typ1, typ2, explicit, label)) env
     | Tctor variant ->
-        mk ~loc (f variant) env
+        mk (f variant) env
     | Tpoly (typs, typ) ->
-        mk ~loc (Tpoly (typs, constr_map env ~f typ)) env
+        mk (Tpoly (typs, constr_map env ~f typ)) env
 
   let rec bubble_label_aux env label typ =
     match typ.type_desc with
@@ -1017,16 +1017,14 @@ module Type = struct
       | None, _ ->
           (None, typ)
       | res, typ2 ->
-          ( res
-          , mk ~loc:typ.type_loc (Tarrow (typ1, typ2, explicit, arr_label)) env
-          ) )
+          (res, mk (Tarrow (typ1, typ2, explicit, arr_label)) env) )
     | _ ->
         (None, typ)
 
   let bubble_label env label typ =
     match bubble_label_aux env label typ with
     | Some (typ1, explicit, arr_label), typ2 ->
-        mk ~loc:typ.type_loc (Tarrow (typ1, typ2, explicit, arr_label)) env
+        mk (Tarrow (typ1, typ2, explicit, arr_label)) env
     | None, typ ->
         typ
 
@@ -1056,15 +1054,14 @@ module TypeDecl = struct
     env.resolve_env.type_env <- type_env ;
     tdec_id
 
-  let mk ?(loc = Location.none) ~name ~params ?(implicit_params = []) desc env
-      =
+  let mk ~name ~params ?(implicit_params = []) desc env =
     let tdec_id = next_id env in
     { tdec_ident= name
     ; tdec_params= params
     ; tdec_implicit_params= implicit_params
     ; tdec_desc= desc
     ; tdec_id
-    ; tdec_loc= loc }
+    ; tdec_loc= Location.none }
 
   let import decl env =
     let tdec_id =
@@ -1095,12 +1092,13 @@ module TypeDecl = struct
     let env = open_expr_scope env in
     let env, tdec_params =
       List.fold_map ~init:env decl.tdec_params ~f:(fun env param ->
+          let loc = param.type_loc in
           match param.type_desc with
           | Tvar _ ->
-              let var, env = Type.import ~must_find:false param env in
+              let var, env = Type.import ~loc ~must_find:false param env in
               (env, var)
           | _ ->
-              raise (Error (param.type_loc, Expected_type_var param)) )
+              raise (Error (loc, Expected_type_var param)) )
     in
     let tdec_implicit_params =
       match decl.tdec_desc with
@@ -1154,16 +1152,21 @@ module TypeDecl = struct
       | (TAbstract | TOpen | TForward _) as desc ->
           (desc, env)
       | TAlias typ ->
-          let typ, env = Type.import ~must_find:true typ env in
+          let typ, env =
+            Type.import ~loc:typ.type_loc ~must_find:true typ env
+          in
           (TAlias typ, env)
       | TUnfold typ ->
-          let typ, env = Type.import ~must_find:false typ env in
+          let typ, env =
+            Type.import ~loc:typ.type_loc ~must_find:false typ env
+          in
           (TUnfold typ, env)
       | TRecord fields ->
           let env, fields =
             List.fold_map ~init:env fields ~f:(fun env field ->
                 let fld_type, env =
-                  Type.import ~must_find:true field.fld_type env
+                  Type.import ~loc:field.fld_type.type_loc ~must_find:true
+                    field.fld_type env
                 in
                 (env, {field with fld_type}) )
           in
@@ -1195,7 +1198,9 @@ module TypeDecl = struct
                             (Error
                                ( ret.type_loc
                                , Constraints_not_satisfied (ret, decl) )) ) ;
-                      let ret, env = Type.import ~must_find:false ret env in
+                      let ret, env =
+                        Type.import ~loc:ret.type_loc ~must_find:false ret env
+                      in
                       let ctor_ret_params =
                         match ret.type_desc with
                         | Tctor {var_params; _} ->
@@ -1212,7 +1217,9 @@ module TypeDecl = struct
                   | Ctor_tuple args ->
                       let env, args =
                         List.fold_map ~init:env args ~f:(fun env arg ->
-                            let arg, env = Type.import ?must_find arg env in
+                            let arg, env =
+                              Type.import ~loc:arg.type_loc ?must_find arg env
+                            in
                             (env, arg) )
                       in
                       (env, Ctor_tuple args)
@@ -1220,13 +1227,14 @@ module TypeDecl = struct
                       let env, fields =
                         List.fold_map ~init:env fields ~f:(fun env field ->
                             let fld_type, env =
-                              Type.import ?must_find field.fld_type env
+                              Type.import ~loc:field.fld_type.type_loc
+                                ?must_find field.fld_type env
                             in
                             (env, {field with fld_type}) )
                       in
                       let decl =
-                        mk ~loc:ctor.ctor_loc ~name:ctor.ctor_ident
-                          ~params:ctor_ret_params (TRecord fields) env
+                        mk ~name:ctor.ctor_ident ~params:ctor_ret_params
+                          (TRecord fields) env
                       in
                       Type.map_env env ~f:(TypeEnvi.add_decl decl) ;
                       (env, Ctor_record (decl.tdec_id, fields))
@@ -1250,9 +1258,9 @@ module TypeDecl = struct
     Type.map_env env ~f:(TypeEnvi.add_decl decl) ;
     (decl, env)
 
-  let mk_typ ?(loc = Location.none) ~params ?ident decl =
+  let mk_typ ~params ?ident decl =
     let ident = Option.value ident ~default:(mk_lid decl.tdec_ident) in
-    Type.mk ~loc
+    Type.mk
       (Tctor
          { var_ident= ident
          ; var_params= params
@@ -1263,7 +1271,7 @@ module TypeDecl = struct
     let decl = raw_find_type_declaration ident env in
     import decl env
 
-  let find_of_type typ env =
+  let find_of_type ~loc typ env =
     let open Option.Let_syntax in
     let%map variant =
       match typ.type_desc with Tctor variant -> Some variant | _ -> None
@@ -1273,7 +1281,7 @@ module TypeDecl = struct
       | Some decl ->
           decl
       | None ->
-          raise (Error (typ.type_loc, Unbound_type variant.var_ident.txt))
+          raise (Error (loc, Unbound_type variant.var_ident.txt))
     in
     let bound_vars =
       match
@@ -1288,7 +1296,7 @@ module TypeDecl = struct
       | Unequal_lengths ->
           raise
             (Error
-               ( typ.type_loc
+               ( loc
                , Wrong_number_args
                    ( variant.var_ident.txt
                    , List.length decl.tdec_params
@@ -1302,18 +1310,18 @@ module TypeDecl = struct
   let find_of_constructor (ctor : lid) env =
     find_of_lident ~kind:"constructor" ~get_name:Scope.get_ctor ctor env
 
-  let unfold_alias typ env =
-    match find_of_type typ env with
+  let unfold_alias ~loc typ env =
+    match find_of_type ~loc typ env with
     | Some ({tdec_desc= TAlias alias_typ; _}, bound_vars, env) ->
-        Some (Type.copy alias_typ bound_vars env)
+        Some (Type.copy ~loc alias_typ bound_vars env)
     | _ ->
         None
 
-  let rec find_unaliased_of_type typ env =
-    match find_of_type typ env with
+  let rec find_unaliased_of_type ~loc typ env =
+    match find_of_type ~loc typ env with
     | Some ({tdec_desc= TAlias alias_typ; _}, bound_vars, env) ->
-        let typ = Type.copy alias_typ bound_vars env in
-        find_unaliased_of_type typ env
+        let typ = Type.copy ~loc alias_typ bound_vars env in
+        find_unaliased_of_type ~loc typ env
     | ret ->
         ret
 end

--- a/meja/src/typechecker.ml
+++ b/meja/src/typechecker.ml
@@ -192,7 +192,7 @@ let get_field (field : lid) env =
       ( ({tdec_desc= TRecord field_decls; tdec_ident; tdec_params; _} as decl)
       , i ) ->
       let vars, bound_vars, _ =
-        Envi.Type.refresh_vars ~loc tdec_params (Map.empty (module Int)) env
+        Envi.Type.refresh_vars tdec_params (Map.empty (module Int)) env
       in
       let name =
         Location.mkloc
@@ -205,22 +205,22 @@ let get_field (field : lid) env =
       in
       let rcd_type = Envi.TypeDecl.mk_typ ~params:vars ~ident:name decl env in
       let {fld_type; _} = List.nth_exn field_decls i in
-      let rcd_type = Envi.Type.copy ~loc rcd_type bound_vars env in
-      let fld_type = Envi.Type.copy ~loc fld_type bound_vars env in
+      let rcd_type = Envi.Type.copy rcd_type bound_vars env in
+      let fld_type = Envi.Type.copy fld_type bound_vars env in
       (i, fld_type, rcd_type)
   | _ ->
       raise (Error (loc, Unbound ("record field", field)))
 
 let get_field_of_decl typ bound_vars field_decls (field : lid) env =
   match field with
-  | {txt= Longident.Lident name; loc} -> (
+  | {txt= Longident.Lident name; _} -> (
     match
       List.findi field_decls ~f:(fun _ {fld_ident; _} ->
           String.equal fld_ident.txt name )
     with
     | Some (i, {fld_type; _}) ->
-        let typ = Envi.Type.copy ~loc typ bound_vars env in
-        let fld_type = Envi.Type.copy ~loc fld_type bound_vars env in
+        let typ = Envi.Type.copy typ bound_vars env in
+        let fld_type = Envi.Type.copy fld_type bound_vars env in
         (i, fld_type, typ)
     | None ->
         get_field field env )
@@ -285,10 +285,10 @@ let get_ctor (name : lid) env =
           (Set.union (Envi.Type.type_vars typ) (Envi.Type.type_vars args_typ))
       in
       let _, bound_vars, _ =
-        Envi.Type.refresh_vars ~loc bound_vars (Map.empty (module Int)) env
+        Envi.Type.refresh_vars bound_vars (Map.empty (module Int)) env
       in
-      let args_typ = Envi.Type.copy ~loc args_typ bound_vars env in
-      let typ = Envi.Type.copy typ ~loc bound_vars env in
+      let args_typ = Envi.Type.copy args_typ bound_vars env in
+      let typ = Envi.Type.copy typ bound_vars env in
       (typ, args_typ)
   | _ ->
       raise (Error (loc, Unbound ("constructor", name)))
@@ -377,9 +377,7 @@ let rec check_pattern ~add env typ pat =
           | Some (({tdec_desc= TRecord field_decls; tdec_params; _} as decl), _)
             ->
               let vars, bound_vars, env =
-                Envi.Type.refresh_vars ~loc tdec_params
-                  (Map.empty (module Int))
-                  env
+                Envi.Type.refresh_vars tdec_params (Map.empty (module Int)) env
               in
               let ident =
                 Longident.(
@@ -482,7 +480,7 @@ let rec get_expression env expected exp =
       check_type ~loc env expected typ ;
       ({exp_loc= loc; exp_type= typ; exp_desc= Apply (f, es)}, env)
   | Variable name ->
-      let typ = Envi.find_name ~loc name env in
+      let typ = Envi.find_name name env in
       check_type ~loc env expected typ ;
       let e = {exp_loc= loc; exp_type= typ; exp_desc= Variable name} in
       (Envi.Type.generate_implicits e env, env)
@@ -564,9 +562,7 @@ let rec get_expression env expected exp =
           | Some (({tdec_desc= TRecord field_decls; tdec_params; _} as decl), i)
             ->
               let vars, bound_vars, env =
-                Envi.Type.refresh_vars ~loc tdec_params
-                  (Map.empty (module Int))
-                  env
+                Envi.Type.refresh_vars tdec_params (Map.empty (module Int)) env
               in
               let ident =
                 Location.mkloc (Longident.Ldot (path, decl.tdec_ident.txt)) loc
@@ -575,7 +571,7 @@ let rec get_expression env expected exp =
                 Envi.TypeDecl.mk_typ ~params:vars ~ident decl env
               in
               let {fld_type; _} = List.nth_exn field_decls i in
-              let fld_type = Envi.Type.copy ~loc fld_type bound_vars env in
+              let fld_type = Envi.Type.copy fld_type bound_vars env in
               check_type ~loc env expected fld_type ;
               Some (fld_type, decl_type, env)
           | _ ->
@@ -608,7 +604,7 @@ let rec get_expression env expected exp =
                   (* This case shouldn't happen! *) )
             with
             | Some {fld_type; _} ->
-                let fld_type = Envi.Type.copy ~loc fld_type bound_vars env in
+                let fld_type = Envi.Type.copy fld_type bound_vars env in
                 check_type ~loc env typ fld_type ;
                 (fld_type, env)
             | None ->
@@ -620,7 +616,7 @@ let rec get_expression env expected exp =
                 (({tdec_desc= TRecord field_decls; tdec_params; _} as decl), i)
               ->
                 let vars, bound_vars, env =
-                  Envi.Type.refresh_vars ~loc tdec_params
+                  Envi.Type.refresh_vars tdec_params
                     (Map.empty (module Int))
                     env
                 in
@@ -639,8 +635,8 @@ let rec get_expression env expected exp =
                 in
                 check_type ~loc env e.exp_type e_typ ;
                 let {fld_type; _} = List.nth_exn field_decls i in
-                let fld_type = Envi.Type.copy ~loc fld_type bound_vars env in
-                let fld_type = Envi.Type.copy ~loc fld_type bound_vars env in
+                let fld_type = Envi.Type.copy fld_type bound_vars env in
+                let fld_type = Envi.Type.copy fld_type bound_vars env in
                 (fld_type, env)
             | _ ->
                 raise (Error (loc, Unbound ("record field", field))) )
@@ -666,9 +662,7 @@ let rec get_expression env expected exp =
           | Some (({tdec_desc= TRecord field_decls; tdec_params; _} as decl), _)
             ->
               let vars, bound_vars, env =
-                Envi.Type.refresh_vars ~loc tdec_params
-                  (Map.empty (module Int))
-                  env
+                Envi.Type.refresh_vars tdec_params (Map.empty (module Int)) env
               in
               let ident =
                 Longident.(


### PR DESCRIPTION
This PR
* removes the dependency on `type_loc` from the environment code
* tweaks the environment functions to accept a `loc` parameter for location
* inlines the `Tvar` case from `Envi.Types.import` into `Envi.Types.refresh_vars`, throwing an `AssertionError` if the passed type isn't a variable
  - this is the only logic change in this PR
  - this change lets us get rid of a cascade of otherwise-unnecessary location parameters
* associates all of the types with `Location.none` when they are created as part of the evironment

These changes make it simpler to split `type_expr` into a parsetree version and a typechecker/environment version, as in #224.