### PR TITLE
Faster Cvar.eval and project/pack

### DIFF
--- a/src/backend_extended.ml
+++ b/src/backend_extended.ml
@@ -53,7 +53,7 @@ module type S = sig
       val of_index : int -> t
     end
 
-    val eval : (int -> Field.t) -> t -> Field.t
+    val eval : [`Return_values_will_be_mutated of (int -> Field.t)] -> t -> Field.t
 
     val constant : Field.t -> t
 

--- a/src/backend_extended.ml
+++ b/src/backend_extended.ml
@@ -53,7 +53,8 @@ module type S = sig
       val of_index : int -> t
     end
 
-    val eval : [`Return_values_will_be_mutated of (int -> Field.t)] -> t -> Field.t
+    val eval :
+      [`Return_values_will_be_mutated of int -> Field.t] -> t -> Field.t
 
     val constant : Field.t -> t
 

--- a/src/checked_runner.ml
+++ b/src/checked_runner.ml
@@ -62,7 +62,7 @@ struct
       if i <= num_inputs then Field.Vector.get input (i - 1)
       else Field.Vector.get aux (i - num_inputs - 1)
     in
-    Cvar.eval get_one
+    Cvar.eval (`Return_values_will_be_mutated get_one)
 
   let store_field_elt {next_auxiliary; aux; _} x =
     let v = !next_auxiliary in

--- a/src/cvar.ml
+++ b/src/cvar.ml
@@ -28,7 +28,7 @@ struct
 
   let scratch = Field.of_int 0
 
-  let eval context t0 =
+  let eval (`Return_values_will_be_mutated context) t0 =
     let open Field in
     let res = of_int 0 in
     let can_mutate_scale = ref false in
@@ -39,13 +39,10 @@ struct
           Mutable.copy ~over:scratch c ;
           scratch *= scale ;
           res += scratch
-      | Var v when !can_mutate_scale ->
-          scale *= context v ;
-          res += scale
       | Var v ->
-          Mutable.copy ~over:scratch (context v) ;
-          scratch *= scale ;
-          res += scratch
+          let v = context v in
+          v *= scale ;
+          res += v
       | Scale (s, t) when !can_mutate_scale ->
           scale *= s ; go scale t
       | Scale (s, t) ->

--- a/src/cvar.ml
+++ b/src/cvar.ml
@@ -41,8 +41,7 @@ struct
           res += scratch
       | Var v ->
           let v = context v in
-          v *= scale ;
-          res += v
+          v *= scale ; res += v
       | Scale (s, t) when !can_mutate_scale ->
           scale *= s ; go scale t
       | Scale (s, t) ->

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -169,7 +169,7 @@ struct
       let system = R1CS_constraint_system.create () in
       let get_value : Cvar.t -> Field.t =
         let get_one v = Field.Vector.get aux (v - 1) in
-        Cvar.eval get_one
+        Cvar.eval (`Return_values_will_be_mutated get_one)
       in
       let state =
         Runner.State.make ~num_inputs ~input ~next_auxiliary ~aux ~system

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -1,3 +1,4 @@
+module Cvar0 = Cvar
 module Bignum_bigint = Bigint
 module Checked_ast = Checked
 open Core_kernel
@@ -1020,14 +1021,20 @@ struct
   module Cvar1 = struct
     include Cvar
 
-    let project (vars : Checked.Boolean.var list) =
-      let rec go c acc = function
+    let project =
+      let two = Field.of_int 2 in
+      fun (vars : Checked.Boolean.var list) ->
+        let rec go res = function
+          | [] ->
+              res
+          | v :: vs ->
+              go Cvar0.(Add (v, Scale (two, res))) vs
+        in
+        match List.rev (vars :> Cvar.t list) with
         | [] ->
-            List.rev acc
+            Cvar0.Constant Field.zero
         | v :: vs ->
-            go (Field.add c c) ((c, v) :: acc) vs
-      in
-      Cvar.linear_combination (go Field.one [] (vars :> Cvar.t list))
+            go v vs
 
     let pack vars =
       assert (List.length vars < Field.size_in_bits) ;


### PR DESCRIPTION
This PR
* reworks `Cvar.eval` to avoid a `Field.Mutable.copy` when reading a variable
* reworks `project` (and thus also `pack`) to be faster.

In particular, the changes to `project` mean that:
* the number of allocations made by `Cvar.eval` is halved
  - these are now just the allocations made when reading from the vector
  - the number of multiplications and additions is unchanged
* no C++ allocations within project/pack`
* there are no field computations within project/pack