### PR TITLE
Implement handle_as_prover

### DIFF
--- a/src/checked.ml
+++ b/src/checked.ml
@@ -172,6 +172,16 @@ module Make
 
   let handle t k = with_handler (Request.Handler.create_single k) t
 
+  let handle_as_prover t k =
+    let handler = ref None in
+    let%bind () =
+      as_prover
+        As_prover.(
+          let%map h = k in
+          handler := Some h)
+    in
+    handle t (fun request -> (Option.value_exn !handler) request)
+
   let do_nothing _ = As_prover.return ()
 
   let with_state ?(and_then = do_nothing) f sub = with_state f and_then sub

--- a/src/checked_intf.ml
+++ b/src/checked_intf.ml
@@ -81,6 +81,11 @@ module type S = sig
   val handle :
     ('a, 's, 'f field) t -> (request -> response) -> ('a, 's, 'f field) t
 
+  val handle_as_prover :
+       ('a, 's, 'f field) t
+    -> (request -> response, 'f field, 's) Types.As_prover.t
+    -> ('a, 's, 'f field) t
+
   val next_auxiliary : (int, 's, 'f field) t
 
   val with_label : string -> ('a, 's, 'f field) t -> ('a, 's, 'f field) t

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -2001,6 +2001,10 @@ module Run = struct
       state := {!state with handler} ;
       a
 
+    let handle_as_prover x h =
+      let h = h () in
+      handle x h
+
     let with_label lbl x =
       let {stack; _} = !state in
       state := {!state with stack= lbl :: stack} ;

--- a/src/snark_intf.ml
+++ b/src/snark_intf.ml
@@ -1174,6 +1174,13 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
       {!val:request_witness}, {!val:perform}, {!val:request} or {!val:exists}.
   *)
 
+  val handle_as_prover :
+    ('a, 's) Checked.t -> (Handler.t, 's) As_prover.t -> ('a, 's) Checked.t
+  (** Generate a handler using the {!module:As_prover} 'superpowers', and use
+      it for {!val:request_witness}, {!val:perform}, {!val:request} or
+      {!val:exists} calls in the wrapped checked computation.
+  *)
+
   val with_label : string -> ('a, 's) Checked.t -> ('a, 's) Checked.t
   (** Add a label to all of the constraints added in the checked computation.
       If a constraint is checked and isn't satisfied, this label will be shown
@@ -1884,6 +1891,8 @@ module type Run_basic = sig
     -> ('var, 'value) Handle.t
 
   val handle : (unit -> 'a) -> Handler.t -> 'a
+
+  val handle_as_prover : (unit -> 'a) -> (unit -> Handler.t As_prover.t) -> 'a
 
   val with_label : string -> (unit -> 'a) -> 'a
 


### PR DESCRIPTION
This PR implements `handle_as_prover`, which lets us communicate prover-only information into handlers. For example, this reduces the code necessary for merkle tree tags (#246) to:

```ocaml
handle_as_prover ( (* code that calls modify_ref here *) )
  As_prover.(
    let%map tag = read Tag.typ is_chain_voting in
    fun (With {request; respond}) ->
      match request with
      | Get_element addr ->
          (* handler code using the value of tag *)
      | _ -> unhandled))
```