### PR TITLE
Functor the core FFI bindings over Ctypes.FOREIGN

### DIFF
--- a/src/backend_types.mli
+++ b/src/backend_types.mli
@@ -6,17 +6,26 @@ module type Prefix_intf = sig
   val prefix : string
 end
 
+module type Foreign_types = sig
+  type 'a return
+
+  type 'a result
+end
+
 module type S = sig
+  include Foreign_types
+
   type t
 
   val typ : t typ
 
   val func_name : string -> string
 
-  val delete : t -> unit
+  val delete : (t -> unit return) result
 end
 
-module Make_foreign (M : Prefix_intf) : S
+module Make_foreign (F : Ctypes.FOREIGN) (M : Prefix_intf) :
+  S with type 'a return := 'a F.return and type 'a result := 'a F.result
 
 module type Field_prefix_intf = sig
   include Prefix_intf
@@ -27,7 +36,11 @@ end
 module type Field_constrained = sig
   type 'field t
 
-  module Make (M : Field_prefix_intf) : S with type t = M.field t
+  module Make (F : Ctypes.FOREIGN) (M : Field_prefix_intf) :
+    S
+    with type t = M.field t
+     and type 'a return := 'a F.return
+     and type 'a result := 'a F.result
 end
 
 module Var : Field_constrained
@@ -43,17 +56,21 @@ module R1CS_constraint : Field_constrained
 module R1CS_constraint_system : Field_constrained
 
 module Proving_key : sig
-  module Make (M : Prefix_intf) : S
+  module Make (F : Ctypes.FOREIGN) (M : Prefix_intf) :
+    S with type 'a return := 'a F.return and type 'a result := 'a F.result
 end
 
 module Verification_key : sig
-  module Make (M : Prefix_intf) : S
+  module Make (F : Ctypes.FOREIGN) (M : Prefix_intf) :
+    S with type 'a return := 'a F.return and type 'a result := 'a F.result
 end
 
 module Keypair : sig
-  module Make (M : Prefix_intf) : S
+  module Make (F : Ctypes.FOREIGN) (M : Prefix_intf) :
+    S with type 'a return := 'a F.return and type 'a result := 'a F.result
 end
 
 module Proof : sig
-  module Make (M : Prefix_intf) : S
+  module Make (F : Ctypes.FOREIGN) (M : Prefix_intf) :
+    S with type 'a return := 'a F.return and type 'a result := 'a F.result
 end

--- a/src/bool_vector.ml
+++ b/src/bool_vector.ml
@@ -9,8 +9,11 @@ module Bindings =
       type t = bool
 
       let typ = bool
-
-      let schedule_delete _ = ()
     end)
 
-include Vector.Make (Bindings)
+include Vector.Make (struct
+            type t = bool
+
+            let schedule_delete _ = ()
+          end)
+          (Bindings)

--- a/src/bool_vector.ml
+++ b/src/bool_vector.ml
@@ -1,11 +1,16 @@
 open Ctypes
 
-include Vector.Make (struct
-  let prefix = "camlsnark_bool_vector"
+module Bindings =
+  Vector.Bind
+    (Ctypes_foreign)
+    (struct
+      let prefix = "camlsnark_bool_vector"
 
-  type t = bool
+      type t = bool
 
-  let typ = bool
+      let typ = bool
 
-  let schedule_delete _ = ()
-end)
+      let schedule_delete _ = ()
+    end)
+
+include Vector.Make (Bindings)

--- a/src/ctypes_foreign.ml
+++ b/src/ctypes_foreign.ml
@@ -1,0 +1,18 @@
+(** An implementation of [Ctypes.FOREIGN] using the usual libffi bindings. *)
+
+open Ctypes
+open Foreign
+
+type 'a fn = 'a Ctypes.fn
+
+type 'a return = 'a
+
+let ( @-> ) = ( @-> )
+
+let returning = returning
+
+type 'a result = 'a
+
+let foreign name typ = foreign name typ
+
+let foreign_value name typ = foreign_value name typ

--- a/src/dune
+++ b/src/dune
@@ -3,7 +3,7 @@
  (public_name snarky)
  (inline_tests)
  (libraries core_kernel fold_lib tuple_lib bitstring_lib interval_union
-   bignum camlsnark_c)
+   bignum camlsnark_c ctypes)
  (c_library_flags :standard -lstdc++ -lpthread)
  (cxx_flags
   (:standard \ -pedantic)

--- a/src/int_vector.ml
+++ b/src/int_vector.ml
@@ -9,8 +9,11 @@ module Bindings =
       type t = int
 
       let typ = int
-
-      let schedule_delete _ = ()
     end)
 
-include Vector.Make (Bindings)
+include Vector.Make (struct
+            type t = int
+
+            let schedule_delete _ = ()
+          end)
+          (Bindings)

--- a/src/int_vector.ml
+++ b/src/int_vector.ml
@@ -1,11 +1,16 @@
 open Ctypes
 
-include Vector.Make (struct
-  let prefix = "camlsnark_int_vector"
+module Bindings =
+  Vector.Bind
+    (Ctypes_foreign)
+    (struct
+      let prefix = "camlsnark_int_vector"
 
-  type t = int
+      type t = int
 
-  let typ = int
+      let typ = int
 
-  let schedule_delete _ = ()
-end)
+      let schedule_delete _ = ()
+    end)
+
+include Vector.Make (Bindings)

--- a/src/libsnark.ml
+++ b/src/libsnark.ml
@@ -740,6 +740,10 @@ module Field = struct
   end
 end
 
+(* NOTE: This isn't functored over Field0 because Common is field-agnostic.
+   Probably the relationship should be inverted, and Field should get
+   to/of_bigint instead.
+*)
 module Bigint = struct
   module Common = struct
     module type Bound = sig

--- a/src/libsnark.ml
+++ b/src/libsnark.ml
@@ -109,17 +109,10 @@ module Group_coefficients (Fq : Foreign_intf) = struct
 end
 
 module Window_table
-    (G : Deletable_intf) (Scalar_field : sig
-        type t
-    end) (Scalar : sig
-      include Foreign_intf
-
-      val of_field : Scalar_field.t -> t
-    end) (V : sig
-      include Deletable_intf
-
-      include Binable.S with type t := t
-    end) =
+    (G : Foreign_intf)
+    (Scalar_field : Foreign_intf)
+    (Scalar : Foreign_intf)
+    (V : Foreign_intf) =
 struct
   module type Bound = sig
     include Foreign_types
@@ -159,8 +152,16 @@ struct
   end
 
   module Make
-      (Bindings : Bound with type 'a return = 'a and type 'a result = 'a) : S =
-  struct
+      (Bindings : Bound with type 'a return = 'a and type 'a result = 'a)
+                                                                        (G : sig
+          val delete : G.t -> unit
+      end) (Scalar : sig
+        val of_field : Scalar_field.t -> Scalar.t
+      end) (V : sig
+        val delete : V.t -> unit
+
+        include Binable.S with type t = V.t
+      end) : S = struct
     open Bindings
     include V
 
@@ -2439,14 +2440,17 @@ struct
       end
 
       module Window_table = struct
-        module T = Window_table (T) (Field) (Bigint.R) (Vector)
+        module T' = Window_table (T) (Field) (Bigint.R) (Vector)
 
-        include T.Make
-                  (T.Bind
+        include T'.Make
+                  (T'.Bind
                      (Ctypes_foreign)
                      (struct
                        let prefix = with_prefix Mnt4_0.prefix "g1"
                      end))
+                     (T)
+                  (Bigint.R)
+                  (Vector)
       end
 
       let%test "window-scale" =
@@ -2556,14 +2560,17 @@ struct
       end
 
       module Window_table = struct
-        module T = Window_table (T) (Field) (Bigint.R) (Vector)
+        module T' = Window_table (T) (Field) (Bigint.R) (Vector)
 
-        include T.Make
-                  (T.Bind
+        include T'.Make
+                  (T'.Bind
                      (Ctypes_foreign)
                      (struct
                        let prefix = with_prefix Mnt6_0.prefix "g1"
                      end))
+                     (T)
+                  (Bigint.R)
+                  (Vector)
       end
 
       let%test "window-scale" =

--- a/src/libsnark.ml
+++ b/src/libsnark.ml
@@ -178,21 +178,10 @@ struct
   end
 end
 
-module Group (Field : sig
-  type t
-
-  val typ : t Ctypes.typ
-end) (Bigint_r : sig
-  type t
-
-  val typ : t Ctypes.typ
-end) (Fq : sig
-  type t [@@deriving bin_io]
-
-  val typ : t Ctypes.typ
-
-  val delete : t -> unit
-end) =
+module Group
+    (Field : Foreign_intf)
+    (Bigint_r : Foreign_intf)
+    (Fq : Foreign_intf) =
 struct
   module type Bound = sig
     include Foreign_types
@@ -343,8 +332,13 @@ struct
   end
 
   module Make
-      (Bindings : Bound with type 'a return = 'a and type 'a result = 'a) : S =
-  struct
+      (Bindings : Bound with type 'a return = 'a and type 'a result = 'a)
+      (Fq : sig
+              type t [@@deriving bin_io]
+
+              val delete : t -> unit
+            end
+            with type t = Fq.t) : S = struct
     include (
       Bindings :
         Bound
@@ -2408,6 +2402,7 @@ struct
                    (struct
                      let prefix = with_prefix Mnt4_0.prefix "g2"
                    end))
+                   (Mnt6_0.Field.Vector)
     end
 
     module G1 = struct
@@ -2420,6 +2415,7 @@ struct
                      (struct
                        let prefix = with_prefix Mnt4_0.prefix "g1"
                      end))
+                     (Mnt6_0.Field)
       end
 
       include T
@@ -2528,6 +2524,7 @@ struct
                    (struct
                      let prefix = with_prefix Mnt6_0.prefix "g2"
                    end))
+                   (Mnt4_0.Field.Vector)
     end
 
     module G1 = struct
@@ -2540,6 +2537,7 @@ struct
                      (struct
                        let prefix = with_prefix Mnt6_0.prefix "g1"
                      end))
+                     (Mnt4_0.Field)
       end
 
       include T

--- a/src/libsnark.ml
+++ b/src/libsnark.ml
@@ -371,14 +371,14 @@ end = struct
           let typ = typ
 
           let prefix = with_prefix prefix "vector"
-
-          let schedule_delete = schedule_delete
         end)
 
     include Vector.Make_binable (struct
                 type nonrec t = t
 
                 include B
+
+                let schedule_delete = schedule_delete
               end)
               (Bindings)
   end
@@ -754,14 +754,14 @@ struct
             let typ = T.typ
 
             let prefix = with_prefix M.prefix "field_vector"
-
-            let schedule_delete = Caml.Gc.finalise T.delete
           end)
 
       include Vector.Make_binable (struct
                   type t = T.t
 
                   include B
+
+                  let schedule_delete = Caml.Gc.finalise T.delete
                 end)
                 (Bindings)
     end
@@ -877,11 +877,14 @@ struct
               let typ = typ
 
               let prefix = with_prefix prefix "vector"
-
-              let schedule_delete = Caml.Gc.finalise delete
             end)
 
-        include Vector.Make (Bindings)
+        include Vector.Make (struct
+                    type nonrec t = t
+
+                    let schedule_delete = Caml.Gc.finalise delete
+                  end)
+                  (Bindings)
       end
     end
 
@@ -897,11 +900,14 @@ struct
             let typ = typ
 
             let prefix = with_prefix prefix "vector"
-
-            let schedule_delete = schedule_delete
           end)
 
-      include Vector.Make (Bindings)
+      include Vector.Make (struct
+                  type nonrec t = t
+
+                  let schedule_delete = schedule_delete
+                end)
+                (Bindings)
     end
 
     let print = foreign (func_name "print") (typ @-> returning void)

--- a/src/libsnark.ml
+++ b/src/libsnark.ml
@@ -1277,7 +1277,12 @@ module Linear_combination (Field : Foreign_intf) (Var : Foreign_intf) = struct
                 type field = Field.t
               end)
 
-    module Term = Term.Bind (F) (P)
+    module Term =
+      Term.Bind
+        (F)
+        (struct
+          let prefix = prefix
+        end)
 
     module Vector =
       Vector.Bind

--- a/src/libsnark.ml
+++ b/src/libsnark.ml
@@ -361,17 +361,27 @@ end = struct
 
   include B
 
-  module Vector = Vector.Make_binable (struct
-    type nonrec t = t
+  module Vector = struct
+    module Bindings =
+      Vector.Bind
+        (Ctypes_foreign)
+        (struct
+          type nonrec t = t
 
-    include B
+          let typ = typ
 
-    let typ = typ
+          let prefix = with_prefix prefix "vector"
 
-    let prefix = with_prefix prefix "vector"
+          let schedule_delete = schedule_delete
+        end)
 
-    let schedule_delete = schedule_delete
-  end)
+    include Vector.Make_binable (struct
+                type nonrec t = t
+
+                include B
+              end)
+              (Bindings)
+  end
 end
 
 module Make_common (M : sig
@@ -734,17 +744,27 @@ struct
 
     include B
 
-    module Vector = Vector.Make_binable (struct
-      type t = T.t
+    module Vector = struct
+      module Bindings =
+        Vector.Bind
+          (Ctypes_foreign)
+          (struct
+            type t = T.t
 
-      include B
+            let typ = T.typ
 
-      let typ = T.typ
+            let prefix = with_prefix M.prefix "field_vector"
 
-      let prefix = with_prefix M.prefix "field_vector"
+            let schedule_delete = Caml.Gc.finalise T.delete
+          end)
 
-      let schedule_delete = Caml.Gc.finalise T.delete
-    end)
+      include Vector.Make_binable (struct
+                  type t = T.t
+
+                  include B
+                end)
+                (Bindings)
+    end
 
     include T
   end
@@ -847,28 +867,42 @@ struct
         let stub = foreign (func_name "index") (typ @-> returning int) in
         fun t -> Var.create (stub t)
 
-      module Vector = Vector.Make (struct
-        type nonrec t = t
+      module Vector = struct
+        module Bindings =
+          Vector.Bind
+            (Ctypes_foreign)
+            (struct
+              type nonrec t = t
 
-        let typ = typ
+              let typ = typ
 
-        let prefix = with_prefix prefix "vector"
+              let prefix = with_prefix prefix "vector"
 
-        let schedule_delete = Caml.Gc.finalise delete
-      end)
+              let schedule_delete = Caml.Gc.finalise delete
+            end)
+
+        include Vector.Make (Bindings)
+      end
     end
 
     let schedule_delete t = Caml.Gc.finalise delete t
 
-    module Vector = Vector.Make (struct
-      type nonrec t = t
+    module Vector = struct
+      module Bindings =
+        Vector.Bind
+          (Ctypes_foreign)
+          (struct
+            type nonrec t = t
 
-      let typ = typ
+            let typ = typ
 
-      let prefix = with_prefix prefix "vector"
+            let prefix = with_prefix prefix "vector"
 
-      let schedule_delete = schedule_delete
-    end)
+            let schedule_delete = schedule_delete
+          end)
+
+      include Vector.Make (Bindings)
+    end
 
     let print = foreign (func_name "print") (typ @-> returning void)
 

--- a/src/libsnark.ml
+++ b/src/libsnark.ml
@@ -1034,7 +1034,7 @@ module Bigint = struct
   end
 end
 
-module Var (Field0 : Deletable_intf) = struct
+module Var (Field0 : Foreign_intf) = struct
   module type Bound = sig
     include Foreign_types
 

--- a/src/long_vector.ml
+++ b/src/long_vector.ml
@@ -9,8 +9,11 @@ module Bindings =
       type t = Signed.Long.t
 
       let typ = long
-
-      let schedule_delete _ = ()
     end)
 
-include Vector.Make (Bindings)
+include Vector.Make (struct
+            type t = Signed.Long.t
+
+            let schedule_delete _ = ()
+          end)
+          (Bindings)

--- a/src/long_vector.ml
+++ b/src/long_vector.ml
@@ -1,11 +1,16 @@
 open Ctypes
 
-include Vector.Make (struct
-  let prefix = "camlsnark_long_vector"
+module Bindings =
+  Vector.Bind
+    (Ctypes_foreign)
+    (struct
+      let prefix = "camlsnark_long_vector"
 
-  type t = Signed.Long.t
+      type t = Signed.Long.t
 
-  let typ = long
+      let typ = long
 
-  let schedule_delete _ = ()
-end)
+      let schedule_delete _ = ()
+    end)
+
+include Vector.Make (Bindings)

--- a/src/vector.mli
+++ b/src/vector.mli
@@ -24,8 +24,6 @@ module type Bound = sig
   val length : (t -> int return) result
 
   val emplace_back : (t -> elt -> unit return) result
-
-  val elt_schedule_delete : (elt -> unit return) result
 end
 
 module type S = sig
@@ -58,8 +56,6 @@ module Bind
 
         val typ : t Ctypes.typ
 
-        val schedule_delete : (t -> unit F.return) F.result
-
         val prefix : string
     end) :
   Bound
@@ -67,11 +63,20 @@ module Bind
    and type 'a result = 'a F.result
    and type elt = Elt.t
 
-module Make (Bindings : Bound with type 'a return = 'a and type 'a result = 'a) :
-  S with type elt = Bindings.elt
+module Make (Elt : sig
+  type t
+
+  val schedule_delete : t -> unit
+end)
+(Bindings : Bound
+            with type 'a return = 'a
+             and type 'a result = 'a
+             and type elt = Elt.t) : S with type elt = Bindings.elt
 
 module Make_binable (Elt : sig
   type t [@@deriving bin_io]
+
+  val schedule_delete : t -> unit
 end)
 (Bindings : Bound
             with type 'a return = 'a


### PR DESCRIPTION
This PR functors the commonly used FFI bindings over `Ctypes.FOREIGN`, so that we can generate C stubs using the Ctypes API and remove the majority of our libffi overhead.

This doesn't do the actual generation yet, that will be in a follow-up PR.