### PR TITLE
[Meja] Internal error locations

### DIFF
--- a/meja/src/ast_build.ml
+++ b/meja/src/ast_build.ml
@@ -18,7 +18,7 @@ module Loc = struct
     ; loc_ghost= false }
 
   let of_pos (loc_start, loc_end) =
-    { Location.loc_start; loc_end; loc_ghost= false }
+    {Location.loc_start; loc_end; loc_ghost= false}
 end
 
 module Lid = struct

--- a/meja/src/ast_build.ml
+++ b/meja/src/ast_build.ml
@@ -6,6 +6,19 @@ module Loc = struct
     Location.mkloc x loc
 
   let map x ~f = {Location.loc= x.Location.loc; txt= f x.Location.txt}
+
+  (** Convert the OCaml primitive [__POS__] into a Lexing.position *)
+  let of_prim (file, lnum, cnum, enum) =
+    (* Note: We use a fake value for [pos_bol], since we can't get the true
+             value from [__POS__]. *)
+    { Location.loc_start=
+        {Lexing.pos_fname= file; pos_lnum= lnum; pos_cnum= cnum; pos_bol= 0}
+    ; loc_end=
+        {Lexing.pos_fname= file; pos_lnum= lnum; pos_cnum= enum; pos_bol= 0}
+    ; loc_ghost= false }
+
+  let of_pos (loc_start, loc_end) =
+    { Location.loc_start; loc_end; loc_ghost= false }
 end
 
 module Lid = struct

--- a/meja/src/parser_impl.mly
+++ b/meja/src/parser_impl.mly
@@ -1,24 +1,23 @@
 %{
 module List = Core_kernel.List
+module Loc = Ast_build.Loc
 open Location
 open Asttypes
 open Parsetypes
 open Longident
 open Parser_errors
 
-let mklocation (loc_start, loc_end) = {loc_start; loc_end; loc_ghost= false}
-
 let lid_last x = mkloc (last x.txt) x.loc
 
-let mkloc ~pos x = mkloc x (mklocation pos)
+let mkloc ~pos x = mkloc x (Loc.of_pos pos)
 
-let mktyp ~pos d = {type_desc= d; type_id= -1; type_loc= mklocation pos}
-let mkpat ~pos d = {pat_desc= d; pat_loc= mklocation pos; pat_type= mktyp ~pos (Tvar (None, -1, Explicit))}
-let mkexp ~pos d = {exp_desc= d; exp_loc= mklocation pos; exp_type= mktyp ~pos (Tvar (None, -1, Explicit))}
-let mkstmt ~pos d = {stmt_desc= d; stmt_loc= mklocation pos}
-let mksig ~pos d = {sig_desc= d; sig_loc= mklocation pos}
-let mkmod ~pos d = {mod_desc= d; mod_loc= mklocation pos}
-let mkmty ~pos d = {msig_desc= d; msig_loc= mklocation pos}
+let mktyp ~pos d = {type_desc= d; type_id= -1; type_loc= Loc.of_pos pos}
+let mkpat ~pos d = {pat_desc= d; pat_loc= Loc.of_pos pos; pat_type= mktyp ~pos (Tvar (None, -1, Explicit))}
+let mkexp ~pos d = {exp_desc= d; exp_loc= Loc.of_pos pos; exp_type= mktyp ~pos (Tvar (None, -1, Explicit))}
+let mkstmt ~pos d = {stmt_desc= d; stmt_loc= Loc.of_pos pos}
+let mksig ~pos d = {sig_desc= d; sig_loc= Loc.of_pos pos}
+let mkmod ~pos d = {mod_desc= d; mod_loc= Loc.of_pos pos}
+let mkmty ~pos d = {msig_desc= d; msig_loc= Loc.of_pos pos}
 
 let conspat ~pos hd tl =
   mkpat ~pos (PCtor
@@ -140,7 +139,7 @@ structure_item:
         ; tdec_implicit_params= []
         ; tdec_desc= k
         ; tdec_id= -1
-        ; tdec_loc= mklocation $loc }) }
+        ; tdec_loc= Loc.of_pos $loc }) }
   | MODULE x = as_loc(UIDENT) EQUAL m = module_expr
     { mkstmt ~pos:$loc (Module (x, m)) }
   | OPEN x = as_loc(longident(UIDENT, UIDENT))
@@ -167,7 +166,7 @@ signature_item:
         ; tdec_implicit_params= []
         ; tdec_desc= k
         ; tdec_id= -1
-        ; tdec_loc= mklocation $loc }) }
+        ; tdec_loc= Loc.of_pos $loc }) }
   | MODULE x = as_loc(UIDENT) COLON m = module_sig
     { mksig ~pos:$loc (SModule (x, m)) }
   | MODULE x = as_loc(UIDENT)
@@ -210,7 +209,7 @@ record_field(ID, EXP):
 field_decl:
   | x = record_field(lident, type_expr)
     { let (fld_ident, fld_type) = x in
-      { fld_ident; fld_type; fld_id= 0; fld_loc= mklocation $loc } }
+      { fld_ident; fld_type; fld_id= 0; fld_loc= Loc.of_pos $loc } }
 
 type_kind:
   | (* empty *)
@@ -291,7 +290,7 @@ ctor_decl:
     { { ctor_ident= id
       ; ctor_args= args
       ; ctor_ret= return_typ
-      ; ctor_loc= mklocation $loc } }
+      ; ctor_loc= Loc.of_pos $loc } }
 
 expr_field:
   | x = record_field(longident(lident, UIDENT), expr)
@@ -562,4 +561,4 @@ longident(X, M):
     { Ldot (path, x) }
 
 %inline err : _x = error
-  { mklocation ($symbolstartpos, $endpos) }
+  { Loc.of_pos ($symbolstartpos, $endpos) }


### PR DESCRIPTION
This PR
* adds converters between the basic location types to `Ast_build.loc`:
  - `Location.t`, the type used for error reporting
  - `Lexing.location * Lexing.location`, generated by menhir
  - `string * int * int * int`, generated by the compiler primitive `__POS__`
* uses the converter to give a useful error location for compiler internal errors, pointing to the code responsible
* uses the converter in place of the function in `Parser_impl`

This makes it much easier to find the source of internal errors, which makes debugging simpler.