### PR TITLE
Fix BG bugs

### DIFF
--- a/src/camlsnark_c/libsnark-caml/libsnark/zk_proof_systems/ppzksnark/r1cs_bg_ppzksnark/r1cs_bg_ppzksnark.tcc
+++ b/src/camlsnark_c/libsnark-caml/libsnark/zk_proof_systems/ppzksnark/r1cs_bg_ppzksnark/r1cs_bg_ppzksnark.tcc
@@ -309,7 +309,7 @@ r1cs_bg_ppzksnark_keypair<ppT> r1cs_bg_ppzksnark_generator(const r1cs_bg_ppzksna
     libff::leave_block("Generating G1 MSM window table");
 
     libff::enter_block("Generating G2 MSM window table");
-    const libff::G2<ppT> G2_gen = libff::G2<ppT>::random_element();
+    const libff::G2<ppT> G2_gen = libff::G2<ppT>::one();
     const size_t g2_scalar_count = non_zero_Bt;
     const size_t g2_scalar_size = libff::Fr<ppT>::size_in_bits();
     size_t g2_window_size = libff::get_exp_window_size<libff::G2<ppT> >(g2_scalar_count);
@@ -559,11 +559,12 @@ bool r1cs_bg_ppzksnark_online_verifier_weak_IC(const r1cs_bg_ppzksnark_processed
     const libff::G2_precomp<ppT> proof_g_B_precomp = ppT::precompute_G2(proof.g_B);
     const libff::G1_precomp<ppT> proof_g_C_precomp = ppT::precompute_G1(proof.g_C);
     const libff::G1_precomp<ppT> acc_precomp = ppT::precompute_G1(acc);
+    const libff::G2_precomp<ppT> proof_delta_prime_precomp = ppT::precompute_G2(proof.delta_prime);
 
     const libff::Fqk<ppT> QAP1 = ppT::miller_loop(proof_g_A_precomp,  proof_g_B_precomp);
     const libff::Fqk<ppT> QAP2 = ppT::double_miller_loop(
         acc_precomp, pvk.vk_generator_g2_precomp,
-        proof_g_C_precomp, pvk.vk_delta_g2_precomp);
+        proof_g_C_precomp, proof_delta_prime_precomp);
     const libff::GT<ppT> QAP = ppT::final_exponentiation(QAP1 * QAP2.unitary_inverse());
 
     const bool groth16_test = QAP == pvk.vk_alpha_g1_beta_g2;
@@ -578,7 +579,7 @@ bool r1cs_bg_ppzksnark_online_verifier_weak_IC(const r1cs_bg_ppzksnark_processed
 
     bool bg_test = ppT::final_exponentiation(
         ppT::double_miller_loop(
-          ppT::precompute_G1(proof.y_s), ppT::precompute_G2(proof.delta_prime),
+          ppT::precompute_G1(proof.y_s), proof_delta_prime_precomp,
           ppT::precompute_G1(-proof.z), pvk.vk_delta_g2_precomp))
       == libff::Fqk<ppT>::one();
 
@@ -670,10 +671,11 @@ bool r1cs_bg_ppzksnark_affine_verifier_weak_IC(const r1cs_bg_ppzksnark_verificat
     const libff::affine_ate_G2_precomp<ppT> proof_g_B_precomp = ppT::affine_ate_precompute_G2(proof.g_B);
     const libff::affine_ate_G1_precomp<ppT> proof_g_C_precomp = ppT::affine_ate_precompute_G1(proof.g_C);
     const libff::affine_ate_G1_precomp<ppT> acc_precomp = ppT::affine_ate_precompute_G1(acc);
+    const libff::affine_ate_G2_precomp<ppT> proof_delta_prime_precomp = ppT::affine_ate_precompute_G2(proof.delta_prime);
 
     const libff::Fqk<ppT> QAP_miller = ppT::affine_ate_e_times_e_over_e_miller_loop(
         acc_precomp, pvk_vk_generator_g2_precomp,
-        proof_g_C_precomp, pvk_vk_delta_g2_precomp,
+        proof_g_C_precomp, proof_delta_prime_precomp,
         proof_g_A_precomp,  proof_g_B_precomp);
     const libff::GT<ppT> QAP = ppT::final_exponentiation(QAP_miller.unitary_inverse());
 
@@ -689,7 +691,7 @@ bool r1cs_bg_ppzksnark_affine_verifier_weak_IC(const r1cs_bg_ppzksnark_verificat
 
     bool bg_test = ppT::final_exponentiation(
         ppT::affine_ate_e_over_e_miller_loop(
-          ppT::affine_ate_precompute_G1(proof.y_s), ppT::affine_ate_precompute_G2(proof.delta_prime),
+          ppT::affine_ate_precompute_G1(proof.y_s), proof_delta_prime_precomp,
           ppT::affine_ate_precompute_G1(proof.z), pvk_vk_delta_g2_precomp))
       == libff::Fqk<ppT>::one();
 

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -2022,13 +2022,13 @@ let make (type field)
 
 let%test_module "snark0-test" =
   ( module struct
-    include Make (Backends.Mnt4.Default)
-
     let bin_io_id m = Fn.compose (Binable.of_string m) (Binable.to_string m)
 
     let swap b (x, y) = if b then (y, x) else (x, y)
 
-    let%test_unit "key serialization" =
+    module Run (Backend : Backend_intf.S) = struct
+      include Make (Backend)
+
       let main x =
         let%bind y = exists Field.typ ~compute:(As_prover.return Field.zero) in
         let rec go b acc i =
@@ -2043,11 +2043,46 @@ let%test_module "snark0-test" =
         let%bind _ = go false x 19 in
         let%bind _ = go true y 20 in
         return ()
-      in
-      let kp = generate_keypair ~exposing:[Field.typ] main in
-      let vk = Keypair.vk kp |> bin_io_id (module Verification_key) in
-      let pk = Keypair.pk kp |> bin_io_id (module Proving_key) in
-      let input = Field.one in
-      let proof = prove pk [Field.typ] () main input in
-      assert (verify proof vk [Field.typ] input)
+
+      let kp = generate_keypair ~exposing:[Field.typ] main
+
+      let%test_unit "proving" =
+        let input = Field.one in
+        let proof = prove (Keypair.pk kp) [Field.typ] () main input in
+        assert (verify proof (Keypair.vk kp) [Field.typ] input)
+
+      let%test_unit "key serialization" =
+        let vk = Keypair.vk kp |> bin_io_id (module Verification_key) in
+        let pk = Keypair.pk kp |> bin_io_id (module Proving_key) in
+        let input = Field.one in
+        let proof = prove pk [Field.typ] () main input in
+        assert (verify proof vk [Field.typ] input)
+    end
+
+    module M0 = Run (Backends.Mnt4.Default)
+
+    module M1 = Run (struct
+      module Full = Backends.Mnt4
+      module Field = Full.Field
+      module Bigint = Full.Bigint
+      module Var = Full.Var
+      module R1CS_constraint = Full.R1CS_constraint
+
+      module R1CS_constraint_system = struct
+        include Full.R1CS_constraint_system
+
+        let finalize = swap_AB_if_beneficial
+      end
+
+      module Linear_combination = Full.Linear_combination
+
+      let field_size = Full.field_size
+
+      include Libsnark.Make_bowe_gabizon
+                (Backends.Mnt4)
+                (struct
+                  let hash ?message:_ ~a:_ ~b:_ ~c:_ ~delta_prime:_ =
+                    Backends.Mnt4.G1.one
+                end)
+    end)
   end )


### PR DESCRIPTION
This PR fixes two bugs in the implementation of the BG SNARK. It adds a test confirming that the BG SNARK does work.

See the top of [page 7 here](https://eprint.iacr.org/2018/187.pdf) for the spec for the verifier which this implements.