### PR TITLE
Tags for merkle tree

### DIFF
--- a/src/merkle_tree.ml
+++ b/src/merkle_tree.ml
@@ -444,35 +444,8 @@ struct
     | Set : Address.value * Elt.value -> unit Request.t
 
   (* addr0 should have least significant bit first *)
-  let%snarkydef_ modify_req ~(depth : int) root addr0 ~f :
-      (Hash.var, 's) Checked.t =
-    let open Let_syntax in
-    let%bind prev, prev_path =
-      request_witness
-        Typ.(Elt.typ * Path.typ ~depth)
-        As_prover.(
-          map
-            (read (Address.typ ~depth) addr0)
-            ~f:(fun a -> Get_element (`Curr_ledger, a)))
-    in
-    let%bind () =
-      let%bind prev_entry_hash = Elt.hash prev in
-      implied_root prev_entry_hash addr0 prev_path >>= Hash.assert_equal root
-    in
-    let%bind next = f prev in
-    let%bind next_entry_hash = Elt.hash next in
-    let%bind () =
-      perform
-        (let open As_prover in
-        let open Let_syntax in
-        let%map addr = read (Address.typ ~depth) addr0
-        and next = read Elt.typ next in
-        Set (addr, next))
-    in
-    implied_root next_entry_hash addr0 prev_path
-
-  let%snarkydef_ modify_or_get_req ~is_chain_voting ~(depth : int) root addr0
-      ~f : (Hash.var * Elt.var, 's) Checked.t =
+  let%snarkydef_ modify_req ~is_chain_voting ~(depth : int) root addr0 ~f :
+      (Hash.var * Elt.var, 's) Checked.t =
     let open Let_syntax in
     let%bind prev, prev_path =
       request_witness

--- a/src/merkle_tree.ml
+++ b/src/merkle_tree.ml
@@ -410,16 +410,13 @@ struct
 
   module Tag = struct
     type value = [`Curr_ledger | `Epoch_ledger]
+
     type var = Boolean.var
 
     let typ : (var, value) Typ.t =
       Typ.transport Boolean.typ
-        ~there:(function
-          | `Curr_ledger -> false
-          | `Epoch_ledger -> true)
-        ~back:(function
-          | false -> `Curr_ledger
-          | true -> `Epoch_ledger)
+        ~there:(function `Curr_ledger -> false | `Epoch_ledger -> true)
+        ~back:(function false -> `Curr_ledger | true -> `Epoch_ledger)
   end
 
   let implied_root entry_hash addr0 path0 =
@@ -440,7 +437,9 @@ struct
     go 0 entry_hash addr0 path0
 
   type _ Request.t +=
-    | Get_element : Tag.value * Address.value -> (Elt.value * Path.value) Request.t
+    | Get_element :
+        Tag.value * Address.value
+        -> (Elt.value * Path.value) Request.t
     | Get_path : Address.value -> Path.value Request.t
     | Set : Address.value * Elt.value -> unit Request.t
 
@@ -452,7 +451,9 @@ struct
       request_witness
         Typ.(Elt.typ * Path.typ ~depth)
         As_prover.(
-          map (read (Address.typ ~depth) addr0) ~f:(fun a -> Get_element (`Curr_ledger, a)))
+          map
+            (read (Address.typ ~depth) addr0)
+            ~f:(fun a -> Get_element (`Curr_ledger, a)))
     in
     let%bind () =
       let%bind prev_entry_hash = Elt.hash prev in
@@ -470,18 +471,17 @@ struct
     in
     implied_root next_entry_hash addr0 prev_path
 
-  let%snarkydef_ modify_or_get_req ~is_chain_voting ~(depth : int) root addr0 ~f :
-      (Hash.var * Elt.var, 's) Checked.t =
+  let%snarkydef_ modify_or_get_req ~is_chain_voting ~(depth : int) root addr0
+      ~f : (Hash.var * Elt.var, 's) Checked.t =
     let open Let_syntax in
     let%bind prev, prev_path =
       request_witness
         Typ.(Elt.typ * Path.typ ~depth)
         As_prover.(
-            Let_syntax.(
+          Let_syntax.(
             let%map addr = read (Address.typ ~depth) addr0
-            and tag = read Tag.typ is_chain_voting
-            in
-            Get_element (tag, addr) ))
+            and tag = read Tag.typ is_chain_voting in
+            Get_element (tag, addr)))
     in
     let%bind () =
       let%bind prev_entry_hash = Elt.hash prev in
@@ -507,7 +507,9 @@ struct
       request_witness
         Typ.(Elt.typ * Path.typ ~depth)
         As_prover.(
-          map (read (Address.typ ~depth) addr0) ~f:(fun a -> Get_element (`Curr_ledger, a)))
+          map
+            (read (Address.typ ~depth) addr0)
+            ~f:(fun a -> Get_element (`Curr_ledger, a)))
     in
     let%bind () =
       let%bind prev_entry_hash = Elt.hash prev in

--- a/src/merkle_tree.ml
+++ b/src/merkle_tree.ml
@@ -456,6 +456,32 @@ struct
     in
     implied_root next_entry_hash addr0 prev_path
 
+  let%snarkydef_ modify_or_get_req ~(depth : int) root addr0 ~f :
+      (Hash.var * Elt.var, 's) Checked.t =
+    let open Let_syntax in
+    let%bind prev, prev_path =
+      request_witness
+        Typ.(Elt.typ * Path.typ ~depth)
+        As_prover.(
+          map (read (Address.typ ~depth) addr0) ~f:(fun a -> Get_element a))
+    in
+    let%bind () =
+      let%bind prev_entry_hash = Elt.hash prev in
+      implied_root prev_entry_hash addr0 prev_path >>= Hash.assert_equal root
+    in
+    let%bind next = f prev in
+    let%bind next_entry_hash = Elt.hash next in
+    let%bind () =
+      perform
+        (let open As_prover in
+        let open Let_syntax in
+        let%map addr = read (Address.typ ~depth) addr0
+        and next = read Elt.typ next in
+        Set (addr, next))
+    in
+    let%map new_root = implied_root next_entry_hash addr0 prev_path in
+    (new_root, prev)
+
   (* addr0 should have least significant bit first *)
   let%snarkydef_ get_req ~(depth : int) root addr0 : (Elt.var, 's) Checked.t =
     let open Let_syntax in

--- a/src/merkle_tree.ml
+++ b/src/merkle_tree.ml
@@ -426,7 +426,7 @@ struct
     go 0 entry_hash addr0 path0
 
   type _ Request.t +=
-    | Get_element : Address.value -> (Elt.value * Path.value) Request.t
+    | Get_element : [< `Curr_ledger | `Epoch_ledger] * Address.value -> (Elt.value * Path.value) Request.t
     | Get_path : Address.value -> Path.value Request.t
     | Set : Address.value * Elt.value -> unit Request.t
 
@@ -438,7 +438,7 @@ struct
       request_witness
         Typ.(Elt.typ * Path.typ ~depth)
         As_prover.(
-          map (read (Address.typ ~depth) addr0) ~f:(fun a -> Get_element a))
+          map (read (Address.typ ~depth) addr0) ~f:(fun a -> Get_element (`Curr_ledger, a)))
     in
     let%bind () =
       let%bind prev_entry_hash = Elt.hash prev in
@@ -456,14 +456,14 @@ struct
     in
     implied_root next_entry_hash addr0 prev_path
 
-  let%snarkydef_ modify_or_get_req ~(depth : int) root addr0 ~f :
+  let%snarkydef_ modify_or_get_req ~tag ~(depth : int) root addr0 ~f :
       (Hash.var * Elt.var, 's) Checked.t =
     let open Let_syntax in
     let%bind prev, prev_path =
       request_witness
         Typ.(Elt.typ * Path.typ ~depth)
         As_prover.(
-          map (read (Address.typ ~depth) addr0) ~f:(fun a -> Get_element a))
+          map (read (Address.typ ~depth) addr0) ~f:(fun a -> Get_element (tag, a)))
     in
     let%bind () =
       let%bind prev_entry_hash = Elt.hash prev in
@@ -489,7 +489,7 @@ struct
       request_witness
         Typ.(Elt.typ * Path.typ ~depth)
         As_prover.(
-          map (read (Address.typ ~depth) addr0) ~f:(fun a -> Get_element a))
+          map (read (Address.typ ~depth) addr0) ~f:(fun a -> Get_element (`Curr_ledger, a)))
     in
     let%bind () =
       let%bind prev_entry_hash = Elt.hash prev in

--- a/src/merkle_tree.mli
+++ b/src/merkle_tree.mli
@@ -100,8 +100,14 @@ module Checked
     val typ : depth:int -> (var, value) Typ.t
   end
 
+  module Tag : sig
+    type value = [`Curr_ledger | `Epoch_ledger]
+    type var = Boolean.var
+    val typ : (var, value) Typ.t
+  end
+
   type _ Request.t +=
-    | Get_element : [< `Curr_ledger | `Epoch_ledger] * Address.value -> (Elt.value * Path.value) Request.t
+    | Get_element : Tag.value * Address.value -> (Elt.value * Path.value) Request.t
     | Get_path : Address.value -> Path.value Request.t
     | Set : Address.value * Elt.value -> unit Request.t
 
@@ -119,8 +125,8 @@ module Checked
     -> (Hash.var, 's) Checked.t
 
   val modify_or_get_req :
-       tag:[< `Curr_ledger | `Epoch_ledger]
--> depth:int       
+       is_chain_voting:Boolean.var
+    -> depth:int       
     -> Hash.var
     -> Address.var
     -> f:(Elt.var -> (Elt.var, 's) Checked.t)

--- a/src/merkle_tree.mli
+++ b/src/merkle_tree.mli
@@ -101,7 +101,7 @@ module Checked
   end
 
   type _ Request.t +=
-    | Get_element : Address.value -> (Elt.value * Path.value) Request.t
+    | Get_element : [< `Curr_ledger | `Epoch_ledger] * Address.value -> (Elt.value * Path.value) Request.t
     | Get_path : Address.value -> Path.value Request.t
     | Set : Address.value * Elt.value -> unit Request.t
 
@@ -119,7 +119,8 @@ module Checked
     -> (Hash.var, 's) Checked.t
 
   val modify_or_get_req :
-       depth:int
+       tag:[< `Curr_ledger | `Epoch_ledger]
+-> depth:int       
     -> Hash.var
     -> Address.var
     -> f:(Elt.var -> (Elt.var, 's) Checked.t)

--- a/src/merkle_tree.mli
+++ b/src/merkle_tree.mli
@@ -100,18 +100,8 @@ module Checked
     val typ : depth:int -> (var, value) Typ.t
   end
 
-  module Tag : sig
-    type value = [`Curr_ledger | `Epoch_ledger]
-
-    type var = Boolean.var
-
-    val typ : (var, value) Typ.t
-  end
-
   type _ Request.t +=
-    | Get_element :
-        Tag.value * Address.value
-        -> (Elt.value * Path.value) Request.t
+    | Get_element : Address.value -> (Elt.value * Path.value) Request.t
     | Get_path : Address.value -> Path.value Request.t
     | Set : Address.value * Elt.value -> unit Request.t
 
@@ -121,8 +111,15 @@ module Checked
   (* TODO: Change [prev] to be [prev_hash : Hash.var] since there may be no need
     to certify that the hash of the element is a particular value. *)
   val modify_req :
-       is_chain_voting:Boolean.var
-    -> depth:int
+       depth:int
+    -> Hash.var
+    -> Address.var
+    -> f:(Elt.var -> (Elt.var, 's) Checked.t)
+    -> (Hash.var, 's) Checked.t
+
+  (* This function does the modification and also returns the old value *)
+  val fetch_and_update_req :
+       depth:int
     -> Hash.var
     -> Address.var
     -> f:(Elt.var -> (Elt.var, 's) Checked.t)

--- a/src/merkle_tree.mli
+++ b/src/merkle_tree.mli
@@ -120,15 +120,7 @@ module Checked
 
   (* TODO: Change [prev] to be [prev_hash : Hash.var] since there may be no need
     to certify that the hash of the element is a particular value. *)
-
   val modify_req :
-       depth:int
-    -> Hash.var
-    -> Address.var
-    -> f:(Elt.var -> (Elt.var, 's) Checked.t)
-    -> (Hash.var, 's) Checked.t
-
-  val modify_or_get_req :
        is_chain_voting:Boolean.var
     -> depth:int
     -> Hash.var

--- a/src/merkle_tree.mli
+++ b/src/merkle_tree.mli
@@ -102,12 +102,16 @@ module Checked
 
   module Tag : sig
     type value = [`Curr_ledger | `Epoch_ledger]
+
     type var = Boolean.var
+
     val typ : (var, value) Typ.t
   end
 
   type _ Request.t +=
-    | Get_element : Tag.value * Address.value -> (Elt.value * Path.value) Request.t
+    | Get_element :
+        Tag.value * Address.value
+        -> (Elt.value * Path.value) Request.t
     | Get_path : Address.value -> Path.value Request.t
     | Set : Address.value * Elt.value -> unit Request.t
 
@@ -126,7 +130,7 @@ module Checked
 
   val modify_or_get_req :
        is_chain_voting:Boolean.var
-    -> depth:int       
+    -> depth:int
     -> Hash.var
     -> Address.var
     -> f:(Elt.var -> (Elt.var, 's) Checked.t)

--- a/src/merkle_tree.mli
+++ b/src/merkle_tree.mli
@@ -118,6 +118,13 @@ module Checked
     -> f:(Elt.var -> (Elt.var, 's) Checked.t)
     -> (Hash.var, 's) Checked.t
 
+  val modify_or_get_req :
+       depth:int
+    -> Hash.var
+    -> Address.var
+    -> f:(Elt.var -> (Elt.var, 's) Checked.t)
+    -> (Hash.var * Elt.var, 's) Checked.t
+
   val get_req : depth:int -> Hash.var -> Address.var -> (Elt.var, 's) Checked.t
 
   (* TODO: Change [prev] to be [prev_hash : Hash.var] since there may be no need


### PR DESCRIPTION
In this PR, I add a `Tag` to merkle_tree.ml. The tag would be used in the `Get_element` request to determine the target merkle_tree.