### PR TITLE
[Meja] Exit tests when Ctrl-C is pressed

### DIFF
--- a/meja/scripts/run-tests.sh
+++ b/meja/scripts/run-tests.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Capture the interrupt signal (Ctrl-C) and exit
+trap "exit" SIGINT
+
 run_dune() {
   dune $1 --display quiet --root=.. ${@:2}
 }


### PR DESCRIPTION
At the moment, sending an interrupt with Ctrl-C just ends the current test, which can be quite frustrating if you didn't mean to run all ~90 tests.

This PR captures the interrupt signal and exits the whole test runner instead.