### PR TITLE
[Meja] Restricted row types

### DIFF
--- a/meja/src/ast_build.ml
+++ b/meja/src/ast_build.ml
@@ -63,6 +63,8 @@ module Type = struct
     mk ?loc (Tarrow (typ1, typ2, explicit, label))
 
   let poly ?loc vars var = mk ?loc (Tpoly (vars, var))
+
+  let row ?loc row = mk ?loc (Trow row)
 end
 
 module Type_decl = struct

--- a/meja/src/ast_types.ml
+++ b/meja/src/ast_types.ml
@@ -9,8 +9,19 @@ let pp_name ppf name =
   then Format.pp_print_string ppf name
   else Format.fprintf ppf "(%s)" name
 
+let pp_map ?(pp_sep = fun _ _ -> ()) pp ppf map =
+  let first = ref true in
+  let pp_sep ppf () = if !first then first := false else pp_sep ppf () in
+  Map.iteri map ~f:(fun ~key ~data -> pp_sep ppf () ; pp ppf key data)
+
 module Longident = struct
-  include Longident
+  type t = Longident.t =
+    | Lident of string
+    | Ldot of t * string
+    | Lapply of t * t
+  [@@deriving sexp]
+
+  include (Longident : module type of Longident with type t := t)
 
   let rec compare lid1 lid2 =
     let nonzero_or x f = if Int.equal x 0 then f () else x in

--- a/meja/src/lexer_impl.mll
+++ b/meja/src/lexer_impl.mll
@@ -94,6 +94,8 @@ rule token = parse
 
   | "!" symbolchar * as op { PREFIXOP op }
   | ['~' '?'] symbolchar + as op { PREFIXOP op }
+  | '<' { LESS }
+  | '>' { GREATER }
   | ['=' '<' '>' '|' '&' '$'] symbolchar * as op { INFIXOP0 op }
   | ['@' '^'] symbolchar * as op { INFIXOP1 op }
   | ['+' '-'] symbolchar * as op { INFIXOP2 op }

--- a/meja/src/parser_impl.mly
+++ b/meja/src/parser_impl.mly
@@ -525,13 +525,15 @@ pat_or_bare_tuple:
   | ps = tuple(pat)
     { mkpat ~pos:$loc (PTuple (List.rev ps)) }
 
-type_var:
+%inline type_var:
   | QUOT x = as_loc(lident)
     { mktyp ~pos:$loc (Tvar (Some x, Explicit)) }
 
 simple_type_expr:
   | UNDERSCORE
     { mktyp ~pos:$loc (Tvar (None, Explicit)) }
+  | t = type_var
+    { t }
   | t = decl_type_expr
     { t }
   | LPAREN x = type_expr RPAREN
@@ -557,11 +559,11 @@ type_expr:
   | label = type_arrow_label LBRACE x = simple_type_expr RBRACE DASHGT y = type_expr
     { mktyp ~pos:$loc (Tarrow (x, y, Implicit, label)) }
 
-row_ctor_field:
+%inline row_ctor_field:
   | ctor = as_loc(longident(ctor_ident, UIDENT))
     { Row_ctor ctor }
 
-row_field:
+%inline row_field:
   | row = row_ctor_field
     { row }
   | typ = type_var
@@ -593,7 +595,7 @@ row_inner_expr_no_diff:
       ; row_diff= None
       ; row_loc= Loc.of_pos $loc } }
   | LESS option(BAR) rows_lower = list(row_field, BAR)
-    GREATER rows = list(row_field, BAR)
+    GREATER rows = list(row_ctor_field, BAR)
     { { row_upper= List.rev rows
       ; row_closed= Asttypes.Closed
       ; row_lower= Some (List.rev rows_lower)

--- a/meja/src/parser_impl.mly
+++ b/meja/src/parser_impl.mly
@@ -618,10 +618,10 @@ row_expr:
   | LBRACKET row = row_inner_expr_no_diff RBRACKET
     { row }
   | LBRACKET row = row_inner_expr_no_diff
-    MINUS rows = list(row_field, BAR) RBRACKET
+    MINUS rows = list(row_ctor_field, BAR) RBRACKET
     { {row with row_diff= Some (List.rev rows) } }
-  | LBRACKET field = row_field MINUS rows = list(row_field, BAR) RBRACKET
-    { { row_upper= [field]
+  | LBRACKET typ = type_var MINUS rows = list(row_ctor_field, BAR) RBRACKET
+    { { row_upper= [Row_var typ]
       ; row_closed= Asttypes.Closed
       ; row_lower= None
       ; row_diff= Some (List.rev rows)

--- a/meja/src/to_ocaml.ml
+++ b/meja/src/to_ocaml.ml
@@ -20,6 +20,9 @@ let rec of_type_desc ?loc typ =
       Typ.constr ?loc name (List.map ~f:of_type_expr (params @ implicits))
   | Ttuple typs ->
       Typ.tuple ?loc (List.map ~f:of_type_expr typs)
+  | Trow _ ->
+      (* Don't emit a type for this row. *)
+      Typ.constr ?loc Ast_build.(Loc.mk ?loc (Lid.of_name "unit")) []
 
 and of_type_expr typ = of_type_desc ~loc:typ.type_loc typ.type_desc
 


### PR DESCRIPTION
This PR implements a restricted version of row types.

In particular
* row types are bounded, so that we can make clear judgements about the constraints on row type variables
  - the lower row constraint is always static, the higher (or the row itself) may contain row type variables
* row union and difference are implemented, but the subtractive part of a row difference must be a static row
  - this keeps constraints between rows simple: every row can be expressed as some static part and some additional row variables, so that we can split the row into distinct parts during unification
* in order to do unification, we need intersection constraints, but we can't expose these to the toplevel typesystem, otherwise we can't split row variables any more

This should be powerful enough to express all the constraints that we need, and for the implicit variable code to discover and fill the correct holes.

The typechecker part of this isn't finished yet, spinning this out without the implementation so I can move focus to the stdlib proper.