### PR TITLE
Ensure that type variables don't get unified across distinct statements

### DIFF
--- a/meja/src/envi.ml
+++ b/meja/src/envi.ml
@@ -349,6 +349,13 @@ module Scope = struct
               raise (Error (loc, Not_a_functor))
         in
         Some (Immediate (f (find_module ~loc lid2 resolve_env scopes)))
+
+  let join_expr_scope (expr_scope : t) (scope : t) =
+    assert (expr_scope.kind = Expr) ;
+    let select_new ~key:_ _ new_value = new_value in
+    { scope with
+      names= Map.merge_skewed scope.names expr_scope.names ~combine:select_new
+    }
 end
 
 let empty_resolve_env : Scope.t resolve_env =
@@ -513,6 +520,9 @@ let find_of_lident ~kind ~get_name (lid : lid) env =
         Option.bind m ~f:(get_name name)
     | _ ->
         None )
+
+let join_expr_scope env expr_scope =
+  map_current_scope ~f:(Scope.join_expr_scope expr_scope) env
 
 let raw_find_type_declaration (lid : lid) env =
   match

--- a/meja/src/typechecker.ml
+++ b/meja/src/typechecker.ml
@@ -1030,7 +1030,12 @@ let rec check_statement env stmt =
   let loc = stmt.stmt_loc in
   match stmt.stmt_desc with
   | Value (p, e) ->
+      let env = Envi.open_expr_scope env in
       let p, e, env = check_binding ~toplevel:true env p e in
+      let scope, env = Envi.pop_expr_scope env in
+      (* Uplift the names from the expression scope, discarding the scope and
+         its associated type variables etc. *)
+      let env = Envi.join_expr_scope env scope in
       (env, {stmt with stmt_desc= Value (p, e)})
   | Instance (name, e) ->
       let p =

--- a/meja/tests/type_variable_scoping.meja
+++ b/meja/tests/type_variable_scoping.meja
@@ -9,11 +9,15 @@ let g : 'a -> 'b = fun (x : bool) => {
 module X = {
   type t('a) = A('a) | B(int) | C(bool) : t(bool);
 
-  let a : t(int) = A(15);
+  let a : t('int) = A(15);
 
-  let a1 : t(unit) = A(());
+  let a1 : t('unit) = A(());
 
-  let b : t(bool) = B(30);
+  let b : t('bool) = B(30);
 
-  let c : t(bool) = C(true);
+  let c : t('bool) = C(true);
+
+  let f : 'int -> 'unit -> 'bool = fun (a : 'a, b : 'a) => {
+    a;
+  };
 };

--- a/meja/tests/type_variable_scoping.meja
+++ b/meja/tests/type_variable_scoping.meja
@@ -1,0 +1,19 @@
+let f : 'a -> 'b = fun (x : int) => {
+  x;
+};
+
+let g : 'a -> 'b = fun (x : bool) => {
+  x;
+};
+
+module X = {
+  type t('a) = A('a) | B(int) | C(bool) : t(bool);
+
+  let a : t(int) = A(15);
+
+  let a1 : t(unit) = A(());
+
+  let b : t(bool) = B(30);
+
+  let c : t(bool) = C(true);
+};

--- a/meja/tests/type_variable_scoping.ml
+++ b/meja/tests/type_variable_scoping.ml
@@ -1,0 +1,18 @@
+module Impl = Snarky.Snark.Make (Snarky.Backends.Mnt4.Default)
+open Impl
+
+let (f : 'a -> 'b) = fun (x : int) -> x
+
+let (g : 'a -> 'b) = fun (x : bool) -> x
+
+module X = struct
+  type 'a t = A of 'a | B of int | C : bool -> bool t
+
+  let (a : int t) = A 15
+
+  let (a1 : unit t) = A ()
+
+  let (b : bool t) = B 30
+
+  let (c : bool t) = C true
+end

--- a/meja/tests/type_variable_scoping.ml
+++ b/meja/tests/type_variable_scoping.ml
@@ -8,11 +8,13 @@ let (g : 'a -> 'b) = fun (x : bool) -> x
 module X = struct
   type 'a t = A of 'a | B of int | C : bool -> bool t
 
-  let (a : int t) = A 15
+  let (a : 'int t) = A 15
 
-  let (a1 : unit t) = A ()
+  let (a1 : 'unit t) = A ()
 
-  let (b : bool t) = B 30
+  let (b : 'bool t) = B 30
 
-  let (c : bool t) = C true
+  let (c : 'bool t) = C true
+
+  let (f : 'int -> 'unit -> 'bool) = fun (a : 'a) (b : 'a) -> a
 end


### PR DESCRIPTION
This PR fixes an oversight where type variables would get unified across toplevel definitions.

Before this PR, the test added would have generated a unification error between `bool` and `int` on the type variables `'a`, `'b`.