### PR TITLE
[Meja] Add a --compiler-backtraces flag

### DIFF
--- a/meja/scripts/run-tests.sh
+++ b/meja/scripts/run-tests.sh
@@ -36,7 +36,12 @@ check_diff() {
 }
 
 run_test() {
-  run_dune exec meja/meja.exe -- --ml "tests/out/$1.ml" --stderr "tests/out/$1.stderr" "tests/$1.meja" 2> /dev/null
+  if [ -z "$MEJA_BACKTRACE" ]; then
+    BACKTRACE_FLAG=""
+  else
+    BACKTRACE_FLAG="--compiler-backtraces"
+  fi
+  run_dune exec meja/meja.exe -- $BACKTRACE_FLAG --ml "tests/out/$1.ml" --stderr "tests/out/$1.stderr" "tests/$1.meja" 2> /dev/null
   if [ $? -ne 0 ]; then
     if [ -e "tests/$1.fail" ]; then
       if [[ "$update_output" -eq 0 ]]; then


### PR DESCRIPTION
This PR
* adds a `--compiler-backtraces` flag, to give backtraces without recompiling Meja
* switches the flag on in the tests if the `MEJA_BACKTRACE` environment variable is present