### PR TITLE
Stop stripping the R1CS from the proving key before converting to string

### DIFF
--- a/src/libsnark.ml
+++ b/src/libsnark.ml
@@ -1272,12 +1272,7 @@ module Make_proof_system_keys (M : Proof_system_inputs_intf) = struct
         (typ @-> returning M.R1CS_constraint_system.typ)
 
     let to_cpp_string_stub : t -> Cpp_string.t =
-      let stub =
-        foreign (func_name "to_string") (typ @-> returning Cpp_string.typ)
-      in
-      fun t ->
-        M.R1CS_constraint_system.clear (r1cs_constraint_system t) ;
-        stub t
+      foreign (func_name "to_string") (typ @-> returning Cpp_string.typ)
 
     let to_string : t -> string =
      fun t ->


### PR DESCRIPTION
This stops us from needing to regenerate the R1CS, which seems to mismatch with the key when we do so.