### PR TITLE
Remove typo in pattern variable printing

### DIFF
--- a/meja/src/pprint.ml
+++ b/meja/src/pprint.ml
@@ -100,7 +100,7 @@ let rec pattern_desc fmt = function
   | PAny ->
       fprintf fmt "_"
   | PVariable str ->
-      fprintf fmt "'%s" str.txt
+      fprintf fmt "%s" str.txt
   | PConstraint (p, typ) ->
       fprintf fmt "%a@ : @[<hv2>%a@]" pattern_bracket p type_expr typ
   | PTuple pats ->


### PR DESCRIPTION
This makes pattern variables print properly, e.g. `let {foo= bar} = x;` instead of `let {foo= 'bar} = x;`.