### PR TITLE
[Meja] Split out OCaml code

### DIFF
--- a/meja/dune
+++ b/meja/dune
@@ -1,6 +1,6 @@
 (executable
  (name meja)
- (libraries core_kernel snarky meja.lib)
+ (libraries core_kernel snarky meja.lib meja.ocaml)
  (preprocess (pps ppxlib.metaquot ppx_jane))
  (modules meja))
 

--- a/meja/meja.ml
+++ b/meja/meja.ml
@@ -1,5 +1,6 @@
 open Core_kernel
 open Meja_lib
+open Meja_ocaml
 
 let print_position outx lexbuf =
   let pos = lexbuf.Lexing.lex_curr_p in

--- a/meja/ocaml/dune
+++ b/meja/ocaml/dune
@@ -1,0 +1,5 @@
+(library
+ (name meja_ocaml)
+ (public_name meja.ocaml)
+ (libraries core_kernel meja.lib ocaml-compiler-libs.common)
+ (preprocess (pps ppxlib.metaquot)))

--- a/meja/ocaml/loader.ml
+++ b/meja/ocaml/loader.ml
@@ -1,5 +1,6 @@
 open Core_kernel
 open Cmt_format
+open Meja_lib
 
 let load ~loc ~name resolve_env filename =
   (*Format.(fprintf err_formatter "Loading %s from %s...@." name filename) ;*)

--- a/meja/ocaml/of_ocaml.ml
+++ b/meja/ocaml/of_ocaml.ml
@@ -1,7 +1,7 @@
 open Path
 open Longident
 open Core_kernel
-open Parsetypes
+open Meja_lib.Parsetypes
 open Types
 open Location
 
@@ -17,35 +17,35 @@ let rec to_type_desc ~loc desc =
   let to_type_expr = to_type_expr ~loc in
   match desc with
   | Tvar x | Tunivar x ->
-      Parsetypes.Ptyp_var (Option.map ~f:(fun x -> mkloc x loc) x, Explicit)
+      Ptyp_var (Option.map ~f:(fun x -> mkloc x loc) x, Explicit)
   | Tarrow (label, typ1, typ2, _) ->
-      Parsetypes.Ptyp_arrow
+      Ptyp_arrow
         (to_type_expr typ1, to_type_expr typ2, Explicit, label)
   | Ttuple typs ->
-      Parsetypes.Ptyp_tuple (List.map ~f:to_type_expr typs)
+      Ptyp_tuple (List.map ~f:to_type_expr typs)
   | Tconstr (path, params, _) ->
       let var_ident = mkloc (longident_of_path path) loc in
-      Parsetypes.Ptyp_ctor
+      Ptyp_ctor
         { var_ident
         ; var_params= List.map ~f:to_type_expr params
         ; var_implicit_params= [] }
   | Tlink typ | Tsubst typ ->
       (to_type_expr typ).type_desc
   | Tpoly (typ, typs) ->
-      Parsetypes.Ptyp_poly (List.map ~f:to_type_expr typs, to_type_expr typ)
+      Ptyp_poly (List.map ~f:to_type_expr typs, to_type_expr typ)
   | Tpackage (path, _bound_names, typs) ->
       (* We don't have packaged module types implemented here, but we can treat
          them as if they were [Tctor]s; there is no overlap between valid paths
          to packages and valid paths to type constructors. *)
       let var_ident = mkloc (longident_of_path path) loc in
-      Parsetypes.Ptyp_ctor
+      Ptyp_ctor
         { var_ident
         ; var_params= List.map ~f:to_type_expr typs
         ; var_implicit_params= [] }
   | Tobject _ | Tfield _ | Tnil | Tvariant _ ->
       (* This type isn't supported here. For now, just replace it with a
          variable, so we can still manipulate values including it. *)
-      Parsetypes.Ptyp_var (None, Explicit)
+      Ptyp_var (None, Explicit)
 
 and to_type_expr ~loc typ =
   {type_desc= to_type_desc ~loc typ.desc; type_id= -1; type_loc= loc}

--- a/meja/ocaml/of_ocaml.ml
+++ b/meja/ocaml/of_ocaml.ml
@@ -19,8 +19,7 @@ let rec to_type_desc ~loc desc =
   | Tvar x | Tunivar x ->
       Ptyp_var (Option.map ~f:(fun x -> mkloc x loc) x, Explicit)
   | Tarrow (label, typ1, typ2, _) ->
-      Ptyp_arrow
-        (to_type_expr typ1, to_type_expr typ2, Explicit, label)
+      Ptyp_arrow (to_type_expr typ1, to_type_expr typ2, Explicit, label)
   | Ttuple typs ->
       Ptyp_tuple (List.map ~f:to_type_expr typs)
   | Tconstr (path, params, _) ->

--- a/meja/ocaml/to_ocaml.ml
+++ b/meja/ocaml/to_ocaml.ml
@@ -1,8 +1,8 @@
 open Core_kernel
 open Asttypes
-open Ast_types
+open Meja_lib.Ast_types
 open Ast_helper
-open Parsetypes
+open Meja_lib.Parsetypes
 
 let rec of_type_desc ?loc typ =
   match typ with

--- a/meja/src/dune
+++ b/meja/src/dune
@@ -2,7 +2,7 @@
  (name meja_lib)
  (public_name meja.lib)
  (libraries core_kernel ocaml-compiler-libs.common)
- (preprocess (pps ppxlib.metaquot ppx_jane)))
+ (preprocess (pps ppx_jane)))
 
 (menhir
   (flags --explain --unused-tokens)


### PR DESCRIPTION
This PR separates the code that interfaces directly with the `ocaml-compiler-libs` library from the rest of the typechecker. Eventually, all of the OCaml codegen will be moved here, and the typechecker will just typecheck ASTs and the environment.

This also frees up a lot of module names for the typechecker, which will make naming things much less painful.