### PR TITLE
Evaluate input constraints when generating the r1cs in prove

### DIFF
--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -975,6 +975,21 @@ struct
             if R1CS_constraint_system.get_primary_input_size s = 0 then Some s
             else None
           in
+          let run =
+            if Option.is_none system then run
+            else
+              (* If we're regenerating the R1CS, we need to collect and
+                 evaluate the constraints for the inputs.
+              *)
+              let next_input = ref 1 in
+              let r = collect_input_constraints next_input t k in
+              let run_in_run x state =
+                let state, _x = Checked.run r state in
+                assert (Int.equal !next_input (Field.Vector.length primary)) ;
+                run x state
+              in
+              run_in_run
+          in
           let auxiliary =
             Checked.auxiliary_input ?system ~run ?handlers
               ~num_inputs:(Field.Vector.length primary)

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -985,7 +985,7 @@ struct
               let r = collect_input_constraints next_input t k in
               let run_in_run x state =
                 let state, _x = Checked.run r state in
-                assert (Int.equal !next_input (Field.Vector.length primary)) ;
+                assert (Int.equal !next_input (Field.Vector.length primary + 1)) ;
                 run x state
               in
               run_in_run


### PR DESCRIPTION
This PR evaluates the `check` part of each `Typ.t` when we are
* generating a proof using `prove` in the old (ie. non-`Proof_system`) API, and
* the proving key has a cleared R1CS, which we need to regenerate.

Previously, these would have been skipped entirely, which meant that the R1CS wouldn't have any constraints corresponding to the inputs. I think this was the culprit behind codaprotocol/coda#2559.

### Analysis:
This was overlooked because
* when we refactored `prove` etc. into a unified `run` function, it was then able to generate constraints for checked computations
* when the R1CS-stripping hack was added, the right constraint system was generated through `run` for the computations themselves, but **no constraints were added for the input's `Data_spec.t`**
* the R1CS-stripping only gets triggered when serialising a proving key to file
* all uses of key-serialisation (that I know of) use the new `Proof_system` API, **except the uses in Coda**
* all of the proofs generated in Coda take inputs with `Typ.t`s that have no constraints, except the wrap proof, where **there may be a constraint if the wrap field is smaller than the base field**
* the wrap field is larger than the base field for the `Mnt4`/`Mnt6` pair, **but not for the `Mnt4753`/`Mnt6753` pair**, so constraints were added only for medium curves
* these constraints on the input curve therefore did not get re-added to the proving key, and resulted in proofs built without these constraints, which &mdash; rightly &mdash; would not verify

Disclaimer: I am still running a final test (medium curves build with R1CS-stripping, ~40 mins on my machine) to confirm that this works, but I fully expect that it will. I will update this PR when it completes.