### PR TITLE
Update QUICK_REFERENCE.markdown

### DIFF
--- a/QUICK_REFERENCE.markdown
+++ b/QUICK_REFERENCE.markdown
@@ -8,9 +8,12 @@ run
 ```
 
 # Example compilation, key generation, proving flow
+
+```bash
 snarky_cli generate-keys snarky-examples/tutorial_simple_snark.zk --curve Bn128
-snarky_cli prove snarky-examples/tutorial_simple_snark.zk --curve Bn128 2 256
+snarky_cli prove snarky-examples/tutorial_simple_snark.zk 2 256
 snarky_cli verify snarky-examples/tutorial_simple_snark.zk 2 256 --proof tutorial_simple_snark_gen.zkp
+```
 
 # Tutorials
 Check out snarky-examples for a bunch of tutorial code.


### PR DESCRIPTION
`--curve` is not valid for the `prove` step