### PR TITLE
Add Typ.t's for non-snarkable values

### DIFF
--- a/src/as_prover.ml
+++ b/src/as_prover.ml
@@ -37,6 +37,12 @@ struct
     let set (r : 'a t) x =
       let%map () = As_prover.return () in
       r := Some x
+
+    let store x = Typ_monads.Store.return (ref (Some x))
+
+    let read r = Typ_monads.Read.return (Option.value_exn !r)
+
+    let alloc () = Typ_monads.Alloc.return (ref None)
   end
 end
 

--- a/src/as_prover_intf.ml
+++ b/src/as_prover_intf.ml
@@ -69,6 +69,12 @@ module type S = sig
     val get : 'a t -> ('a, 'f field, _) Types.As_prover.t
 
     val set : 'a t -> 'a -> (unit, 'f field, _) Types.As_prover.t
+
+    val store : 'a -> ('a t, 'f field) Typ_monads.Store.t
+
+    val read : 'a t -> ('a, 'f field) Typ_monads.Read.t
+
+    val alloc : unit -> ('a t, 'f field) Typ_monads.Alloc.t
   end
 end
 

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -1489,10 +1489,6 @@ module Run = struct
 
       let field = field
 
-      let snarkless = snarkless
-
-      let ref = ref
-
       let tuple2 = tuple2
 
       let ( * ) = ( * )
@@ -1511,6 +1507,7 @@ module Run = struct
 
       let of_hlistable = of_hlistable
 
+      module Internal = Internal
       module Of_traversable = Of_traversable
     end
 

--- a/src/snark_intf.ml
+++ b/src/snark_intf.ml
@@ -290,27 +290,6 @@ module type Basic = sig
 
     val field : (Field.Var.t, field) t
 
-    val snarkless : 'a -> ('a, 'a) t
-    (** A do-nothing [Typ.t] that returns the input value for all modes. This
-        may be used to convert objects from the [Checked] world into and
-        through [As_prover] blocks.
-
-        This is the dual of [ref], which allows [OCaml] values from [As_prover]
-        blocks to pass through the [Checked] world.
-
-        Reading or writing using this [Typ.t] will assert that the argument and
-        the value stored are physically equal -- ie. that they refer to the
-        same object.
-    *)
-
-    val ref : unit -> ('a As_prover.Ref.t, 'a) t
-    (** A [Typ.t] for marshalling OCaml values generated in [As_prover] blocks,
-        while keeping them opaque to the [Checked] world.
-
-        This is the dual of [snarkless], which allows [OCaml] values from the
-        [Checked] world to pass through [As_prover] blocks.
-    *)
-
     (** Common constructors: *)
 
     val tuple2 :
@@ -386,6 +365,34 @@ module type Basic = sig
         describes the relationship between ['var] and ['value] in terms of a
         {!type:Data_spec.t}.
     *)
+
+    (** [Typ.t]s that make it easier to write a [Typ.t] for a mix of R1CS data
+        and normal OCaml data.
+
+        Using this module is not recommended.
+    *)
+    module Internal : sig
+      val snarkless : 'a -> ('a, 'a) t
+      (** A do-nothing [Typ.t] that returns the input value for all modes. This
+          may be used to convert objects from the [Checked] world into and
+          through [As_prover] blocks.
+
+          This is the dual of [ref], which allows [OCaml] values from
+          [As_prover] blocks to pass through the [Checked] world.
+
+          Note: Reading or writing using this [Typ.t] will assert that the
+          argument and the value stored are physically equal -- ie. that they
+          refer to the same object.
+      *)
+
+      val ref : unit -> ('a As_prover.Ref.t, 'a) t
+      (** A [Typ.t] for marshalling OCaml values generated in [As_prover]
+          blocks, while keeping them opaque to the [Checked] world.
+
+          This is the dual of [snarkless], which allows [OCaml] values from the
+          [Checked] world to pass through [As_prover] blocks.
+    *)
+    end
 
     module Of_traversable (T : Traversable.S) : sig
       val typ :
@@ -1502,22 +1509,6 @@ module type Run_basic = sig
 
     val field : (Field.t, field) t
 
-    val snarkless : 'a -> ('a, 'a) t
-    (** A do-nothing [Typ.t] that returns the input value for all modes.
-
-        reading or writing using this [Typ.t] will assert that the argument and
-        the value stored are physically equal -- ie. that they refer to the
-        same object.
-    *)
-
-    val ref : unit -> ('a As_prover.Ref.t, 'a) t
-    (** A [Typ.t] for marshalling OCaml values generated in [As_prover] blocks,
-        while keeping them opaque to the [Checked] world.
-
-        This is the dual of [snarkless], which allows [OCaml] values from the
-        [Checked] world to pass through [As_prover] blocks.
-    *)
-
     (** Common constructors: *)
 
     val tuple2 :
@@ -1569,6 +1560,32 @@ module type Run_basic = sig
       -> value_to_hlist:('value -> (unit, 'k_value) H_list.t)
       -> value_of_hlist:((unit, 'k_value) H_list.t -> 'value)
       -> ('var, 'value) t
+
+    (** [Typ.t]s that make it easier to write a [Typ.t] for a mix of R1CS data
+        and normal OCaml data.
+
+        Using this module is not recommended.
+    *)
+    module Internal : sig
+      val snarkless : 'a -> ('a, 'a) t
+      (** A do-nothing [Typ.t] that returns the input value for all modes.
+
+          This is the dual of [ref], which allows [OCaml] values from
+          [As_prover] blocks to pass through the [Checked] world.
+
+          Note: Reading or writing using this [Typ.t] will assert that the
+          argument and the value stored are physically equal -- ie. that they
+          refer to the same object.
+      *)
+
+      val ref : unit -> ('a As_prover.Ref.t, 'a) t
+      (** A [Typ.t] for marshalling OCaml values generated in [As_prover]
+          blocks, while keeping them opaque to the [Checked] world.
+
+          This is the dual of [snarkless], which allows [OCaml] values from the
+          [Checked] world to pass through [As_prover] blocks.
+      *)
+    end
 
     module Of_traversable (T : Traversable.S) : sig
       val typ :

--- a/src/snark_intf.ml
+++ b/src/snark_intf.ml
@@ -3,6 +3,7 @@ open Core_kernel
 module Constraint0 = Constraint
 module Boolean0 = Boolean
 module Typ0 = Typ
+module As_prover0 = As_prover
 
 (** Yojson-compatible JSON type. *)
 type 'a json =
@@ -288,6 +289,27 @@ module type Basic = sig
     val unit : (unit, unit) t
 
     val field : (Field.Var.t, field) t
+
+    val snarkless : 'a -> ('a, 'a) t
+    (** A do-nothing [Typ.t] that returns the input value for all modes. This
+        may be used to convert objects from the [Checked] world into and
+        through [As_prover] blocks.
+
+        This is the dual of [ref], which allows [OCaml] values from [As_prover]
+        blocks to pass through the [Checked] world.
+
+        Reading or writing using this [Typ.t] will assert that the argument and
+        the value stored are physically equal -- ie. that they refer to the
+        same object.
+    *)
+
+    val ref : unit -> ('a As_prover.Ref.t, 'a) t
+    (** A [Typ.t] for marshalling OCaml values generated in [As_prover] blocks,
+        while keeping them opaque to the [Checked] world.
+
+        This is the dual of [snarkless], which allows [OCaml] values from the
+        [Checked] world to pass through [As_prover] blocks.
+    *)
 
     (** Common constructors: *)
 
@@ -749,47 +771,18 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
     (** Describes how to convert between {!type:t} and {!type:Var.t} values. *)
   end
 
-  module Let_syntax :
-    Monad_let.Syntax2 with type ('a, 's) t := ('a, 's) Checked.t
-
-  (** Zero-knowledge proofs generated from checked computations. *)
-  module Proof : sig
-    type t
-
-    (** The type of messages that can be associated with a proof. *)
-    type message
-
-    include Binable.S with type t := t
-  end
-
-  (** Utility functions for dealing with lists of bits in the R1CS. *)
-  module Bitstring_checked : sig
-    type t = Boolean.var list
-
-    val equal : t -> t -> (Boolean.var, _) Checked.t
-
-    val lt_value :
-         Boolean.var Bitstring_lib.Bitstring.Msb_first.t
-      -> bool Bitstring_lib.Bitstring.Msb_first.t
-      -> (Boolean.var, _) Checked.t
-
-    module Assert : sig
-      val equal : t -> t -> (unit, _) Checked.t
-    end
-  end
-
   (** Code that can be run by the prover only, using 'superpowers' like looking
       at the contents of R1CS variables and creating new variables from other
       OCaml values.
   *)
-  module As_prover : sig
+  and As_prover : sig
     (** An [('a, 'prover_state) t] value uses the current ['prover_state] to
         generate a value of type ['a], and update the ['prover_state] as
         necessary, within a checked computation.
 
         This type specialises the {!type:As_prover.t} type for the backend's
         particular field and variable type. *)
-    type ('a, 'prover_state) t = ('a, field, 'prover_state) As_prover.t
+    type ('a, 'prover_state) t = ('a, field, 'prover_state) As_prover0.t
 
     type ('a, 'prover_state) as_prover = ('a, 'prover_state) t
 
@@ -836,6 +829,35 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
     (** [with_lens lens as_prover] uses the {!type:Lens.t} provided to lift the
         prover state of [as_prover] to ['whole] from a sub-type ['lens].
     *)
+  end
+
+  module Let_syntax :
+    Monad_let.Syntax2 with type ('a, 's) t := ('a, 's) Checked.t
+
+  (** Zero-knowledge proofs generated from checked computations. *)
+  module Proof : sig
+    type t
+
+    (** The type of messages that can be associated with a proof. *)
+    type message
+
+    include Binable.S with type t := t
+  end
+
+  (** Utility functions for dealing with lists of bits in the R1CS. *)
+  module Bitstring_checked : sig
+    type t = Boolean.var list
+
+    val equal : t -> t -> (Boolean.var, _) Checked.t
+
+    val lt_value :
+         Boolean.var Bitstring_lib.Bitstring.Msb_first.t
+      -> bool Bitstring_lib.Bitstring.Msb_first.t
+      -> (Boolean.var, _) Checked.t
+
+    module Assert : sig
+      val equal : t -> t -> (unit, _) Checked.t
+    end
   end
 
   (** Representation of an R1CS value and an OCaml value (if running as the
@@ -1480,6 +1502,22 @@ module type Run_basic = sig
 
     val field : (Field.t, field) t
 
+    val snarkless : 'a -> ('a, 'a) t
+    (** A do-nothing [Typ.t] that returns the input value for all modes.
+
+        reading or writing using this [Typ.t] will assert that the argument and
+        the value stored are physically equal -- ie. that they refer to the
+        same object.
+    *)
+
+    val ref : unit -> ('a As_prover.Ref.t, 'a) t
+    (** A [Typ.t] for marshalling OCaml values generated in [As_prover] blocks,
+        while keeping them opaque to the [Checked] world.
+
+        This is the dual of [snarkless], which allows [OCaml] values from the
+        [Checked] world to pass through [As_prover] blocks.
+    *)
+
     (** Common constructors: *)
 
     val tuple2 :
@@ -1734,37 +1772,29 @@ module type Run_basic = sig
     val typ : (t, Constant.t) Typ.t
   end
 
-  module Proof : sig
-    type t
-
-    type message
-
-    include Binable.S with type t := t
-  end
-
-  module Bitstring_checked : sig
-    type t = Boolean.var list
-
-    val equal : t -> t -> Boolean.var
-
-    val lt_value :
-         Boolean.var Bitstring_lib.Bitstring.Msb_first.t
-      -> bool Bitstring_lib.Bitstring.Msb_first.t
-      -> Boolean.var
-
-    module Assert : sig
-      val equal : t -> t -> unit
-    end
-  end
-
   (** The functions in this module may only be run as the prover; trying to
       run them outside of functions that refer to [As_prover.t] will result in
       a runtime error. *)
-  module As_prover : sig
+  and As_prover : sig
     (** This type marks function arguments that can include function calls from
         this module. Using these functions outside of these will result in a
         runtime error. *)
     type 'a t = 'a
+
+    type 'a as_prover = 'a t
+
+    (** Opaque references for use by the prover in a checked computation. *)
+    module Ref : sig
+      (** A mutable reference to an ['a] value, which may be used in checked
+          computations. *)
+      type 'a t
+
+      val create : (unit -> 'a) as_prover -> 'a t
+
+      val get : 'a t -> 'a as_prover
+
+      val set : 'a t -> 'a -> unit as_prover
+    end
 
     val in_prover_block : unit -> bool
 
@@ -1786,10 +1816,33 @@ module type Run_basic = sig
     val project : bool list -> field
 
     val with_lens :
-      (prover_state, 'lens) Lens.t -> ('a, field, 'lens) As_prover.t -> 'a t
+      (prover_state, 'lens) Lens.t -> ('a, field, 'lens) As_prover0.t -> 'a t
     (** Lift the monadic {!type:As_prover.t} defined with state ['lens] to an
         as-prover computation using [prover_state].
     *)
+  end
+
+  module Proof : sig
+    type t
+
+    type message
+
+    include Binable.S with type t := t
+  end
+
+  module Bitstring_checked : sig
+    type t = Boolean.var list
+
+    val equal : t -> t -> Boolean.var
+
+    val lt_value :
+         Boolean.var Bitstring_lib.Bitstring.Msb_first.t
+      -> bool Bitstring_lib.Bitstring.Msb_first.t
+      -> Boolean.var
+
+    module Assert : sig
+      val equal : t -> t -> unit
+    end
   end
 
   module Handle : sig
@@ -1959,7 +2012,10 @@ module type Run_basic = sig
 
   val clear_constraint_logger : unit -> unit
 
-  module Internal_Basic : Basic with type field = field
+  module Internal_Basic :
+    Basic
+    with type field = field
+     and type 'a As_prover.Ref.t = 'a As_prover.Ref.t
 
   val run_checked : ('a, prover_state) Internal_Basic.Checked.t -> 'a
 end

--- a/src/typ.ml
+++ b/src/typ.ml
@@ -114,23 +114,25 @@ struct
       ; alloc= Alloc.alloc
       ; check= (fun _ -> Checked.return ()) }
 
-    let snarkless value =
-      { store=
-          (fun value' ->
-            assert (phys_equal value value') ;
-            Store.return value )
-      ; read=
-          (fun value' ->
-            assert (phys_equal value value') ;
-            Read.return value )
-      ; check= (fun _ -> Checked.return ())
-      ; alloc= Alloc.return value }
+    module Internal = struct
+      let snarkless value =
+        { store=
+            (fun value' ->
+              assert (phys_equal value value') ;
+              Store.return value )
+        ; read=
+            (fun value' ->
+              assert (phys_equal value value') ;
+              Read.return value )
+        ; check= (fun _ -> Checked.return ())
+        ; alloc= Alloc.return value }
 
-    let ref () =
-      { store= As_prover.Ref.store
-      ; read= As_prover.Ref.read
-      ; check= (fun _ -> Checked.return ())
-      ; alloc= As_prover.Ref.alloc () }
+      let ref () =
+        { store= As_prover.Ref.store
+        ; read= As_prover.Ref.read
+        ; check= (fun _ -> Checked.return ())
+        ; alloc= As_prover.Ref.alloc () }
+    end
 
     let transport ({read; store; alloc; check} : ('var1, 'value1, 'field) t)
         ~(there : 'value2 -> 'value1) ~(back : 'value1 -> 'value2) :

--- a/src/typ.ml
+++ b/src/typ.ml
@@ -114,6 +114,24 @@ struct
       ; alloc= Alloc.alloc
       ; check= (fun _ -> Checked.return ()) }
 
+    let snarkless value =
+      { store=
+          (fun value' ->
+            assert (phys_equal value value') ;
+            Store.return value )
+      ; read=
+          (fun value' ->
+            assert (phys_equal value value') ;
+            Read.return value )
+      ; check= (fun _ -> Checked.return ())
+      ; alloc= Alloc.return value }
+
+    let ref () =
+      { store= As_prover.Ref.store
+      ; read= As_prover.Ref.read
+      ; check= (fun _ -> Checked.return ())
+      ; alloc= As_prover.Ref.alloc () }
+
     let transport ({read; store; alloc; check} : ('var1, 'value1, 'field) t)
         ~(there : 'value2 -> 'value1) ~(back : 'value1 -> 'value2) :
         ('var1, 'value2, 'field) t =


### PR DESCRIPTION
This will let us avoid the hacks that we used in Meja during the
conference to handle string passing etc. between the worlds.

This slightly overloads the behaviour of `As_prover.Ref.t`, but for Meja's
purposes this will be invisible to the user anyway. Perhaps more
importantly, this type can be special-cased to give good error messages
when the user tries to use prover-generated data outside of a prover
block.

Generating code that uses `snarkable` will be slightly more awkward,
since we need to track when the same variable is read and then
re-stored, but it should be possible to make it work.  The important case
that this supports is code like:

```reason
...
let x = {data: 1000f, aux_data: 50};
let x = Prover { {x.. data= x.data * 10f} };
...
```

where the int `aux_data` might be used later in checked code as e.g. the
length of a loop