### PR TITLE
[Meja] Iterators

### DIFF
--- a/meja/src/envi.ml
+++ b/meja/src/envi.ml
@@ -963,12 +963,12 @@ module Type = struct
   let implicit_params _env typ =
     let rec implicit_params set typ =
       match typ.type_desc with
-    | Tvar (_, _, Implicit) ->
-        Set.add set typ
-    | Tpoly (_, typ) ->
-        implicit_params set typ
-    | _ ->
-        fold ~init:set typ ~f:implicit_params
+      | Tvar (_, _, Implicit) ->
+          Set.add set typ
+      | Tpoly (_, typ) ->
+          implicit_params set typ
+      | _ ->
+          fold ~init:set typ ~f:implicit_params
     in
     implicit_params (Set.empty (module Comparator)) typ
 

--- a/meja/src/type0.ml
+++ b/meja/src/type0.ml
@@ -1,3 +1,4 @@
+open Core_kernel
 open Ast_types
 
 type type_expr = {type_desc: type_desc; type_id: int}
@@ -85,3 +86,21 @@ let rec typ_debug_print fmt typ =
   | Ttuple typs ->
       print "(%a)" (print_list typ_debug_print) typs ) ;
   print ")"
+
+let fold ~init ~f typ =
+  match typ.type_desc with
+  | Tvar _ ->
+      init
+  | Ttuple typs ->
+      List.fold ~init ~f typs
+  | Tarrow (typ1, typ2, _, _) ->
+      let acc = f init typ1 in
+      f acc typ2
+  | Tctor variant ->
+      let acc = List.fold ~init ~f variant.var_params in
+      List.fold ~init:acc ~f variant.var_implicit_params
+  | Tpoly (typs, typ) ->
+      let acc = List.fold ~init ~f typs in
+      f acc typ
+
+let iter ~f = fold ~init:() ~f:(fun () -> f)


### PR DESCRIPTION
This PR
* adds `Type0.fold`/`iter`
* replaces some recursive functions with recursive calls to `Type0.fold`
  - this makes it easier to add and tweak the representation of types, since these functions touch a smaller surface of the `type_desc` type

This will have the largest impact in #258, where the co-recursor for rows could be completely replaced with a single one for fold for these functions.