### PR TITLE
Add 4.08 support to snarky

### DIFF
--- a/bitstring_lib.opam
+++ b/bitstring_lib.opam
@@ -10,14 +10,14 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "core"
+  "core" {>= "v0.12" & < "v0.13" }
   "tuple_lib"
   "ppx_deriving"
   "ppx_jane"
   "bisect_ppx"
-  "jbuilder"                {build & >= "1.0+beta12"}
+  "dune"                {build & >= "1.6"}
 ]
-available: [ ocaml-version >= "4.04.1" ]
+available: [ ocaml-version >= "4.07.0" ]
 descr: "
 A helper library for bitstrings in snarky
 "

--- a/fold_lib.opam
+++ b/fold_lib.opam
@@ -10,13 +10,13 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "core"
+  "core" {>= "v0.12" & < "v0.13" }
   "ppx_deriving"
   "ppx_jane"
   "bisect_ppx"
-  "jbuilder"                {build & >= "1.0+beta12"}
+  "dune"                {build & >= "1.6"}
 ]
-available: [ ocaml-version >= "4.04.1" ]
+available: [ ocaml-version >= "4.07.0" ]
 descr: "
 A library for treating folds as a first-class data structure and a monad
 "

--- a/interval_union.opam
+++ b/interval_union.opam
@@ -10,13 +10,13 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "core_kernel"
+  "core_kernel" {>= "v0.12" & < "v0.13" }
   "ppx_deriving"
   "ppx_jane"
   "bisect_ppx"
-  "jbuilder"                {build & >= "1.0+beta12"}
+  "dune"                {build & >= "1.6"}
 ]
-available: [ ocaml-version >= "4.04.1" ]
+available: [ ocaml-version >= "4.07.0" ]
 descr: "
 A helper library for manipulating intervals -- pairs of integers -- in snarky
 "

--- a/meja.opam
+++ b/meja.opam
@@ -10,13 +10,13 @@ build: [
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "core_kernel"
+  "core_kernel" {>= "v0.12" & < "v0.13" }
   "ocaml-compiler-libs"
   "ppxlib"
   "ppx_jane"
-  "dune"                {build & >= "1.0+beta12"}
+  "dune"                {build & >= "1.6"}
 ]
-available: [ ocaml-version >= "4.04.1" ]
+available: [ ocaml-version >= "4.07.0" ]
 descr: "
 A Reason-ML style language with baked-in support for Snarky
 "

--- a/ppx/snarky_module.ml
+++ b/ppx/snarky_module.ml
@@ -24,7 +24,7 @@ let cmp_modinfo x y =
   | ModuleName x, ModuleName y
   | IdentName x, IdentName y
   | BaseModule x, BaseModule y ->
-      Pervasives.compare x.txt y.txt
+      compare x.txt y.txt
   | ModuleName _, _ ->
       -1
   | _, ModuleName _ ->

--- a/ppx/snarkydef.ml
+++ b/ppx/snarkydef.ml
@@ -7,13 +7,13 @@ let name = "snarkydef"
 
 let located_label_expr expr =
   let loc = expr.pexp_loc in
-  [%expr Pervasives.( ^ ) [%e expr] (Pervasives.( ^ ) ": " Pervasives.__LOC__)]
+  [%expr Stdlib.( ^ ) [%e expr] (Stdlib.( ^ ) ": " Stdlib.__LOC__)]
 
 let located_label_string ~loc str =
   [%expr
-    Pervasives.( ^ )
+    Stdlib.( ^ )
       [%e Exp.constant ~loc (Const.string (str ^ ": "))]
-      Pervasives.__LOC__]
+      Stdlib.__LOC__]
 
 let with_label ~local ~loc exprs =
   let with_label_expr =

--- a/ppx_snarky.opam
+++ b/ppx_snarky.opam
@@ -16,7 +16,7 @@ depends: [
   "ppx_sexp_conv"
   "dune"                {build & >= "1.6"}
 ]
-available: [ ocaml-version >= "4.07.1" ]
+available: [ ocaml-version >= "4.07.0" ]
 descr: "
 A rewiter for Snarky
 "

--- a/ppx_snarky.opam
+++ b/ppx_snarky.opam
@@ -10,12 +10,13 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "core_kernel"
+  "core" {>= "v0.12" & < "v0.13" }
   "ppxlib"
+  "ppx_tools"
   "ppx_sexp_conv"
-  "dune"                {build & >= "1.0"}
+  "dune"                {build & >= "1.6"}
 ]
-available: [ ocaml-version >= "4.04.1" ]
+available: [ ocaml-version >= "4.07.1" ]
 descr: "
 A rewiter for Snarky
 "

--- a/snarky.opam
+++ b/snarky.opam
@@ -22,9 +22,9 @@ depends: [
   "ppx_jane" {>= "v0.12" & < "v0.13"}
   "ppx_deriving" {>= "4.2.1" & < "4.3"}
   "bisect_ppx" {>= "1.4.1" & < "1.5"}
-  "dune"                {build & >= "1.0"}
+  "dune"                {build & >= "1.6"}
 ]
-available: [ ocaml-version >= "4.04.1" ]
+available: [ ocaml-version >= "4.07.0" ]
 descr: "
 A snarks DSL
 "

--- a/snarky_bench.opam
+++ b/snarky_bench.opam
@@ -10,7 +10,7 @@ build: [
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "core_kernel" {>= "v0.12" & < "v0.13" }
+  "core" {>= "v0.12" & < "v0.13" }
   "snarky"
   "ppx_jane"
   "ppx_bench"

--- a/snarky_bench.opam
+++ b/snarky_bench.opam
@@ -10,11 +10,11 @@ build: [
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "core"
+  "core_kernel" {>= "v0.12" & < "v0.13" }
   "snarky"
   "ppx_jane"
   "ppx_bench"
-  "jbuilder"                {build & >= "1.0+beta12"}
+  "dune"                {build & >= "1.6"}
 ]
 available: [ ocaml-version >= "4.04.1" ]
 descr: "

--- a/snarky_bench.opam
+++ b/snarky_bench.opam
@@ -16,7 +16,7 @@ depends: [
   "ppx_bench"
   "dune"                {build & >= "1.6"}
 ]
-available: [ ocaml-version >= "4.04.1" ]
+available: [ ocaml-version >= "4.07.0" ]
 descr: "
 Benchmark runner for snarky
 "

--- a/tuple_lib.opam
+++ b/tuple_lib.opam
@@ -10,13 +10,13 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "core_kernel"
+  "core_kernel" {>= "v0.12" & < "v0.13" }
   "ppx_deriving"
   "ppx_jane"
   "bisect_ppx"
-  "jbuilder"                {build & >= "1.0+beta12"}
+  "dune"                {build & >= "1.6"}
 ]
-available: [ ocaml-version >= "4.04.1" ]
+available: [ ocaml-version >= "4.07.0" ]
 descr: "
 A tiny library with names and a useful getter for tuples
 "


### PR DESCRIPTION
This PR
* updates the `*.opam` files to reflect the actual version constraints
* changes the code generated by `snarky_ppx` to produce `Stdlib` instead of `Pervasives` (which is deprecated in 4.08)

There are still compilation errors in meja with 4.08, but they're slightly more involved because it interfaces with `ocaml-compiler-libs`. I haven't found a good way to support 4.07 and 4.08 simultaneously yet, so (for now) those migrations will have to happen at the time of the 4.07->4.08 change..