### PR TITLE
[Meja] Add row types

### DIFF
--- a/meja.opam
+++ b/meja.opam
@@ -14,6 +14,7 @@ depends: [
   "ocaml-compiler-libs"
   "ppxlib"
   "ppx_jane"
+  "ppx_deriving"
   "dune"                {build & >= "1.0+beta12"}
 ]
 available: [ ocaml-version >= "4.04.1" ]

--- a/meja/src/ast_build.ml
+++ b/meja/src/ast_build.ml
@@ -63,6 +63,8 @@ module Type = struct
     mk ?loc (Tarrow (typ1, typ2, explicit, label))
 
   let poly ?loc vars var = mk ?loc (Tpoly (vars, var))
+
+  let row ?loc row = mk ?loc (Trow row)
 end
 
 module Type_decl = struct

--- a/meja/src/dune
+++ b/meja/src/dune
@@ -3,7 +3,7 @@
  (public_name meja.lib)
  (libraries core_kernel ocaml-compiler-libs.common)
  (flags :standard -warn-error -39-21)
- (preprocess (pps ppxlib.metaquot ppx_jane)))
+ (preprocess (pps ppxlib.metaquot ppx_deriving.ord ppx_jane)))
 
 (menhir
   (flags --explain --unused-tokens)

--- a/meja/src/lexer_impl.mll
+++ b/meja/src/lexer_impl.mll
@@ -81,6 +81,7 @@ rule token = parse
   | ".." { DOTDOT }
   | '.' { DOT }
   | '-' { MINUS }
+  | '&' { AMP }
   | "//" ([^'\n']* as comment) newline
     { new_line lexbuf; COMMENT (comment) }
   | "//" ([^'\n']* as comment) eof

--- a/meja/src/pprint.ml
+++ b/meja/src/pprint.ml
@@ -27,6 +27,8 @@ let rec type_desc ?(bracket = false) fmt = function
       fprintf fmt "/*@[%a.@]*/@ %a" (type_desc ~bracket:false) (Ttuple vars)
         type_expr typ ;
       if bracket then fprintf fmt ")"
+  | Trow row ->
+      fprintf fmt "[@[<hv1>@,%a@,@]]" row_desc row
 
 and tuple fmt typs =
   fprintf fmt "(@,%a@,)" (pp_print_list ~pp_sep:comma_sep type_expr) typs
@@ -42,6 +44,20 @@ and variant fmt v =
   | _ ->
       fprintf fmt "@[<hv2>%a%a@]" Longident.pp v.var_ident.txt tuple
         v.var_params
+
+and row_desc fmt = function
+  | Row_empty ->
+      ()
+  | Row_ctor lid ->
+      Longident.pp fmt lid.txt
+  | Row_var typ ->
+      type_expr fmt typ
+  | Row_union (row1, row2) ->
+      row_desc fmt row1 ; bar_sep fmt () ; row_desc fmt row2
+  | Row_inter (row1, row2) ->
+      fprintf fmt "%a@ & [@[<hv1>@,%a@,@]]" row_desc row1 row_desc row2
+  | Row_diff (row1, row2) ->
+      fprintf fmt "%a@ - [@[<hv1>@,%a@,@]]" row_desc row1 row_desc row2
 
 let field_decl fmt decl =
   fprintf fmt "%s:@ @[<hv>%a@]" decl.fld_ident.txt type_expr decl.fld_type

--- a/meja/src/to_ocaml.ml
+++ b/meja/src/to_ocaml.ml
@@ -20,6 +20,8 @@ let rec of_type_desc ?loc typ =
       Typ.constr ?loc name (List.map ~f:of_type_expr (params @ implicits))
   | Ttuple typs ->
       Typ.tuple ?loc (List.map ~f:of_type_expr typs)
+  | Trow _ ->
+      assert false
 
 and of_type_expr typ = of_type_desc ~loc:typ.type_loc typ.type_desc
 

--- a/meja/src/to_ocaml.ml
+++ b/meja/src/to_ocaml.ml
@@ -21,7 +21,7 @@ let rec of_type_desc ?loc typ =
   | Ttuple typs ->
       Typ.tuple ?loc (List.map ~f:of_type_expr typs)
   | Trow _ ->
-      assert false
+      Typ.constr ?loc (Location.mknoloc (Longident.Lident "unit")) []
 
 and of_type_expr typ = of_type_desc ~loc:typ.type_loc typ.type_desc
 

--- a/meja/src/typechecker.ml
+++ b/meja/src/typechecker.ml
@@ -267,13 +267,12 @@ let rec add_implicits ~loc implicits typ env =
       Envi.Type.mk (Tarrow (typ', typ, Implicit, Nolabel)) env
 
 let free_type_vars ?depth typ =
-  let empty = Set.empty (module Envi.Type) in
+  let empty = Envi.Type.Set.empty in
   let rec free_type_vars set typ =
     match typ.type_desc with
     | Tpoly (vars, typ) ->
         let poly_vars =
-          Set.union_list
-            (module Envi.Type)
+          Envi.Type.Set.union_list
             (List.map ~f:(Envi.Type.type_vars ?depth) vars)
         in
         Set.union set (Set.diff (free_type_vars empty typ) poly_vars)

--- a/meja/src/typeprint.ml
+++ b/meja/src/typeprint.ml
@@ -27,6 +27,8 @@ let rec type_desc ?(bracket = false) fmt = function
       fprintf fmt "/*@[%a.@]*/@ %a" (type_desc ~bracket:false) (Ttuple vars)
         type_expr typ ;
       if bracket then fprintf fmt ")"
+  | Trow row ->
+      fprintf fmt "[@[<hv1>@,%a@,@]]" row_desc row
 
 and tuple fmt typs =
   fprintf fmt "(@,%a@,)" (pp_print_list ~pp_sep:comma_sep type_expr) typs
@@ -42,6 +44,20 @@ and variant fmt v =
   | _ ->
       fprintf fmt "@[<hv2>%a%a@]" Longident.pp v.var_ident.txt tuple
         v.var_params
+
+and row_desc fmt = function
+  | Row_empty ->
+      ()
+  | Row_ctor (lid, _) ->
+      Longident.pp fmt lid.txt
+  | Row_var typ ->
+      type_expr fmt typ
+  | Row_union (row1, row2) ->
+      row_desc fmt row1 ; bar_sep fmt () ; row_desc fmt row2
+  | Row_inter (row1, row2) ->
+      fprintf fmt "%a@ & [@[<hv1>@,%a@,@]]" row_desc row1 row_desc row2
+  | Row_diff (row1, row2) ->
+      fprintf fmt "%a@ - [@[<hv1>@,%a@,@]]" row_desc row1 row_desc row2
 
 let field_decl fmt decl =
   fprintf fmt "%s:@ @[<hv>%a@]" decl.fld_ident.txt type_expr decl.fld_type

--- a/meja/src/typeprint.ml
+++ b/meja/src/typeprint.ml
@@ -1,3 +1,4 @@
+open Core_kernel
 open Ast_types
 open Type0
 open Format
@@ -46,18 +47,21 @@ and variant fmt v =
         v.var_params
 
 and row_desc fmt = function
-  | Row_empty ->
-      ()
-  | Row_ctor (lid, _) ->
-      Longident.pp fmt lid.txt
-  | Row_var typ ->
-      type_expr fmt typ
+  | Row_spec spec ->
+      row_spec fmt spec
   | Row_union (row1, row2) ->
       row_desc fmt row1 ; bar_sep fmt () ; row_desc fmt row2
   | Row_inter (row1, row2) ->
       fprintf fmt "%a@ & [@[<hv1>@,%a@,@]]" row_desc row1 row_desc row2
   | Row_diff (row1, row2) ->
       fprintf fmt "%a@ - [@[<hv1>@,%a@,@]]" row_desc row1 row_desc row2
+
+and row_spec fmt spec =
+  let first = ref true in
+  let bar_sep fmt () = if !first then first := false else bar_sep fmt () in
+  List.iter spec.row_ctors ~f:(fun (lid, _) ->
+      bar_sep fmt () ; Longident.pp fmt lid ) ;
+  List.iter spec.row_typs ~f:(fun typ -> bar_sep fmt () ; type_expr fmt typ)
 
 let field_decl fmt decl =
   fprintf fmt "%s:@ @[<hv>%a@]" decl.fld_ident.txt type_expr decl.fld_type

--- a/meja/src/typet.ml
+++ b/meja/src/typet.ml
@@ -128,6 +128,8 @@ module Type = struct
         let typ1, env = import typ1 env in
         let typ2, env = import typ2 env in
         (mk (Tarrow (typ1, typ2, explicit, label)) env, env)
+    | Trow _ ->
+        assert false
 end
 
 module TypeDecl = struct

--- a/meja/src/typet.mli
+++ b/meja/src/typet.mli
@@ -4,6 +4,7 @@ type error =
   | Wrong_number_implicit_args of Longident.t * int * int
   | Expected_type_var of Parsetypes.type_expr
   | Constraints_not_satisfied of Parsetypes.type_expr * Parsetypes.type_decl
+  | Unbound of string * Longident.t Location.loc
 
 module Type : sig
   val import :

--- a/meja/src/untype_ast.ml
+++ b/meja/src/untype_ast.ml
@@ -22,8 +22,24 @@ let rec type_desc ?loc = function
       Type.constr ?loc ~params ~implicits ident.txt
   | Tpoly (vars, var) ->
       Type.poly ?loc (List.map ~f:(type_expr ?loc) vars) (type_expr ?loc var)
+  | Trow row ->
+      Type.row ?loc (row_desc ?loc row)
 
 and type_expr ?loc typ = type_desc ?loc typ.type_desc
+
+and row_desc ?loc = function
+  | Row_empty ->
+      Parsetypes.Row_empty
+  | Row_ctor (lid, _) ->
+      Parsetypes.Row_ctor lid
+  | Row_var typ ->
+      Parsetypes.Row_var (type_expr ?loc typ)
+  | Row_union (row1, row2) ->
+      Parsetypes.Row_union (row_desc ?loc row1, row_desc ?loc row2)
+  | Row_inter (row1, row2) ->
+      Parsetypes.Row_inter (row_desc ?loc row1, row_desc ?loc row2)
+  | Row_diff (row1, row2) ->
+      Parsetypes.Row_diff (row_desc ?loc row1, row_desc ?loc row2)
 
 let field_decl ?loc fld =
   Type_decl.Field.mk ?loc fld.fld_ident.txt (type_expr ?loc fld.fld_type)

--- a/meja/tests/row-types.meja
+++ b/meja/tests/row-types.meja
@@ -1,0 +1,9 @@
+type t = ..;
+
+type t += A | B | C;
+
+type u = [A | B];
+
+type v('a) = [A | B | 'a];
+
+type w('a, 'b, 'c) = [[A | B | C] - ['a & 'b]];

--- a/meja/tests/row-types.ml
+++ b/meja/tests/row-types.ml
@@ -1,0 +1,12 @@
+module Impl = Snarky.Snark.Make (Snarky.Backends.Mnt4.Default)
+open Impl
+
+type t = ..
+
+type t += C | B | A
+
+type u = unit
+
+type 'a v = unit
+
+type ('a, 'b, 'c) w = unit


### PR DESCRIPTION
This PR adds row types to the parser and typechecker.

Currently, the row types cannot be instantiated, since they are incompatible with OCaml's row types. Instead, these will be a phantom type parameter (not exported to OCaml), which classifies which constructors of an open type (notably either `request` or `exn`) a value may represent, and allow other types to express relations between them in terms of these phantom types.

For example, request handlers will be of the type `(_, _, ['a]) Checked -> (_, _, [['a] - [Handled_request]]) Checked)`.