### PR TITLE
[Meja] Only resolve implicit arguments when the instance is a supertype

### DIFF
--- a/meja/src/envi.ml
+++ b/meja/src/envi.ml
@@ -862,20 +862,19 @@ module Type = struct
        ; implicit_id= implicit_id + 1 } ;
     new_exp
 
-  let implicit_instances ~loc ~(unify : env -> type_expr -> type_expr -> 'a)
+  let implicit_instances ~loc
+      ~(is_subtype : env -> type_expr -> of_:type_expr -> bool)
       (typ : type_expr) env =
     List.filter_map env.resolve_env.type_env.instances
       ~f:(fun (id, instance_typ) ->
         let instance_typ =
           copy ~loc instance_typ (Map.empty (module Int)) env
         in
-        match unify env typ instance_typ with
-        | _ ->
-            List.find_map env.scope_stack ~f:(fun {instances; _} ->
-                Option.map (Map.find instances id) ~f:(fun path ->
-                    (path, instance_typ) ) )
-        | exception _ ->
-            None )
+        if is_subtype env typ ~of_:instance_typ then
+          List.find_map env.scope_stack ~f:(fun {instances; _} ->
+              Option.map (Map.find instances id) ~f:(fun path ->
+                  (path, instance_typ) ) )
+        else None )
 
   let generate_implicits e env =
     let loc = e.Parsetypes.exp_loc in
@@ -890,7 +889,7 @@ module Type = struct
         in
         {exp_loc= loc; exp_type= typ; exp_desc= Apply (e, es)}
 
-  let rec instantiate_implicits ~loc ~unify implicit_vars env =
+  let rec instantiate_implicits ~loc ~is_subtype implicit_vars env =
     let implicit_vars =
       List.map implicit_vars ~f:(fun e ->
           {e with Parsetypes.exp_type= flatten e.Parsetypes.exp_type env} )
@@ -900,13 +899,9 @@ module Type = struct
     <- {env.resolve_env.type_env with implicit_vars= []} ;
     let implicit_vars =
       List.filter implicit_vars ~f:(fun ({exp_loc; exp_type; _} as exp) ->
-          match implicit_instances ~loc ~unify exp_type env with
+          match implicit_instances ~loc ~is_subtype exp_type env with
           | [(name, instance_typ)] ->
-              let instance_typ =
-                copy ~loc instance_typ (Map.empty (module Int)) env
-              in
               let name = Location.mkloc name exp_loc in
-              unify env exp_type instance_typ ;
               let e =
                 generate_implicits
                   {exp_loc; exp_type= instance_typ; exp_desc= Variable name}
@@ -930,12 +925,18 @@ module Type = struct
     | [] ->
         implicit_vars
     | _ ->
-        instantiate_implicits ~loc ~unify (new_implicits @ implicit_vars) env
+        instantiate_implicits ~loc ~is_subtype
+          (new_implicits @ implicit_vars)
+          env
 
-  let flattened_implicit_vars ~loc ~toplevel ~unify typ_vars env =
-    let unify env typ ctyp = unify env typ (snd (get_implicits [] ctyp)) in
+  let flattened_implicit_vars ~loc ~toplevel ~is_subtype typ_vars env =
+    let is_subtype env typ ~of_:ctyp =
+      is_subtype env typ ~of_:(snd (get_implicits [] ctyp))
+    in
     let {TypeEnvi.implicit_vars; _} = env.resolve_env.type_env in
-    let implicit_vars = instantiate_implicits ~loc ~unify implicit_vars env in
+    let implicit_vars =
+      instantiate_implicits ~loc ~is_subtype implicit_vars env
+    in
     let implicit_vars =
       List.dedup_and_sort implicit_vars ~compare:(fun exp1 exp2 ->
           let cmp =

--- a/meja/src/typechecker.ml
+++ b/meja/src/typechecker.ml
@@ -145,6 +145,16 @@ let check_type ~loc env typ constr_typ =
   | () ->
       ()
 
+(** [is_subtype ~loc env typ ~of_:ctyp] returns whether [typ] is a subtype of
+    [ctyp], instantiating any variables in [ctyp] to those they match with in
+    [typ].
+
+    If this function returns [false], the [ctyp] value *must not* be used,
+    since its variables may have been instantiated incorrectly. A type
+    containing only fresh variables should be used.
+
+    The type variables within [typ] will remain unchanged.
+    *)
 let rec is_subtype ~loc env typ ~of_:ctyp =
   let is_subtype = is_subtype ~loc env in
   let without_instance ~f (typ : type_expr) =


### PR DESCRIPTION
This PR
- adds an `is_subtype` method
- uses `is_subtype` to check whether instances are general enough to catch all the cases necessary
  * this fixes a bug (which made my computer OOM :sweat_smile:) that would recursively try and fill an implicit variable of type `'a` with an instance of type `poly('a)`.