### PR TITLE
[Meja] Always unfold type aliases when unifying

### DIFF
--- a/meja/src/envi.ml
+++ b/meja/src/envi.ml
@@ -1108,6 +1108,9 @@ module TypeDecl = struct
 
   let unfold_alias ~loc typ env =
     match find_of_type ~loc typ env with
+    | Some ({tdec_desc= TUnfold typ'; _}, _, _) when not (phys_equal typ typ')
+      ->
+        Some typ'
     | Some ({tdec_desc= TAlias alias_typ; _}, bound_vars, env) ->
         Some (Type.copy ~loc alias_typ bound_vars env)
     | _ ->
@@ -1115,6 +1118,9 @@ module TypeDecl = struct
 
   let rec find_unaliased_of_type ~loc typ env =
     match find_of_type ~loc typ env with
+    | Some ({tdec_desc= TUnfold typ'; _}, _, _) when not (phys_equal typ typ')
+      ->
+        find_unaliased_of_type ~loc typ' env
     | Some ({tdec_desc= TAlias alias_typ; _}, bound_vars, env) ->
         let typ = Type.copy ~loc alias_typ bound_vars env in
         find_unaliased_of_type ~loc typ env

--- a/meja/tests/type-alias-unification.meja
+++ b/meja/tests/type-alias-unification.meja
@@ -1,0 +1,49 @@
+module Alias_alias = {
+  type u('a, 'b) = 'a -> 'a;
+
+  type v('a, 'b) = u('a, 'a);
+
+  let f = fun (x : u(int, bool)) : u(int, int) => { x; };
+
+  let g = fun (x : v(int, int)) : v(int, bool) => { x; };
+
+  let h = fun (x : v(int, bool)) : u(int, int) => { x; };
+
+  let i = fun (x : u(bool, bool)) : v(bool, unit) => { x; };
+};
+
+module Alias_opaque = {
+  type u('a, 'b);
+
+  type v('a, 'b) = u('a, 'a);
+
+  let f = fun (x : v(int, int)) : v(int, bool) => { x; };
+
+  let g = fun (x : v(int, bool)) : u(int, int) => { x; };
+
+  let h = fun (x : u(bool, bool)) : v(bool, unit) => { x; };
+};
+
+module Alias_record = {
+  type u('a, 'b) = {a : 'a, b : 'b};
+
+  type v('a, 'b) = u('a, 'a);
+
+  let f = fun (x : v(int, int)) : v(int, bool) => { x; };
+
+  let g = fun (x : v(int, bool)) : u(int, int) => { x; };
+
+  let h = fun (x : u(bool, bool)) : v(bool, unit) => { x; };
+};
+
+module Alias_variant = {
+  type u('a, 'b) = A | B | C('a) | D('b);
+
+  type v('a, 'b) = u('a, 'a);
+
+  let f = fun (x : v(int, int)) : v(int, bool) => { x; };
+
+  let g = fun (x : v(int, bool)) : u(int, int) => { x; };
+
+  let h = fun (x : u(bool, bool)) : v(bool, unit) => { x; };
+};

--- a/meja/tests/type-alias-unification.ml
+++ b/meja/tests/type-alias-unification.ml
@@ -1,0 +1,75 @@
+module Impl = Snarky.Snark.Make (Snarky.Backends.Mnt4.Default)
+open Impl
+
+module Alias_alias = struct
+  type ('a, 'b) u = 'a -> 'a
+
+  type ('a, 'b) v = ('a, 'a) u
+
+  let f (x : (int, bool) u) : (int, int) u = x
+
+  let g (x : (int, int) v) : (int, bool) v = x
+
+  let h (x : (int, bool) v) : (int, int) u = x
+
+  let i (x : (bool, bool) u) : (bool, unit) v = x
+end
+
+module Alias_opaque = struct
+  type ('a, 'b) u
+
+  type ('a, 'b) v = ('a, 'a) u
+
+  let f (x : (int, int) v) : (int, bool) v = x
+
+  let g (x : (int, bool) v) : (int, int) u = x
+
+  let h (x : (bool, bool) u) : (bool, unit) v = x
+end
+
+module Alias_record = struct
+  include struct
+    type ('a, 'b) u = {a: 'a; b: 'b}
+
+    let u_typ : (_, (_, _) u) Typ.t =
+      { Typ.store=
+          (fun {a; b; _} ->
+            Typ.Store.bind (Typ.store b) (fun b ->
+                Typ.Store.bind (Typ.store a) (fun a -> Typ.Store.return {a; b})
+            ) )
+      ; Typ.read=
+          (fun {a; b; _} ->
+            Typ.Read.bind (Snarky.read b) (fun b ->
+                Typ.Read.bind (Snarky.read a) (fun a -> Typ.Read.return {a; b})
+            ) )
+      ; Typ.alloc=
+          (fun {a; b; _} ->
+            Typ.Alloc.bind Typ.alloc (fun b ->
+                Typ.Alloc.bind Typ.alloc (fun a -> Typ.Alloc.return {a; b}) )
+            )
+      ; Typ.check=
+          (fun {a; b; _} ->
+            (fun f x -> f x) (Typ.check b) (fun b ->
+                (fun f x -> f x) (Typ.check a) (fun a -> ()) ) ) }
+  end
+
+  type ('a, 'b) v = ('a, 'a) u
+
+  let f (x : (int, int) v) : (int, bool) v = x
+
+  let g (x : (int, bool) v) : (int, int) u = x
+
+  let h (x : (bool, bool) u) : (bool, unit) v = x
+end
+
+module Alias_variant = struct
+  type ('a, 'b) u = A | B | C of 'a | D of 'b
+
+  type ('a, 'b) v = ('a, 'a) u
+
+  let f (x : (int, int) v) : (int, bool) v = x
+
+  let g (x : (int, bool) v) : (int, int) u = x
+
+  let h (x : (bool, bool) u) : (bool, unit) v = x
+end


### PR DESCRIPTION
This PR changes the unification algorithm so that alias types with phantom parameters will still unify, and adds a test.

This matches OCaml's behaviour.