### PR TITLE
Fix GM bug (don't swap AB)

### DIFF
--- a/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_bn128.cpp
+++ b/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_bn128.cpp
@@ -563,7 +563,8 @@ void camlsnark_bn128_r1cs_constraint_system_report_statistics(r1cs_constraint_sy
   sys->report_linear_constraint_statistics();
 }
 
-void camlsnark_bn128_r1cs_constraint_system_finalize(r1cs_constraint_system<FieldT>* sys) {
+void camlsnark_bn128_r1cs_constraint_system_swap_AB_if_beneficial(
+    r1cs_constraint_system<FieldT>* sys) {
   sys->swap_AB_if_beneficial();
 }
 

--- a/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_mnt4.cpp
+++ b/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_mnt4.cpp
@@ -563,7 +563,8 @@ void camlsnark_mnt4_r1cs_constraint_system_report_statistics(r1cs_constraint_sys
   sys->report_linear_constraint_statistics();
 }
 
-void camlsnark_mnt4_r1cs_constraint_system_finalize(r1cs_constraint_system<FieldT>* sys) {
+void camlsnark_mnt4_r1cs_constraint_system_swap_AB_if_beneficial(
+    r1cs_constraint_system<FieldT>* sys) {
   sys->swap_AB_if_beneficial();
 }
 

--- a/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_mnt4753.cpp
+++ b/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_mnt4753.cpp
@@ -563,7 +563,8 @@ void camlsnark_mnt4753_r1cs_constraint_system_report_statistics(r1cs_constraint_
   sys->report_linear_constraint_statistics();
 }
 
-void camlsnark_mnt4753_r1cs_constraint_system_finalize(r1cs_constraint_system<FieldT>* sys) {
+void camlsnark_mnt4753_r1cs_constraint_system_swap_AB_if_beneficial(
+    r1cs_constraint_system<FieldT>* sys) {
   sys->swap_AB_if_beneficial();
 }
 

--- a/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_mnt6.cpp
+++ b/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_mnt6.cpp
@@ -563,7 +563,8 @@ void camlsnark_mnt6_r1cs_constraint_system_report_statistics(r1cs_constraint_sys
   sys->report_linear_constraint_statistics();
 }
 
-void camlsnark_mnt6_r1cs_constraint_system_finalize(r1cs_constraint_system<FieldT>* sys) {
+void camlsnark_mnt6_r1cs_constraint_system_swap_AB_if_beneficial(
+    r1cs_constraint_system<FieldT>* sys) {
   sys->swap_AB_if_beneficial();
 }
 

--- a/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_mnt6753.cpp
+++ b/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_mnt6753.cpp
@@ -563,7 +563,8 @@ void camlsnark_mnt6753_r1cs_constraint_system_report_statistics(r1cs_constraint_
   sys->report_linear_constraint_statistics();
 }
 
-void camlsnark_mnt6753_r1cs_constraint_system_finalize(r1cs_constraint_system<FieldT>* sys) {
+void camlsnark_mnt6753_r1cs_constraint_system_swap_AB_if_beneficial(
+    r1cs_constraint_system<FieldT>* sys) {
   sys->swap_AB_if_beneficial();
 }
 


### PR DESCRIPTION
This should fix the bug which is causing the proposer to fail in coda. I was calling swap_AB_if_beneficial always after rebuilding a constraint system, but it is in fact not called in the groth-maller key generator, and only in the groth16 key generator. This change it so that for groth-maller we do not call that function on rebuilding a constraint system.