### PR TITLE
[Meja] Store a depth for all types

### DIFF
--- a/meja/src/codegen.ml
+++ b/meja/src/codegen.ml
@@ -45,7 +45,7 @@ let typ_of_decl ~loc env (decl : Type0.type_decl) =
                (module String)
                (List.map decl.tdec_params ~f:(fun param ->
                     match param.type_desc with
-                    | Tvar (Some name, _, _) ->
+                    | Tvar (Some name, _) ->
                         name.txt
                     | _ ->
                         "" )))
@@ -87,8 +87,7 @@ let typ_of_decl ~loc env (decl : Type0.type_decl) =
                                   ~key:variant.var_decl_id ~data:(name, variant) ;
                               name
                         in
-                        Tvar (Some (Location.mkloc var_name loc), -1, Explicit)
-                  )
+                        Tvar (Some (Location.mkloc var_name loc), Explicit) )
                 in
                 Untype_ast.field_decl ~loc {field with fld_type= typ} )
           in

--- a/meja/src/type0.ml
+++ b/meja/src/type0.ml
@@ -1,10 +1,10 @@
 open Ast_types
 
-type type_expr = {type_desc: type_desc; type_id: int}
+type type_expr = {type_desc: type_desc; type_id: int; type_depth: int}
 
 and type_desc =
   (* A type variable. Name is None when not yet chosen. *)
-  | Tvar of str option * (* depth *) int * explicitness
+  | Tvar of str option * explicitness
   | Ttuple of type_expr list
   | Tarrow of type_expr * type_expr * explicitness * Asttypes.arg_label
   (* A type name. *)
@@ -45,7 +45,7 @@ and type_decl_desc =
   | TForward of int option ref
       (** Forward declaration for types loaded from cmi files. *)
 
-let none = {type_desc= Tvar (None, -1, Explicit); type_id= -1}
+let none = {type_desc= Tvar (None, Explicit); type_id= -1; type_depth= -1}
 
 let rec typ_debug_print fmt typ =
   let open Format in
@@ -62,14 +62,14 @@ let rec typ_debug_print fmt typ =
   in
   print "(%i:" typ.type_id ;
   ( match typ.type_desc with
-  | Tvar (None, i, Explicit) ->
-      print "var _@%i" i
-  | Tvar (Some name, i, Explicit) ->
-      print "var %s@%i" name.txt i
-  | Tvar (None, i, Implicit) ->
-      print "implicit_var _@%i" i
-  | Tvar (Some name, i, Implicit) ->
-      print "implicit_var %s@%i" name.txt i
+  | Tvar (None, Explicit) ->
+      print "var _"
+  | Tvar (Some name, Explicit) ->
+      print "var %s@" name.txt
+  | Tvar (None, Implicit) ->
+      print "implicit_var _"
+  | Tvar (Some name, Implicit) ->
+      print "implicit_var %s" name.txt
   | Tpoly (typs, typ) ->
       print "poly [%a] %a"
         (print_list typ_debug_print)
@@ -84,4 +84,4 @@ let rec typ_debug_print fmt typ =
       print "%a (%a)" Longident.pp name.txt (print_list typ_debug_print) params
   | Ttuple typs ->
       print "(%a)" (print_list typ_debug_print) typs ) ;
-  print ")"
+  print " @%i)" typ.type_depth

--- a/meja/src/typechecker.ml
+++ b/meja/src/typechecker.ml
@@ -67,7 +67,7 @@ let rec check_type_aux ~loc typ ctyp env =
       check_type_aux typ ctyp env
   | _, Tpoly (_, ctyp) ->
       check_type_aux typ ctyp env
-  | Tvar (_, depth, _), Tvar (_, constr_depth, _) ->
+  | Tvar _, Tvar _ ->
       bind_none
         (without_instance typ env ~f:(fun typ -> check_type_aux typ ctyp))
         (fun () ->
@@ -78,8 +78,9 @@ let rec check_type_aux ~loc typ ctyp env =
                  the instance for the other. If they are at the same level, prefer
                  the lowest ID to ensure strict ordering and thus no cycles. *)
               if
-                constr_depth < depth
-                || (Int.equal constr_depth depth && ctyp.type_id < typ.type_id)
+                ctyp.type_depth < typ.type_depth
+                || Int.equal ctyp.type_depth typ.type_depth
+                   && ctyp.type_id < typ.type_id
               then Envi.Type.add_instance typ ctyp env
               else Envi.Type.add_instance ctyp typ env ) )
   | Tvar _, _ ->

--- a/meja/src/typeprint.ml
+++ b/meja/src/typeprint.ml
@@ -4,9 +4,9 @@ open Format
 open Ast_print
 
 let rec type_desc ?(bracket = false) fmt = function
-  | Tvar (None, _, _) ->
+  | Tvar (None, _) ->
       fprintf fmt "_"
-  | Tvar (Some name, _, _) ->
+  | Tvar (Some name, _) ->
       fprintf fmt "'%s" name.txt
   | Ttuple typs ->
       fprintf fmt "@[<1>%a@]" tuple typs

--- a/meja/src/untype_ast.ml
+++ b/meja/src/untype_ast.ml
@@ -3,9 +3,9 @@ open Type0
 open Ast_build
 
 let rec type_desc ?loc = function
-  | Tvar (None, _, explicit) ->
+  | Tvar (None, explicit) ->
       Type.none ?loc ~explicit ()
-  | Tvar (Some name, _, explicit) ->
+  | Tvar (Some name, explicit) ->
       Type.var ?loc ~explicit name.txt
   | Ttuple typs ->
       Type.tuple ?loc (List.map ~f:(type_expr ?loc) typs)


### PR DESCRIPTION
This PR separates depth from `Tvar`. This is necessary for
* compatibility with #221, for managing which local type declarations are in scope or not
* unifying implicits fully to fix the quirks in #255 
* making the level mutable, for tracking visibility and interacting with the mutable type description I'm working on

This should be a no-op. The only behavioural change is in `Type0.typ_debug_print`, which I use for my debugging only.