### PR TITLE
[Meja] Unify implicits with free variables in the common case

### DIFF
--- a/meja/meja.ml
+++ b/meja/meja.ml
@@ -202,7 +202,10 @@ let main =
       List.fold ~init:env cmi_scopes ~f:(fun env scope ->
           Envi.open_namespace_scope scope env )
     in
-    let meji_files = List.rev !meji_files in
+    let meji_files =
+      "meji/field.meji" :: "meji/boolean.meji" :: "meji/typ.meji"
+      :: List.rev !meji_files
+    in
     let env =
       List.fold ~init:env meji_files ~f:(fun env file ->
           let parse_ast =

--- a/meja/meji/boolean.meji
+++ b/meja/meji/boolean.meji
@@ -1,0 +1,1 @@
+type var;

--- a/meja/meji/field.meji
+++ b/meja/meji/field.meji
@@ -1,0 +1,4 @@
+module Var :
+{
+  type t;
+}

--- a/meja/meji/typ.meji
+++ b/meja/meji/typ.meji
@@ -1,0 +1,254 @@
+module Store :
+{
+   type t('a);
+   
+   let (>>=) : t('a) -> ('a -> t('b)) -> t('b);
+   
+   let (>>|) : t('a) -> ('a -> 'b) -> t('b);
+   
+   module Monad_infix :
+   {
+      let (>>=) : t('a) -> ('a -> t('b)) -> t('b);
+      
+      let (>>|) : t('a) -> ('a -> 'b) -> t('b);
+      
+      };
+   
+   let bind : t('a) -> ('a -> t('b)) -> t('b);
+   
+   let return : 'a -> t('a);
+   
+   let map : t('a) -> ('a -> 'b) -> t('b);
+   
+   let join : t(t('a)) -> t('a);
+   
+   let ignore_m : t('a) -> t(unit);
+   
+   let all : list(t('a)) -> t(list('a));
+   
+   let all_unit : list(t(unit)) -> t(unit);
+   
+   let all_ignore : list(t(unit)) -> t(unit);
+   
+   module Let_syntax :
+   {
+      let (>>=) : t('a) -> ('a -> t('b)) -> t('b);
+      
+      let (>>|) : t('a) -> ('a -> 'b) -> t('b);
+      
+      let return : 'a -> t('a);
+      
+      let bind : t('a) -> ('a -> t('b)) -> t('b);
+      
+      let map : t('a) -> ('a -> 'b) -> t('b);
+      
+      let both : t('a) -> t('b) -> t(('a, 'b));
+      
+      module Open_on_rhs : {
+                              };
+      
+      module Let_syntax :
+      {
+         let return : 'a -> t('a);
+         
+         let bind : t('a) -> ('a -> t('b)) -> t('b);
+         
+         let map : t('a) -> ('a -> 'b) -> t('b);
+         
+         let both : t('a) -> t('b) -> t(('a, 'b));
+         
+         module Open_on_rhs : {
+                                 };
+         
+         };
+      
+      };
+   
+   let store : field -> t(Field.Var.t);
+   
+   };
+
+module Alloc :
+{
+   type t('a);
+   
+   let (>>=) : t('a) -> ('a -> t('b)) -> t('b);
+   
+   let (>>|) : t('a) -> ('a -> 'b) -> t('b);
+   
+   module Monad_infix :
+   {
+      let (>>=) : t('a) -> ('a -> t('b)) -> t('b);
+      
+      let (>>|) : t('a) -> ('a -> 'b) -> t('b);
+      
+      };
+   
+   let bind : t('a) -> ('a -> t('b)) -> t('b);
+   
+   let return : 'a -> t('a);
+   
+   let map : t('a) -> ('a -> 'b) -> t('b);
+   
+   let join : t(t('a)) -> t('a);
+   
+   let ignore_m : t('a) -> t(unit);
+   
+   let all : list(t('a)) -> t(list('a));
+   
+   let all_unit : list(t(unit)) -> t(unit);
+   
+   let all_ignore : list(t(unit)) -> t(unit);
+   
+   module Let_syntax :
+   {
+      let (>>=) : t('a) -> ('a -> t('b)) -> t('b);
+      
+      let (>>|) : t('a) -> ('a -> 'b) -> t('b);
+      
+      let return : 'a -> t('a);
+      
+      let bind : t('a) -> ('a -> t('b)) -> t('b);
+      
+      let map : t('a) -> ('a -> 'b) -> t('b);
+      
+      let both : t('a) -> t('b) -> t(('a, 'b));
+      
+      module Open_on_rhs : {
+                              };
+      
+      module Let_syntax :
+      {
+         let return : 'a -> t('a);
+         
+         let bind : t('a) -> ('a -> t('b)) -> t('b);
+         
+         let map : t('a) -> ('a -> 'b) -> t('b);
+         
+         let both : t('a) -> t('b) -> t(('a, 'b));
+         
+         module Open_on_rhs : {
+                                 };
+         
+         };
+      
+      };
+   
+   let alloc : t(Field.Var.t);
+   
+   };
+
+module Read :
+{
+   type t('a);
+   
+   let (>>=) : t('a) -> ('a -> t('b)) -> t('b);
+   
+   let (>>|) : t('a) -> ('a -> 'b) -> t('b);
+   
+   module Monad_infix :
+   {
+      let (>>=) : t('a) -> ('a -> t('b)) -> t('b);
+      
+      let (>>|) : t('a) -> ('a -> 'b) -> t('b);
+      
+      };
+   
+   let bind : t('a) -> ('a -> t('b)) -> t('b);
+   
+   let return : 'a -> t('a);
+   
+   let map : t('a) -> ('a -> 'b) -> t('b);
+   
+   let join : t(t('a)) -> t('a);
+   
+   let ignore_m : t('a) -> t(unit);
+   
+   let all : list(t('a)) -> t(list('a));
+   
+   let all_unit : list(t(unit)) -> t(unit);
+   
+   let all_ignore : list(t(unit)) -> t(unit);
+   
+   module Let_syntax :
+   {
+      let (>>=) : t('a) -> ('a -> t('b)) -> t('b);
+      
+      let (>>|) : t('a) -> ('a -> 'b) -> t('b);
+      
+      let return : 'a -> t('a);
+      
+      let bind : t('a) -> ('a -> t('b)) -> t('b);
+      
+      let map : t('a) -> ('a -> 'b) -> t('b);
+      
+      let both : t('a) -> t('b) -> t(('a, 'b));
+      
+      module Open_on_rhs : {
+                              };
+      
+      module Let_syntax :
+      {
+         let return : 'a -> t('a);
+         
+         let bind : t('a) -> ('a -> t('b)) -> t('b);
+         
+         let map : t('a) -> ('a -> 'b) -> t('b);
+         
+         let both : t('a) -> t('b) -> t(('a, 'b));
+         
+         module Open_on_rhs : {
+                                 };
+         
+         };
+      
+      };
+   
+   let read : Field.Var.t -> t(field);
+   
+   };
+
+type t('var, 'value) = {
+  store: 'value -> Store.t('var),
+  read: 'var -> Read.t('value),
+  alloc: Alloc.t('var),
+  check: 'var -> unit
+};
+
+let store : {t('var, 'value)} -> 'value -> Store.t('var);
+
+let read : {t('var, 'value)} -> 'var -> Read.t('value);
+
+let alloc : {t('var, _)} -> Alloc.t('var);
+
+let check : {t('var, _)} -> 'var -> unit;
+
+let unit : t(unit, unit);
+
+let field : t(Field.Var.t, field);
+
+let tuple2 :
+t('var1, 'value1) ->
+t('var2, 'value2) -> t(('var1, 'var2), ('value1, 'value2));
+
+let (*) :
+t('var1, 'value1) ->
+t('var2, 'value2) -> t(('var1, 'var2), ('value1, 'value2));
+
+let tuple3 :
+t('var1, 'value1) ->
+t('var2, 'value2) ->
+t('var3, 'value3) ->
+t(('var1, 'var2, 'var3), ('value1, 'value2, 'value3));
+
+let list : int -> t('var, 'value) -> t(list('var), list('value));
+
+let array : int -> t('var, 'value) -> t(array('var), array('value));
+
+let transport :
+t('var, 'value1) ->
+('value2 -> 'value1) -> ('value1 -> 'value2) -> t('var, 'value2);
+
+let transport_var :
+t('var1, 'value) ->
+('var2 -> 'var1) -> ('var1 -> 'var2) -> t('var2, 'value);

--- a/meja/src/parser_impl.mly
+++ b/meja/src/parser_impl.mly
@@ -320,6 +320,8 @@ simpl_expr:
 expr:
   | x = simpl_expr
     { x }
+  | LPAREN x = simpl_expr COLON typ = type_expr RPAREN
+    { mkexp ~pos:$loc (Constraint (x, typ)) }
   | FUN LPAREN RPAREN EQUALGT LBRACE body = block RBRACE
     { let unit_pat =
         mkpat ~pos:$loc (PCtor (mkloc (Lident "()") ~pos:$loc, None))

--- a/meja/src/type0.ml
+++ b/meja/src/type0.ml
@@ -104,6 +104,58 @@ let fold ~init ~f typ =
 
 let iter ~f = fold ~init:() ~f:(fun () -> f)
 
+let explicitness_equal e1 e2 =
+  match (e1, e2) with
+  | Explicit, Explicit | Implicit, Implicit ->
+      true
+  | _, _ ->
+      false
+
+let arg_label_equal lbl1 lbl2 =
+  match (lbl1, lbl2) with
+  | Asttypes.Nolabel, Asttypes.Nolabel ->
+      true
+  | Labelled str1, Labelled str2 | Optional str1, Optional str2 ->
+      String.equal str1 str2
+  | _, _ ->
+      false
+
+let rec equal_at_depth ~depth typ1 typ2 =
+  if Int.equal typ1.type_id typ2.type_id then true
+  else
+    match (typ1.type_desc, typ2.type_desc) with
+    | Tvar _, _ when typ1.type_depth > depth ->
+        true
+    | _, Tvar _ when typ2.type_depth > depth ->
+        true
+    | Ttuple typs1, Ttuple typs2 -> (
+      match List.for_all2 typs1 typs2 ~f:(equal_at_depth ~depth) with
+      | Ok b ->
+          b
+      | Unequal_lengths ->
+          false )
+    | ( Tarrow (typ1a, typ1b, explicitness1, label1)
+      , Tarrow (typ2a, typ2b, explicitness2, label2) ) ->
+        explicitness_equal explicitness1 explicitness2
+        && arg_label_equal label1 label2
+        && equal_at_depth ~depth typ1a typ2a
+        && equal_at_depth ~depth typ1b typ2b
+    | ( Tctor ({var_decl= decl1; _} as variant1)
+      , Tctor ({var_decl= decl2; _} as variant2) )
+      when Int.equal decl1.tdec_id decl2.tdec_id ->
+        List.for_all2_exn ~f:(equal_at_depth ~depth) variant1.var_params
+          variant2.var_params
+        && List.for_all2_exn ~f:(equal_at_depth ~depth)
+             variant1.var_implicit_params variant2.var_implicit_params
+    | Tpoly (typs1, typ1), Tpoly (typs2, typ2) -> (
+      match List.for_all2 typs1 typs2 ~f:(equal_at_depth ~depth) with
+      | Ok true ->
+          equal_at_depth ~depth typ1 typ2
+      | _ ->
+          false )
+    | _, _ ->
+        false
+
 (* TODO: integrate with a backtrack mechanism for unification errors. *)
 let set_depth depth typ = typ.type_depth <- depth
 

--- a/meja/src/type0.ml
+++ b/meja/src/type0.ml
@@ -107,8 +107,7 @@ let iter ~f = fold ~init:() ~f:(fun () -> f)
 (* TODO: integrate with a backtrack mechanism for unification errors. *)
 let set_depth depth typ = typ.type_depth <- depth
 
-let update_depth depth typ =
-  if typ.type_depth > depth then set_depth depth typ
+let update_depth depth typ = if typ.type_depth > depth then set_depth depth typ
 
 let unify_depths typ1 typ2 =
   iter ~f:(update_depth typ1.type_depth) typ2 ;

--- a/meja/src/type0.ml
+++ b/meja/src/type0.ml
@@ -1,7 +1,8 @@
 open Core_kernel
 open Ast_types
 
-type type_expr = {mutable type_desc: type_desc; type_id: int; type_depth: int}
+type type_expr =
+  {mutable type_desc: type_desc; type_id: int; mutable type_depth: int}
 
 and type_desc =
   (* A type variable. Name is None when not yet chosen. *)
@@ -102,3 +103,13 @@ let fold ~init ~f typ =
       f acc typ
 
 let iter ~f = fold ~init:() ~f:(fun () -> f)
+
+(* TODO: integrate with a backtrack mechanism for unification errors. *)
+let set_depth depth typ = typ.type_depth <- depth
+
+let update_depth depth typ =
+  if typ.type_depth > depth then set_depth depth typ
+
+let unify_depths typ1 typ2 =
+  iter ~f:(update_depth typ1.type_depth) typ2 ;
+  iter ~f:(update_depth typ2.type_depth) typ1

--- a/meja/src/typechecker.ml
+++ b/meja/src/typechecker.ml
@@ -563,9 +563,10 @@ let rec get_expression env expected exp =
       ({exp_loc= loc; exp_type= typ; exp_desc= Apply (f, es)}, env)
   | Variable name ->
       let typ = Envi.find_name ~loc name env in
-      check_type ~loc env expected typ ;
       let e = {exp_loc= loc; exp_type= typ; exp_desc= Variable name} in
-      (Envi.Type.generate_implicits e env, env)
+      let e = Envi.Type.generate_implicits e env in
+      check_type ~loc env expected e.exp_type ;
+      (e, env)
   | Int i ->
       let typ = Initial_env.Type.int in
       check_type ~loc env expected typ ;

--- a/meja/src/typechecker.ml
+++ b/meja/src/typechecker.ml
@@ -62,6 +62,7 @@ let rec check_type_aux ~loc typ ctyp env =
     | None ->
         None
   in
+  Type0.unify_depths typ ctyp ;
   match (typ.type_desc, ctyp.type_desc) with
   | _, _ when Int.equal typ.type_id ctyp.type_id ->
       ()
@@ -77,13 +78,10 @@ let rec check_type_aux ~loc typ ctyp env =
             (without_instance ctyp env ~f:(fun ctyp -> check_type_aux typ ctyp))
             (fun () ->
               (* Add the outermost (in terms of lexical scope) of the variables as
-                 the instance for the other. If they are at the same level, prefer
-                 the lowest ID to ensure strict ordering and thus no cycles. *)
-              if
-                ctyp.type_depth < typ.type_depth
-                || Int.equal ctyp.type_depth typ.type_depth
-                   && ctyp.type_id < typ.type_id
-              then Envi.Type.add_instance typ ctyp env
+                 the instance for the other. We do this by chosing the type of
+                 lowest ID, to ensure strict ordering and thus no cycles. *)
+              if ctyp.type_id < typ.type_id then
+                Envi.Type.add_instance typ ctyp env
               else Envi.Type.add_instance ctyp typ env ) )
   | Tvar _, _ ->
       bind_none
@@ -590,6 +588,7 @@ let rec get_expression env expected exp =
       let p, env = check_pattern ~add:add_name env p_typ p in
       let body, env = get_expression env body_typ body in
       let env = Envi.close_expr_scope env in
+      Envi.Type.update_depths env typ ;
       ( {exp_loc= loc; exp_type= typ; exp_desc= Fun (label, p, body, explicit)}
       , env )
   | Newtype (name, body) ->
@@ -616,6 +615,7 @@ let rec get_expression env expected exp =
       (* Substitute the self-reference for a type variable. *)
       typ.type_desc <- Tvar (Some name, Explicit) ;
       let env = Envi.close_expr_scope env in
+      Envi.Type.update_depths env body.exp_type ;
       ( {exp_loc= loc; exp_type= body.exp_type; exp_desc= Newtype (name, body)}
       , env )
   | Seq (e1, e2) ->
@@ -627,6 +627,7 @@ let rec get_expression env expected exp =
       let p, e1, env = check_binding env p e1 in
       let e2, env = get_expression env expected e2 in
       let env = Envi.close_expr_scope env in
+      Envi.Type.update_depths env e2.exp_type ;
       ({exp_loc= loc; exp_type= e2.exp_type; exp_desc= Let (p, e1, e2)}, env)
   | Constraint (e, typ') ->
       let typ, env = Typet.Type.import typ' env in
@@ -662,6 +663,7 @@ let rec get_expression env expected exp =
             let env = Envi.close_expr_scope env in
             (env, (p, e)) )
       in
+      Envi.Type.update_depths env expected ;
       ({exp_loc= loc; exp_type= expected; exp_desc= Match (e, cases)}, env)
   | Field (e, field) ->
       let field_info =
@@ -853,6 +855,7 @@ and check_binding ?(toplevel = false) (env : Envi.t) p e : 's =
   let env = Envi.open_expr_scope env in
   let e, env = get_expression env typ e in
   let env = Envi.close_expr_scope env in
+  Envi.Type.update_depths env e.exp_type ;
   let exp_type = Envi.Type.flatten e.exp_type env in
   let e = {e with exp_type} in
   let typ_vars = free_type_vars ~depth:env.Envi.depth exp_type in
@@ -912,11 +915,13 @@ let rec check_signature_item env item =
       let env = Envi.open_expr_scope env in
       let typ, env = Typet.Type.import ~must_find:false typ env in
       let env = Envi.close_expr_scope env in
+      Envi.Type.update_depths env typ ;
       add_polymorphised name typ env
   | SInstance (name, typ) ->
       let env = Envi.open_expr_scope env in
       let typ, env = Typet.Type.import ~must_find:false typ env in
       let env = Envi.close_expr_scope env in
+      Envi.Type.update_depths env typ ;
       let env = add_polymorphised name typ env in
       Envi.add_implicit_instance name.txt typ env
   | STypeDecl decl ->

--- a/meja/src/typechecker.ml
+++ b/meja/src/typechecker.ml
@@ -914,13 +914,13 @@ let rec check_signature_item env item =
   match item.sig_desc with
   | SValue (name, typ) ->
       let env = Envi.open_expr_scope env in
-      let typ, env = Typet.Type.import ~must_find:false typ env in
+      let typ, env = Typet.Type.import typ env in
       let env = Envi.close_expr_scope env in
       Envi.Type.update_depths env typ ;
       add_polymorphised name typ env
   | SInstance (name, typ) ->
       let env = Envi.open_expr_scope env in
-      let typ, env = Typet.Type.import ~must_find:false typ env in
+      let typ, env = Typet.Type.import typ env in
       let env = Envi.close_expr_scope env in
       Envi.Type.update_depths env typ ;
       let env = add_polymorphised name typ env in

--- a/meja/tests/typ-explicit.meja
+++ b/meja/tests/typ-explicit.meja
@@ -1,0 +1,26 @@
+let typ =
+  ({ Typ.store: fun ((a, b)) => {
+      Typ.Store.bind(Typ.store(b), fun (b) => {
+        Typ.Store.bind(Typ.store(a), fun (a) => {
+          Typ.Store.return((a, b));
+        });
+      });
+    }
+  , Typ.read: fun ((a, b)) => {
+      Typ.Read.bind(Typ.read(b), fun (b) => {
+        Typ.Read.bind(Typ.read(a), fun (a) => {
+          Typ.Read.return((a, b));
+        });
+      });
+    }
+  , Typ.alloc:
+      Typ.Alloc.bind(Typ.alloc, fun (b) => {
+        Typ.Alloc.bind(Typ.alloc, fun (a) => {
+          Typ.Alloc.return((a, b));
+        });
+      })
+  , Typ.check: fun ((a, b)) => {
+      Typ.check(a);
+      Typ.check(b);
+    }
+  } : Typ.t(('var_a, 'var_b), ('value_a, 'value_b)));

--- a/meja/tests/typ-explicit.ml
+++ b/meja/tests/typ-explicit.ml
@@ -1,0 +1,29 @@
+module Impl = Snarky.Snark.Make (Snarky.Backends.Mnt4.Default)
+open Impl
+
+let typ __implicit8__ __implicit5__ __implicit1__ __implicit7__ __implicit6__
+    __implicit2__ : ('var_a * 'var_b, 'value_a * 'value_b) Typ.t =
+  { Typ.store=
+      (fun (a, b) ->
+        Typ.Store.bind
+          ((Typ.store __implicit1__) b)
+          (fun b ->
+            Typ.Store.bind
+              ((Typ.store __implicit2__) a)
+              (fun a -> Typ.Store.return (a, b)) ) )
+  ; Typ.read=
+      (fun (a, b) ->
+        Typ.Read.bind
+          ((Typ.read __implicit1__) b)
+          (fun b ->
+            Typ.Read.bind
+              ((Typ.read __implicit2__) a)
+              (fun a -> Typ.Read.return (a, b)) ) )
+  ; Typ.alloc=
+      Typ.Alloc.bind (Typ.alloc __implicit5__) (fun b ->
+          Typ.Alloc.bind (Typ.alloc __implicit6__) (fun a ->
+              Typ.Alloc.return (a, b) ) )
+  ; Typ.check=
+      (fun (a, b) ->
+        (Typ.check __implicit7__) a ;
+        (Typ.check __implicit8__) b ) }

--- a/meja/tests/typ-explicit.ml
+++ b/meja/tests/typ-explicit.ml
@@ -1,8 +1,8 @@
 module Impl = Snarky.Snark.Make (Snarky.Backends.Mnt4.Default)
 open Impl
 
-let typ __implicit8__ __implicit5__ __implicit1__ __implicit7__ __implicit6__
-    __implicit2__ : ('var_a * 'var_b, 'value_a * 'value_b) Typ.t =
+let typ __implicit1__ __implicit2__ :
+    ('var_a * 'var_b, 'value_a * 'value_b) Typ.t =
   { Typ.store=
       (fun (a, b) ->
         Typ.Store.bind
@@ -20,10 +20,10 @@ let typ __implicit8__ __implicit5__ __implicit1__ __implicit7__ __implicit6__
               ((Typ.read __implicit2__) a)
               (fun a -> Typ.Read.return (a, b)) ) )
   ; Typ.alloc=
-      Typ.Alloc.bind (Typ.alloc __implicit5__) (fun b ->
-          Typ.Alloc.bind (Typ.alloc __implicit6__) (fun a ->
+      Typ.Alloc.bind (Typ.alloc __implicit1__) (fun b ->
+          Typ.Alloc.bind (Typ.alloc __implicit2__) (fun a ->
               Typ.Alloc.return (a, b) ) )
   ; Typ.check=
       (fun (a, b) ->
-        (Typ.check __implicit7__) a ;
-        (Typ.check __implicit8__) b ) }
+        (Typ.check __implicit2__) a ;
+        (Typ.check __implicit1__) b ) }


### PR DESCRIPTION
This PR
* fixes importing types from signatures
  - specifically, this change ensures that type variables with the same name are considered to be the same type variable (a2b552b)
* adds some interface files containing the declarations that `Typ.t` deriving relies on
  - ae9471e and 4b948cd
  - these will be lazily loaded at some point, using roughly the same strategy as for `.cmi` files
* fixes a bug where the expected type was being compared with variable names before the implicit arguments have been stripped from them
  - e4b1483 
* adds parsing support for type annotations in expressions
  - 59c0989
  - this was already used internally in the `fun (...) : ... => {...}` syntax and for `Typ.t` generation over in #255, this just exposes it properly
  - the syntax explicitly requires enclosing `(` and `)` (otherwise we can't distinguish a record `{name: value}` from a block `{name: value;}` early enough to make parsing work). In practise, this seems to match the syntax of reason, presumably for the same reason.
* fully implement type depths
  - unification lowers the depth of types so that they properly represent the outermost scope in which they are available
  - flattening a type no longer changes the depth to that of the current scope
* uses type depths to identify 'weak' type variables (ie. variables that have no way of deciding a concrete instance) within implicit arguments and unifies them with other implicit variables if possible
  - this only happens if the implicit arguments don't share any weak type variables, otherwise we would have to solve potentially arbitrarily complicated constraint systems
  - we currently don't unify implicit variables with weak type variables with eachother, only with non-weak implicit variables
* adds an example of an explicit `Typ.t('a, 'b)` instance, which compiles to the expected OCaml code.

This fixes the problem with #255 where we were generating too many implicit variables, and also gives us the right implementation of levels to make `switch` statements work with GADTs fully.