### PR TITLE
Builds are portable

### DIFF
--- a/src/camlsnark_c/dune
+++ b/src/camlsnark_c/dune
@@ -49,7 +49,11 @@
    pushd libsnark-caml
    mkdir -p build
    pushd build
-     cmake -DPERFORMANCE=$SNARKY_PERFORMANCE -DMULTICORE=ON -DUSE_PT_COMPRESSION=OFF ..
+     cmake -DPERFORMANCE=$SNARKY_PERFORMANCE \\
+       -DMULTICORE=ON \\
+       -DUSE_PT_COMPRESSION=OFF \\
+       -DUSE_ASM=ON \\
+       -DOPT_FLAGS='-ggdb3 -O2' ..
      make -j$(nproc)
  
      mkdir _stubs_build
@@ -79,7 +83,9 @@
        LDFLAGS='-L/usr/local/opt/openssl/lib -L/usr/local/opt/boost/lib -L/usr/local/opt/gmp/lib' \\
        PKG_CONFIG_PATH=/usr/local/opt/openssl/lib/pkgconfig \\
        cmake \\
-         -DPERFORMANCE=$SNARKY_PERFORMANCE \\
+         -DPERFORMANCE=OFF \\
+         -DUSE_ASM=ON \\
+         -DOPT_FLAGS='-ggdb3 -O2' \\
          -DMULTICORE=ON \\
          -DUSE_PT_COMPRESSION=OFF \\
          -DWITH_SUPERCOP=OFF \\


### PR DESCRIPTION
Tested on macOS, we may need to make more changes to the linux build
later. The biggest change here is explicitly setting `OPT_FLAGS` to not
include `-march=native -mtune=native`, and explicitly turning on
USE_ASM.

I ran transaction-snark-profiler over in Coda both with and without the
OPT_FLAGS override and there is negligible changes in performance
numbers. USE_ASM is what really gets this thing flying.

PERFORMANCE is disable always on macOS because there are errors in the
rest of the build that were always present when it was on.