### PR TITLE
Add a stateless version of the imperative interface

### DIFF
--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -2008,12 +2008,16 @@ module Run = struct
     module Number = Number.Run.Make (Basic)
     module Enumerable = Enumerable.Run.Make (Basic)
   end
+
+  module Make_stateless (Backend : Backend_intf.S) = Make(Backend)(Unit)
 end
 
 type ('prover_state, 'field) m =
   (module Snark_intf.Run
      with type field = 'field
       and type prover_state = 'prover_state)
+
+type 'field m' = (unit, 'field) m
 
 let make (type field prover_state)
     (module Backend : Backend_intf.S with type Field.t = field) :

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -2009,7 +2009,7 @@ module Run = struct
     module Enumerable = Enumerable.Run.Make (Basic)
   end
 
-  module Make_stateless (Backend : Backend_intf.S) = Make(Backend)(Unit)
+  module Make_stateless (Backend : Backend_intf.S) = Make (Backend) (Unit)
 end
 
 type ('prover_state, 'field) m =

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -2008,20 +2008,22 @@ module Run = struct
     module Number = Number.Run.Make (Basic)
     module Enumerable = Enumerable.Run.Make (Basic)
   end
-
-  module Make_stateless (Backend : Backend_intf.S) = Make (Backend) (Unit)
 end
 
-type ('prover_state, 'field) m =
+type 'field m = (module Snark_intf.Run with type field = 'field)
+
+type ('prover_state, 'field) m' =
   (module Snark_intf.Run
      with type field = 'field
       and type prover_state = 'prover_state)
 
-type 'field m' = (unit, 'field) m
+let make (type field)
+    (module Backend : Backend_intf.S with type Field.t = field) : field m =
+  (module Run.Make (Backend) (Unit))
 
-let make (type field prover_state)
+let make' (type field prover_state)
     (module Backend : Backend_intf.S with type Field.t = field) :
-    (prover_state, field) m =
+    (prover_state, field) m' =
   ( module Run.Make
              (Backend)
              (struct

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -2030,6 +2030,10 @@ let make' (type field prover_state)
                type t = prover_state
              end) )
 
+let ignore_state (type prover_state field)
+    ((module M) : (prover_state, field) m') : field m =
+  (module M)
+
 let%test_module "snark0-test" =
   ( module struct
     let bin_io_id m = Fn.compose (Binable.of_string m) (Binable.to_string m)

--- a/src/snark0.mli
+++ b/src/snark0.mli
@@ -44,28 +44,17 @@ module Run : sig
      and type Proving_key.t = Backend.Proving_key.t
      and type Proof.t = Backend.Proof.t
      and type Proof.message = Backend.Proof.message
-
-  module Make_stateless (Backend : Backend_intf.S) :
-    Snark_intf.Run
-    with type field = Backend.Field.t
-     and type prover_state = unit
-     and type Bigint.t = Backend.Bigint.R.t
-     and type R1CS_constraint_system.t = Backend.R1CS_constraint_system.t
-     and type Var.t = Backend.Var.t
-     and type Field.Constant.Vector.t = Backend.Field.Vector.t
-     and type Verification_key.t = Backend.Verification_key.t
-     and type Proving_key.t = Backend.Proving_key.t
-     and type Proof.t = Backend.Proof.t
-     and type Proof.message = Backend.Proof.message
 end
 
-type ('prover_state, 'field) m =
+type 'field m = (module Snark_intf.Run with type field = 'field)
+
+val make : (module Backend_intf.S with type Field.t = 'field) -> 'field m
+
+type ('prover_state, 'field) m' =
   (module Snark_intf.Run
      with type field = 'field
       and type prover_state = 'prover_state)
 
-type 'field m' = (unit, 'field) m
-
-val make :
+val make' :
      (module Backend_intf.S with type Field.t = 'field)
-  -> ('prover_state, 'field) m
+  -> ('prover_state, 'field) m'

--- a/src/snark0.mli
+++ b/src/snark0.mli
@@ -45,8 +45,7 @@ module Run : sig
      and type Proof.t = Backend.Proof.t
      and type Proof.message = Backend.Proof.message
 
-  module Make_stateless
-      (Backend : Backend_intf.S) :
+  module Make_stateless (Backend : Backend_intf.S) :
     Snark_intf.Run
     with type field = Backend.Field.t
      and type prover_state = unit

--- a/src/snark0.mli
+++ b/src/snark0.mli
@@ -44,12 +44,28 @@ module Run : sig
      and type Proving_key.t = Backend.Proving_key.t
      and type Proof.t = Backend.Proof.t
      and type Proof.message = Backend.Proof.message
+
+  module Make_stateless
+      (Backend : Backend_intf.S) :
+    Snark_intf.Run
+    with type field = Backend.Field.t
+     and type prover_state = unit
+     and type Bigint.t = Backend.Bigint.R.t
+     and type R1CS_constraint_system.t = Backend.R1CS_constraint_system.t
+     and type Var.t = Backend.Var.t
+     and type Field.Constant.Vector.t = Backend.Field.Vector.t
+     and type Verification_key.t = Backend.Verification_key.t
+     and type Proving_key.t = Backend.Proving_key.t
+     and type Proof.t = Backend.Proof.t
+     and type Proof.message = Backend.Proof.message
 end
 
 type ('prover_state, 'field) m =
   (module Snark_intf.Run
      with type field = 'field
       and type prover_state = 'prover_state)
+
+type 'field m' = (unit, 'field) m
 
 val make :
      (module Backend_intf.S with type Field.t = 'field)

--- a/src/snark0.mli
+++ b/src/snark0.mli
@@ -58,3 +58,5 @@ type ('prover_state, 'field) m' =
 val make' :
      (module Backend_intf.S with type Field.t = 'field)
   -> ('prover_state, 'field) m'
+
+val ignore_state : ('prover_state, 'field) m' -> 'field m


### PR DESCRIPTION
This PR adds stateless versions of the imperative interface functor and the type `m` of module expressions from this functor.