### PR TITLE
[Meja] Resolve type names before OCaml printing

### DIFF
--- a/meja/meja.ml
+++ b/meja/meja.ml
@@ -162,8 +162,8 @@ let main =
             let m, env =
               let loc = Location.none in
               let mkloc s = Location.mkloc s loc in
-              let env = Envi.open_module env in
-              let env = Envi.open_module env in
+              let env = Envi.open_absolute_module None env in
+              let env = Envi.open_absolute_module None env in
               let m =
                 try
                   Envi.find_module ~loc
@@ -211,10 +211,13 @@ let main =
           let parse_ast =
             read_file (Parser_impl.interface Lexer_impl.token) file
           in
-          let env = Envi.open_module env in
+          let module_name = Loader.modname_of_filename file in
+          let env =
+            Envi.open_absolute_module (Some (Longident.Lident module_name)) env
+          in
           let env = Typechecker.check_signature env parse_ast in
           let m, env = Envi.pop_module ~loc:Location.none env in
-          let name = Location.(mkloc (Loader.modname_of_filename file) none) in
+          let name = Location.(mkloc module_name none) in
           Envi.add_module name m env )
     in
     let file =

--- a/meja/src/ast_types.ml
+++ b/meja/src/ast_types.ml
@@ -65,6 +65,21 @@ module Longident = struct
         Ldot (add_outer_module name lid, name2)
     | Lapply _ ->
         failwith "Unhandled Lapply in add_outer_module"
+
+  let rec join lid1 lid2 =
+    match lid2 with
+    | Lident name ->
+        Ldot (lid1, name)
+    | Ldot (lid2, name) ->
+        Ldot (join lid1 lid2, name)
+    | Lapply (lid2, lid_apply) ->
+        Lapply (join lid1 lid2, lid_apply)
+
+  let join_name lid name =
+    match lid with Some lid -> Ldot (lid, name) | None -> Lident name
+
+  let join_path lid1 lid2 =
+    match lid1 with Some lid1 -> join lid1 lid2 | None -> lid2
 end
 
 type str = string Location.loc

--- a/meja/src/loader.ml
+++ b/meja/src/loader.ml
@@ -1,11 +1,12 @@
 open Core_kernel
 open Cmt_format
 
-let load ~loc ~name:_ resolve_env filename =
+let load ~loc ~name resolve_env filename =
   (*Format.(fprintf err_formatter "Loading %s from %s...@." name filename) ;*)
   let cmi_info = read_cmi filename in
   let signature = Of_ocaml.to_signature cmi_info.cmi_sign in
   let env = {Initial_env.env with resolve_env} in
+  let env = Envi.open_absolute_module (Some (Longident.Lident name)) env in
   let env = Typechecker.check_signature env signature in
   (*Format.(fprintf err_formatter "Loaded@.") ;*)
   let m, _ = Envi.pop_module ~loc env in

--- a/meja/src/typechecker.ml
+++ b/meja/src/typechecker.ml
@@ -302,7 +302,7 @@ let get_field (field : lid) env =
       ( ({tdec_desc= TRecord field_decls; tdec_ident; tdec_params; _} as decl)
       , i ) ->
       let vars, bound_vars, _ =
-        Envi.Type.refresh_vars ~loc tdec_params (Map.empty (module Int)) env
+        Envi.Type.refresh_vars ~loc tdec_params Int.Map.empty env
       in
       let name =
         Location.mkloc
@@ -396,7 +396,7 @@ let get_ctor (name : lid) env =
           (Set.union (Envi.Type.type_vars typ) (Envi.Type.type_vars args_typ))
       in
       let _, bound_vars, _ =
-        Envi.Type.refresh_vars ~loc bound_vars (Map.empty (module Int)) env
+        Envi.Type.refresh_vars ~loc bound_vars Int.Map.empty env
       in
       let args_typ = Envi.Type.copy ~loc args_typ bound_vars env in
       let typ = Envi.Type.copy ~loc typ bound_vars env in
@@ -474,9 +474,7 @@ let rec check_pattern ~add env typ pat =
           | Some (({tdec_desc= TRecord field_decls; tdec_params; _} as decl), _)
             ->
               let vars, bound_vars, env =
-                Envi.Type.refresh_vars ~loc tdec_params
-                  (Map.empty (module Int))
-                  env
+                Envi.Type.refresh_vars ~loc tdec_params Int.Map.empty env
               in
               let ident =
                 Longident.(
@@ -689,9 +687,7 @@ let rec get_expression env expected exp =
           | Some (({tdec_desc= TRecord field_decls; tdec_params; _} as decl), i)
             ->
               let vars, bound_vars, env =
-                Envi.Type.refresh_vars ~loc tdec_params
-                  (Map.empty (module Int))
-                  env
+                Envi.Type.refresh_vars ~loc tdec_params Int.Map.empty env
               in
               let ident =
                 Location.mkloc (Longident.Ldot (path, decl.tdec_ident.txt)) loc
@@ -745,9 +741,7 @@ let rec get_expression env expected exp =
                 (({tdec_desc= TRecord field_decls; tdec_params; _} as decl), i)
               ->
                 let vars, bound_vars, env =
-                  Envi.Type.refresh_vars ~loc tdec_params
-                    (Map.empty (module Int))
-                    env
+                  Envi.Type.refresh_vars ~loc tdec_params Int.Map.empty env
                 in
                 let ident =
                   Longident.(
@@ -791,9 +785,7 @@ let rec get_expression env expected exp =
           | Some (({tdec_desc= TRecord field_decls; tdec_params; _} as decl), _)
             ->
               let vars, bound_vars, env =
-                Envi.Type.refresh_vars ~loc tdec_params
-                  (Map.empty (module Int))
-                  env
+                Envi.Type.refresh_vars ~loc tdec_params Int.Map.empty env
               in
               let ident =
                 Longident.(

--- a/meja/src/typechecker.ml
+++ b/meja/src/typechecker.ml
@@ -416,7 +416,10 @@ let rec check_pattern ~add env typ pat =
       let ctyp, env = Typet.Type.import constr_typ env in
       check_type ~loc env typ ctyp ;
       let p, env = check_pattern ~add env ctyp p in
-      let constr_typ = Untype_ast.type_expr ~loc:constr_typ.type_loc ctyp in
+      let constr_typ =
+        Untype_ast.type_expr ~loc:constr_typ.type_loc
+          (Envi.Type.normalise_constr_names env ctyp)
+      in
       ( {pat_loc= loc; pat_type= typ; pat_desc= PConstraint (p, constr_typ)}
       , env )
   | PTuple ps ->
@@ -646,7 +649,10 @@ let rec get_expression env expected exp =
       check_type ~loc env expected typ ;
       let e, env = get_expression env typ e in
       check_type ~loc env e.exp_type typ ;
-      let typ' = Untype_ast.type_expr ~loc:typ'.type_loc typ in
+      let typ' =
+        Untype_ast.type_expr ~loc:typ'.type_loc
+          (Envi.Type.normalise_constr_names env typ)
+      in
       ({exp_loc= loc; exp_type= typ; exp_desc= Constraint (e, typ')}, env)
   | Tuple es ->
       let typs = List.map es ~f:(fun _ -> Envi.Type.mkvar None env) in
@@ -906,7 +912,9 @@ and check_binding ?(toplevel = false) (env : Envi.t) p e : 's =
       in
       let env = Envi.add_name str ctyp env in
       let p' = {p' with pat_type= ctyp} in
-      let typ = Untype_ast.type_expr ~loc ctyp in
+      let typ =
+        Untype_ast.type_expr ~loc (Envi.Type.normalise_constr_names env ctyp)
+      in
       let p = {p with pat_desc= PConstraint (p', typ); pat_type= ctyp} in
       (p, e, env)
   | _, [] ->

--- a/meja/tests/resolve_type_names.meja
+++ b/meja/tests/resolve_type_names.meja
@@ -1,0 +1,9 @@
+module A = {
+  type t = int;
+};
+
+let x : A.t = 15;
+
+open A;
+
+let y : A.t = 20;

--- a/meja/tests/resolve_type_names.ml
+++ b/meja/tests/resolve_type_names.ml
@@ -1,0 +1,12 @@
+module Impl = Snarky.Snark.Make (Snarky.Backends.Mnt4.Default)
+open Impl
+
+module A = struct
+  type t = int
+end
+
+let (x : A.t) = 15
+
+open A
+
+let (y : t) = 20


### PR DESCRIPTION
This PR
* carries the current path to a module in the module
  - I am going to use this to identify multiple 'versions' of modules in the stdlib: one version for the checked stuff, and one version for the prover stuff
* fixes some bugs I uncovered about module hierarchies
* keeps a log of the most recent names for type constructors in the scope stack
  - I am going to use this to cast the names to the appropriate types in the OCaml code, so that e.g. under the hood the prover and checked `field` types are distinct (but named the same in Meja), and then they get disambiguated to the 'best recent name', which will be `Field.t`/`Field.Unchecked.t` as appropriate.
* adds a simple test to check that this is working as intended.