### PR TITLE
[Meja] Fix expression printing

### DIFF
--- a/meja/src/ast_types.ml
+++ b/meja/src/ast_types.ml
@@ -5,7 +5,7 @@ let pp_name ppf name =
   if
     (Char.compare c 'a' >= 0 && Char.compare c 'z' <= 0)
     || (Char.compare c 'A' >= 0 && Char.compare c 'z' <= 0)
-    || Char.equal c '_'
+    || Char.equal c '_' || String.equal name "()"
   then Format.pp_print_string ppf name
   else Format.fprintf ppf "(%s)" name
 

--- a/meja/src/pprint.ml
+++ b/meja/src/pprint.ml
@@ -124,10 +124,10 @@ let rec pattern_desc fmt = function
 
 and pattern_desc_bracket fmt pat =
   match pat with
-  | PConstraint _ | POr _ ->
-      fprintf fmt "(@[<hv1>@,%a@,@])" pattern_desc pat
-  | _ ->
+  | PAny | PVariable _ | PTuple _ | PInt _ | PRecord _ | PCtor _ ->
       pattern_desc fmt pat
+  | _ ->
+      fprintf fmt "(@[<hv1>@,%a@,@])" pattern_desc pat
 
 and pattern fmt pat = pattern_desc fmt pat.pat_desc
 
@@ -214,12 +214,19 @@ let rec expression_desc fmt = function
 
 and expression_desc_bracket fmt exp =
   match exp with
-  | Seq _ | Fun _ | Newtype _ | Let _ | Match _ ->
-      fprintf fmt "(@[<hv1>@,%a@,@])" expression_desc exp
   | Unifiable {expression= Some e; _} ->
       expression_bracket fmt e
-  | _ ->
+  | Apply _
+  | Variable _
+  | Int _
+  | Constraint _
+  | Tuple _
+  | Field _
+  | Record _
+  | Ctor _ ->
       expression_desc fmt exp
+  | _ ->
+      fprintf fmt "(@[<hv1>@,%a@,@])" expression_desc exp
 
 and expression fmt exp = expression_desc fmt exp.exp_desc
 

--- a/meja/src/pprint.ml
+++ b/meja/src/pprint.ml
@@ -100,11 +100,11 @@ let rec pattern_desc fmt = function
   | PAny ->
       fprintf fmt "_"
   | PVariable str ->
-      fprintf fmt "'%s" str.txt
+      fprintf fmt "%s" str.txt
   | PConstraint (p, typ) ->
       fprintf fmt "%a@ : @[<hv2>%a@]" pattern_bracket p type_expr typ
   | PTuple pats ->
-      fprintf fmt "(@[<hv1>@;%a@;@])"
+      fprintf fmt "(@[<hv1>@,%a@,@])"
         (pp_print_list ~pp_sep:comma_sep pattern)
         pats
   | POr (p1, p2) ->
@@ -117,13 +117,15 @@ let rec pattern_desc fmt = function
         fields
   | PCtor (path, None) ->
       Longident.pp fmt path.txt
+  | PCtor (path, Some ({pat_desc= PTuple _; _} as arg)) ->
+      fprintf fmt "%a@ %a" Longident.pp path.txt pattern arg
   | PCtor (path, Some arg) ->
-      fprintf fmt "%a%a" Longident.pp path.txt pattern arg
+      fprintf fmt "%a@ (@[<hv1>@,%a@,@])" Longident.pp path.txt pattern arg
 
 and pattern_desc_bracket fmt pat =
   match pat with
   | PConstraint _ | POr _ ->
-      fprintf fmt "(@[<hv1>@;%a@;@])" pattern_desc pat
+      fprintf fmt "(@[<hv1>@,%a@,@])" pattern_desc pat
   | _ ->
       pattern_desc fmt pat
 
@@ -132,23 +134,24 @@ and pattern fmt pat = pattern_desc fmt pat.pat_desc
 and pattern_bracket fmt pat = pattern_desc_bracket fmt pat.pat_desc
 
 and pattern_field fmt (path, p) =
-  fprintf fmt "@[<hv2>%a =@;@[<hv>%a@]@]" Longident.pp path.txt pattern p
+  fprintf fmt "@[<hv2>%a =@ @[<hv>%a@]@]" Longident.pp path.txt pattern p
 
 let arg_label fmt = function
   | Asttypes.Nolabel ->
       ()
   | Labelled a ->
-      fprintf fmt "%s=@;" a
+      fprintf fmt "%s=@," a
   | Optional a ->
-      fprintf fmt "?%s=@;" a
+      fprintf fmt "?%s=@," a
 
 let rec expression_desc fmt = function
   | Apply
       (e, [(Asttypes.Nolabel, {exp_desc= Variable {txt= Lident "()"; _}; _})])
     ->
-      fprintf fmt "@[<hv2>@[<h2>%a@]@;()@]" expression_bracket e
+      fprintf fmt "@[<hv2>@[<hv2>%a@]@,()@]" expression_bracket e
   | Apply (e, args) ->
-      fprintf fmt "@[<hv2>@[<h2>%a@]@;@[<hv2>(@;%a@;)@]@]" expression_bracket e
+      fprintf fmt "@[<hv2>@[<hv2>%a@]@,(@[<hv1>@,%a@,@])@]" expression_bracket
+        e
         (pp_print_list ~pp_sep:comma_sep expression_args)
         args
   | Variable lid ->
@@ -180,29 +183,30 @@ let rec expression_desc fmt = function
   | Constraint (e, typ) ->
       fprintf fmt "@[<hv2>%a :@ %a@]" expression_bracket e type_expr typ
   | Tuple es ->
-      fprintf fmt "(@[<hv1>%a@;@])"
+      fprintf fmt "(@[<hv1>@,%a@,@])"
         (pp_print_list ~pp_sep:comma_sep expression)
         es
   | Match (e, cases) ->
-      fprintf fmt "@[<hv2>switch (%a) {@;@[<h2>%a@]@;}@]" expression e
-        (pp_print_list ~pp_sep:pp_print_newline (fun fmt (p, e) ->
-             fprintf fmt "| @[<hv2>%a@] =>@ @[<hv2>%a@]" pattern p expression e
-         ))
+      fprintf fmt "@[<hv2>@[<h>switch@ (@[<hv1>@,%a@,@])@] {@ %a@ }@]"
+        expression e
+        (pp_print_list ~pp_sep:pp_print_space (fun fmt (p, e) ->
+             fprintf fmt "@[<hv>| @[<hv2>%a@] =>@;<1 4>@[<hv2>%a@]@]" pattern p
+               expression e ))
         cases
   | Field (e, lid) ->
-      fprintf fmt "@[<hv2>%a@;@].%a" expression_bracket e Longident.pp lid.txt
+      fprintf fmt "@[<hv2>%a@,@].%a" expression_bracket e Longident.pp lid.txt
   | Record (fields, None) ->
-      fprintf fmt "@[<hv2>{@;@[<hv2>%a@]@;}@]"
+      fprintf fmt "@[<hv2>{@,@[<hv2>%a@]@,}@]"
         (pp_print_list ~pp_sep:comma_sep expression_field)
         fields
   | Record (fields, Some default) ->
-      fprintf fmt "@[<hv2>{@;@[<hv2>...%a@;%a@]@;}@]" expression default
+      fprintf fmt "@[<hv2>{@,@[<hv2>...%a@,%a@]@,}@]" expression default
         (pp_print_list ~pp_sep:comma_sep expression_field)
         fields
   | Ctor (path, None) ->
       Longident.pp fmt path.txt
   | Ctor (path, Some args) ->
-      fprintf fmt "%a(@[<hv2>%a@;@])" Longident.pp path.txt expression args
+      fprintf fmt "%a(@[<hv2>%a@,@])" Longident.pp path.txt expression args
   | Unifiable {expression= Some e; _} ->
       expression fmt e
   | Unifiable {expression= None; name; _} ->
@@ -211,7 +215,7 @@ let rec expression_desc fmt = function
 and expression_desc_bracket fmt exp =
   match exp with
   | Seq _ | Fun _ | Newtype _ | Let _ | Match _ ->
-      fprintf fmt "(@[<hv1>@;%a@;@])" expression_desc exp
+      fprintf fmt "(@[<hv1>@,%a@,@])" expression_desc exp
   | Unifiable {expression= Some e; _} ->
       expression_bracket fmt e
   | _ ->

--- a/meja/src/pprint.ml
+++ b/meja/src/pprint.ml
@@ -181,7 +181,7 @@ let rec expression_desc fmt = function
       fprintf fmt "let@[<hv2>@ %a@] =@ @[<hv2>%a@];@;@]@ %a" pattern p
         expression e1 expression e2
   | Constraint (e, typ) ->
-      fprintf fmt "@[<hv2>%a :@ %a@]" expression_bracket e type_expr typ
+      fprintf fmt "(@[<hv1>%a :@ %a@])" expression e type_expr typ
   | Tuple es ->
       fprintf fmt "(@[<hv1>@,%a@,@])"
         (pp_print_list ~pp_sep:comma_sep expression)

--- a/meja/src/pprint.ml
+++ b/meja/src/pprint.ml
@@ -187,10 +187,10 @@ let rec expression_desc fmt = function
         (pp_print_list ~pp_sep:comma_sep expression)
         es
   | Match (e, cases) ->
-      fprintf fmt "@[<hv2>@[<h>switch@ (@[<hv1>@,%a@,@])@] {@ %a@ }@]"
+      fprintf fmt "@[<hv2>@[<h>switch@ (@[<hv1>@,%a@,@])@] {@;@[<hv>%a@]@;}@]"
         expression e
         (pp_print_list ~pp_sep:pp_print_space (fun fmt (p, e) ->
-             fprintf fmt "@[<hv>| @[<hv2>%a@] =>@;<1 4>@[<hv2>%a@]@]" pattern p
+             fprintf fmt "| @[<hv2>%a@] =>@;<1 4>@[<hv2>%a@]" pattern p
                expression e ))
         cases
   | Field (e, lid) ->

--- a/meja/src/pprint.ml
+++ b/meja/src/pprint.ml
@@ -134,7 +134,7 @@ and pattern fmt pat = pattern_desc fmt pat.pat_desc
 and pattern_bracket fmt pat = pattern_desc_bracket fmt pat.pat_desc
 
 and pattern_field fmt (path, p) =
-  fprintf fmt "@[<hv2>%a =@ @[<hv>%a@]@]" Longident.pp path.txt pattern p
+  fprintf fmt "@[<hv2>%a:@ @[<hv>%a@]@]" Longident.pp path.txt pattern p
 
 let arg_label fmt = function
   | Asttypes.Nolabel ->
@@ -229,7 +229,7 @@ and expression_args fmt (label, e) =
   fprintf fmt "%a%a" arg_label label expression e
 
 and expression_field fmt (label, e) =
-  fprintf fmt "%a=@ %a" Longident.pp label.txt expression e
+  fprintf fmt "%a:@ %a" Longident.pp label.txt expression e
 
 let rec signature_desc fmt = function
   | SValue (name, typ) ->


### PR DESCRIPTION
This PR
* stops the pretty-printer from wrapping `()` in parentheses (ie. `(())`)
* reworks expression printing to use mostly 'cut' hints, so that fewer spaces are inserted and fewer lines wrap
  - this is particularly noticeable in nested `switch` statements (like the generated code for request handlers), which ended up pretty unreadable with about 1 line per syntax tree node