### PR TITLE
[Meja] Carry type declarations in variants instead of the ID

### DIFF
--- a/meja/src/codegen.ml
+++ b/meja/src/codegen.ml
@@ -69,7 +69,7 @@ let typ_of_decl ~loc env (decl : Type0.type_decl) =
                 ) ;
                 let typ =
                   Envi.Type.constr_map env field.fld_type ~f:(fun variant ->
-                      if Int.equal variant.var_decl_id decl.tdec_id then
+                      if Int.equal variant.var_decl.tdec_id decl.tdec_id then
                         Tctor
                           { variant with
                             var_ident=
@@ -77,14 +77,14 @@ let typ_of_decl ~loc env (decl : Type0.type_decl) =
                                 variant.var_ident.loc }
                       else
                         let var_name =
-                          match Map.find !constr_map variant.var_decl_id with
+                          match Map.find !constr_map variant.var_decl.tdec_id with
                           | Some (name, _) ->
                               name
                           | None ->
                               let name = next_var_name () in
                               constr_map :=
                                 Map.add_exn !constr_map
-                                  ~key:variant.var_decl_id ~data:(name, variant) ;
+                                  ~key:variant.var_decl.tdec_id ~data:(name, variant) ;
                               name
                         in
                         Tvar (Some (Location.mkloc var_name loc), -1, Explicit)

--- a/meja/src/codegen.ml
+++ b/meja/src/codegen.ml
@@ -77,14 +77,17 @@ let typ_of_decl ~loc env (decl : Type0.type_decl) =
                                 variant.var_ident.loc }
                       else
                         let var_name =
-                          match Map.find !constr_map variant.var_decl.tdec_id with
+                          match
+                            Map.find !constr_map variant.var_decl.tdec_id
+                          with
                           | Some (name, _) ->
                               name
                           | None ->
                               let name = next_var_name () in
                               constr_map :=
                                 Map.add_exn !constr_map
-                                  ~key:variant.var_decl.tdec_id ~data:(name, variant) ;
+                                  ~key:variant.var_decl.tdec_id
+                                  ~data:(name, variant) ;
                               name
                         in
                         Tvar (Some (Location.mkloc var_name loc), -1, Explicit)

--- a/meja/src/envi.ml
+++ b/meja/src/envi.ml
@@ -39,7 +39,6 @@ module TypeEnvi = struct
     ; variable_instances: type_expr int_map
     ; implicit_vars: Parsetypes.expression list
     ; implicit_id: int
-    ; type_decls: type_decl int_map
     ; instances: (int * type_expr) list
     ; predeclared_types:
         (int (* id *) * int option ref (* num. args *) * Location.t) name_map
@@ -52,7 +51,6 @@ module TypeEnvi = struct
     ; variable_instances= Map.empty (module Int)
     ; implicit_id= 1
     ; implicit_vars= []
-    ; type_decls= Map.empty (module Int)
     ; instances= []
     ; predeclared_types= Map.empty (module String) }
 
@@ -71,11 +69,6 @@ module TypeEnvi = struct
 
   let next_decl_id env =
     (env.type_decl_id, {env with type_decl_id= env.type_decl_id + 1})
-
-  let decl env (ctor : variant) = Map.find env.type_decls ctor.var_decl_id
-
-  let add_decl (decl : type_decl) env =
-    {env with type_decls= Map.set env.type_decls ~key:decl.tdec_id ~data:decl}
 
   let next_instance_id env =
     (env.instance_id, {env with instance_id= env.instance_id + 1})
@@ -622,7 +615,7 @@ module Type = struct
         | decl ->
             let variant =
               { variant with
-                var_decl_id= decl.tdec_id
+                var_decl= decl
               ; var_implicit_params= decl.tdec_implicit_params }
             in
             let given_args_length = List.length var_params in
@@ -805,8 +798,8 @@ module Type = struct
           -1
       | _, Tvar _ ->
           1
-      | ( Tctor {var_decl_id= id1; var_params= params1; _}
-        , Tctor {var_decl_id= id2; var_params= params2; _} ) ->
+      | ( Tctor {var_decl= {tdec_id= id1; _}; var_params= params1; _}
+        , Tctor {var_decl= {tdec_id= id2; _}; var_params= params2; _} ) ->
           or_compare (Int.compare id1 id2) ~f:(fun () ->
               compare_all params1 params2 )
       | Tctor _, _ ->
@@ -1122,8 +1115,10 @@ module TypeDecl = struct
                    match ctor.ctor_args with
                    | Ctor_tuple typs ->
                        typs
-                   | Ctor_record (_, fields) ->
+                   | Ctor_record {tdec_desc= TRecord fields; _} ->
                        List.map ~f:(fun {fld_type; _} -> fld_type) fields
+                   | Ctor_record _ ->
+                       assert false
                  in
                  let typs =
                    match ctor.ctor_ret with
@@ -1220,7 +1215,7 @@ module TypeDecl = struct
                             (env, arg) )
                       in
                       (env, Ctor_tuple args)
-                  | Ctor_record (_, fields) ->
+                  | Ctor_record {tdec_desc= TRecord fields; _} ->
                       let env, fields =
                         List.fold_map ~init:env fields ~f:(fun env field ->
                             let fld_type, env =
@@ -1232,8 +1227,9 @@ module TypeDecl = struct
                         mk ~name:ctor.ctor_ident ~params:ctor_ret_params
                           (TRecord fields) env
                       in
-                      Type.map_env env ~f:(TypeEnvi.add_decl decl) ;
-                      (env, Ctor_record (decl.tdec_id, fields))
+                      (env, Ctor_record decl)
+                  | Ctor_record _ ->
+                      assert false
                 in
                 let env = push_scope scope (close_expr_scope env) in
                 (env, {ctor with ctor_args; ctor_ret}) )
@@ -1251,7 +1247,6 @@ module TypeDecl = struct
     let env =
       map_current_scope ~f:(Scope.register_type_declaration decl) env
     in
-    Type.map_env env ~f:(TypeEnvi.add_decl decl) ;
     (decl, env)
 
   let mk_typ ~params ?ident decl =
@@ -1261,20 +1256,14 @@ module TypeDecl = struct
          { var_ident= ident
          ; var_params= params
          ; var_implicit_params= []
-         ; var_decl_id= decl.tdec_id })
+         ; var_decl= decl })
 
   let find_of_type ~loc typ env =
     let open Option.Let_syntax in
     let%map variant =
       match typ.type_desc with Tctor variant -> Some variant | _ -> None
     in
-    let decl =
-      match TypeEnvi.decl env.resolve_env.type_env variant with
-      | Some decl ->
-          decl
-      | None ->
-          raise (Error (loc, Unbound_type variant.var_ident.txt))
-    in
+    let decl = variant.var_decl in
     let bound_vars =
       match
         List.fold2
@@ -1349,7 +1338,7 @@ let pp_decl_typ ppf decl =
           { var_ident= mk_lid decl.tdec_ident
           ; var_params= decl.tdec_params
           ; var_implicit_params= decl.tdec_implicit_params
-          ; var_decl_id= decl.tdec_id }
+          ; var_decl= decl }
     ; type_id= -1 }
 
 let report_error ppf = function

--- a/meja/src/type0.ml
+++ b/meja/src/type0.ml
@@ -19,9 +19,7 @@ and variant =
 
 and field_decl = {fld_ident: str; fld_type: type_expr; fld_id: int}
 
-and ctor_args =
-  | Ctor_tuple of type_expr list
-  | Ctor_record of type_decl
+and ctor_args = Ctor_tuple of type_expr list | Ctor_record of type_decl
 
 and ctor_decl =
   {ctor_ident: str; ctor_args: ctor_args; ctor_ret: type_expr option}

--- a/meja/src/type0.ml
+++ b/meja/src/type0.ml
@@ -15,18 +15,18 @@ and variant =
   { var_ident: lid
   ; var_params: type_expr list
   ; var_implicit_params: type_expr list
-  ; var_decl_id: int }
+  ; var_decl: type_decl }
 
-type field_decl = {fld_ident: str; fld_type: type_expr; fld_id: int}
+and field_decl = {fld_ident: str; fld_type: type_expr; fld_id: int}
 
-type ctor_args =
+and ctor_args =
   | Ctor_tuple of type_expr list
-  | Ctor_record of int * field_decl list
+  | Ctor_record of type_decl
 
-type ctor_decl =
+and ctor_decl =
   {ctor_ident: str; ctor_args: ctor_args; ctor_ret: type_expr option}
 
-type type_decl =
+and type_decl =
   { tdec_ident: str
   ; tdec_params: type_expr list
   ; tdec_implicit_params: type_expr list

--- a/meja/src/type0.ml
+++ b/meja/src/type0.ml
@@ -1,6 +1,7 @@
+open Core_kernel
 open Ast_types
 
-type type_expr = {type_desc: type_desc; type_id: int}
+type type_expr = {mutable type_desc: type_desc; type_id: int}
 
 and type_desc =
   (* A type variable. Name is None when not yet chosen. *)
@@ -83,3 +84,21 @@ let rec typ_debug_print fmt typ =
   | Ttuple typs ->
       print "(%a)" (print_list typ_debug_print) typs ) ;
   print ")"
+
+let fold ~init ~f typ =
+  match typ.type_desc with
+  | Tvar _ ->
+      init
+  | Ttuple typs ->
+      List.fold ~init ~f typs
+  | Tarrow (typ1, typ2, _, _) ->
+      let acc = f init typ1 in
+      f acc typ2
+  | Tctor variant ->
+      let acc = List.fold ~init ~f variant.var_params in
+      List.fold ~init:acc ~f variant.var_implicit_params
+  | Tpoly (typs, typ) ->
+      let acc = List.fold ~init ~f typs in
+      f acc typ
+
+let iter ~f = fold ~init:() ~f:(fun () -> f)

--- a/meja/src/typechecker.ml
+++ b/meja/src/typechecker.ml
@@ -30,7 +30,9 @@ let bind_none x f = match x with Some x -> x | None -> f ()
 let unpack_decls ~loc typ ctyp env =
   match (typ.type_desc, ctyp.type_desc) with
   | Tctor variant, Tctor cvariant ->
-      let decl_id, cdecl_id = (variant.var_decl.tdec_id, cvariant.var_decl.tdec_id) in
+      let decl_id, cdecl_id =
+        (variant.var_decl.tdec_id, cvariant.var_decl.tdec_id)
+      in
       let unfold_typ () =
         Option.map (Envi.TypeDecl.unfold_alias ~loc typ env) ~f:(fun typ ->
             (typ, ctyp) )
@@ -114,7 +116,8 @@ let rec check_type_aux ~loc typ ctyp env =
       check_type_aux typ1 ctyp1 env ;
       check_type_aux typ2 ctyp2 env
   | Tctor variant, Tctor constr_variant ->
-      if Int.equal variant.var_decl.tdec_id constr_variant.var_decl.tdec_id then
+      if Int.equal variant.var_decl.tdec_id constr_variant.var_decl.tdec_id
+      then
         match
           List.iter2 variant.var_params constr_variant.var_params
             ~f:(fun param constr_param -> check_type_aux param constr_param env
@@ -222,7 +225,8 @@ let rec is_subtype ~loc env typ ~of_:ctyp =
           false )
       && is_subtype typ1 ~of_:ctyp1 && is_subtype typ2 ~of_:ctyp2
   | Tctor variant, Tctor constr_variant -> (
-      if Int.equal variant.var_decl.tdec_id constr_variant.var_decl.tdec_id then
+      if Int.equal variant.var_decl.tdec_id constr_variant.var_decl.tdec_id
+      then
         match
           List.for_all2 variant.var_params constr_variant.var_params
             ~f:(fun param constr_param -> is_subtype param ~of_:constr_param)
@@ -954,8 +958,7 @@ and check_module_sig env msig =
 
 let type_extension ~loc variant ctors env =
   let {Parsetypes.var_ident; var_params; var_implicit_params= _} = variant in
-  let ( {tdec_ident; tdec_params; tdec_implicit_params; tdec_desc; _}
-      as decl ) =
+  let ({tdec_ident; tdec_params; tdec_implicit_params; tdec_desc; _} as decl) =
     match Envi.raw_find_type_declaration var_ident env with
     | open_decl ->
         open_decl

--- a/meja/src/typeprint.ml
+++ b/meja/src/typeprint.ml
@@ -51,10 +51,12 @@ let ctor_args fmt = function
       ()
   | Ctor_tuple typs ->
       tuple fmt typs
-  | Ctor_record (_, fields) ->
+  | Ctor_record {tdec_desc= TRecord fields; _} ->
       fprintf fmt "{@[<2>%a@]}"
         (pp_print_list ~pp_sep:comma_sep field_decl)
         fields
+  | Ctor_record _ ->
+      assert false
 
 let ctor_decl fmt decl =
   fprintf fmt "%a%a" pp_name decl.ctor_ident.txt ctor_args decl.ctor_args ;

--- a/meja/src/typet.ml
+++ b/meja/src/typet.ml
@@ -116,10 +116,7 @@ module Type = struct
                   (env, param) )
             in
             let variant =
-              { Type0.var_params
-              ; var_ident
-              ; var_decl= decl
-              ; var_implicit_params }
+              {Type0.var_params; var_ident; var_decl= decl; var_implicit_params}
             in
             (mk (Tctor variant) env, env) )
     | Ttuple typs ->
@@ -363,7 +360,8 @@ module TypeDecl = struct
           | Ctor_tuple typs ->
               Ctor_tuple (List.map ~f:map_type typs)
           | Ctor_record ({tdec_desc= TRecord fields; _} as decl) ->
-              Ctor_record ({decl with tdec_desc= TRecord (List.map ~f:map_field fields)})
+              Ctor_record
+                {decl with tdec_desc= TRecord (List.map ~f:map_field fields)}
           | Ctor_record _ ->
               assert false
         in

--- a/meja/src/untype_ast.ml
+++ b/meja/src/untype_ast.ml
@@ -16,7 +16,7 @@ let rec type_desc ?loc = function
       { var_ident= ident
       ; var_params= params
       ; var_implicit_params= implicits
-      ; var_decl_id= _ } ->
+      ; var_decl= _ } ->
       let params = List.map ~f:(type_expr ?loc) params in
       let implicits = List.map ~f:(type_expr ?loc) implicits in
       Type.constr ?loc ~params ~implicits ident.txt
@@ -32,9 +32,11 @@ let ctor_args ?loc ?ret name = function
   | Ctor_tuple typs ->
       Type_decl.Ctor.with_args ?loc ?ret name
         (List.map ~f:(type_expr ?loc) typs)
-  | Ctor_record (_, fields) ->
+  | Ctor_record {tdec_desc= TRecord fields; _} ->
       Type_decl.Ctor.with_record ?loc ?ret name
         (List.map ~f:(field_decl ?loc) fields)
+  | Ctor_record _ ->
+      assert false
 
 let ctor_decl ?loc ctor =
   ctor_args ?loc ctor.ctor_ident.txt ctor.ctor_args


### PR DESCRIPTION
This PR
* switches to carrying the type declaration for a variant directly, instead of carrying its ID
* removes global variant registration from the environment

Doing this makes several things much simpler:
* temporary type declarations (#221) are much more straightforward to manage, since they will just be garbage-collected when the types using them are recast to generalised type variables
* unfolding types during unification/subtype checking can be done without reference to the environment
  - this will make it a lot less cumbersome and error-prone to type matches over GADTs properly
* type substitutions (for functors/local modules) can be much more simply implemented

This is a no-op.

Edit: Updated to
* make `type_desc` mutable
* updates types in-place during type declaration import, so that the inner `decl`s match the containing `decl` for recursive types