### PR TITLE
[Meja] AST iterators/mappers

### DIFF
--- a/meja/ocaml/of_ocaml.ml
+++ b/meja/ocaml/of_ocaml.ml
@@ -47,7 +47,7 @@ let rec to_type_desc ~loc desc =
       Ptyp_var (None, Explicit)
 
 and to_type_expr ~loc typ =
-  {type_desc= to_type_desc ~loc typ.desc; type_id= -1; type_loc= loc}
+  {type_desc= to_type_desc ~loc typ.desc; type_loc= loc}
 
 let to_field_decl {ld_id; ld_type; ld_loc; _} =
   { fld_ident= mkloc (Ident.name ld_id) ld_loc

--- a/meja/ocaml/of_ocaml.ml
+++ b/meja/ocaml/of_ocaml.ml
@@ -58,7 +58,7 @@ let to_ctor_args ~loc = function
   | Cstr_tuple typs ->
       Ctor_tuple (List.map ~f:(to_type_expr ~loc) typs)
   | Cstr_record labels ->
-      Ctor_record (0, List.map ~f:to_field_decl labels)
+      Ctor_record (List.map ~f:to_field_decl labels)
 
 let to_ctor_decl {cd_id; cd_args; cd_res; cd_loc; _} =
   { ctor_ident= mkloc (Ident.name cd_id) cd_loc

--- a/meja/ocaml/to_ocaml.ml
+++ b/meja/ocaml/to_ocaml.ml
@@ -29,7 +29,7 @@ let of_field_decl {fld_ident= name; fld_type= typ; fld_loc= loc; _} =
 let of_ctor_args = function
   | Ctor_tuple args ->
       Parsetree.Pcstr_tuple (List.map ~f:of_type_expr args)
-  | Ctor_record (_, fields) ->
+  | Ctor_record fields ->
       Parsetree.Pcstr_record (List.map ~f:of_field_decl fields)
 
 let of_ctor_decl

--- a/meja/src/ast_build.ml
+++ b/meja/src/ast_build.ml
@@ -107,7 +107,7 @@ module Type_decl = struct
     let with_args ?loc ?ret name args = mk ?loc ?ret name (Ctor_tuple args)
 
     let with_record ?loc ?ret name fields =
-      mk ?loc ?ret name (Ctor_record (-1, fields))
+      mk ?loc ?ret name (Ctor_record fields)
   end
 end
 

--- a/meja/src/ast_build.ml
+++ b/meja/src/ast_build.ml
@@ -42,7 +42,7 @@ end
 
 module Type = struct
   let mk ?(loc = Location.none) d : Parsetypes.type_expr =
-    {type_desc= d; type_id= -1; type_loc= loc}
+    {type_desc= d; type_loc= loc}
 
   let variant ?loc ?(params = []) ?(implicits = []) ident =
     { var_ident= Loc.mk ident ?loc

--- a/meja/src/parser_impl.mly
+++ b/meja/src/parser_impl.mly
@@ -251,7 +251,7 @@ ctor_decl_args:
   | LPAREN rev_args = list(type_expr, COMMA) RPAREN
     { Ctor_tuple (List.rev rev_args) }
   | LBRACE fields = list(field_decl, COMMA) RBRACE
-    { Ctor_record (0, List.rev fields) }
+    { Ctor_record (List.rev fields) }
 
 %inline type_lident:
   | id = lident

--- a/meja/src/parser_impl.mly
+++ b/meja/src/parser_impl.mly
@@ -12,7 +12,7 @@ let lid_last x = mkloc (last x.txt) x.loc
 
 let mkloc ~pos x = mkloc x (Loc.of_pos pos)
 
-let mktyp ~pos d = {type_desc= d; type_id= -1; type_loc= Loc.of_pos pos}
+let mktyp ~pos d = {type_desc= d; type_loc= Loc.of_pos pos}
 let mkpat ~pos d = {pat_desc= d; pat_loc= Loc.of_pos pos}
 let mkexp ~pos d = {exp_desc= d; exp_loc= Loc.of_pos pos}
 let mkstmt ~pos d = {stmt_desc= d; stmt_loc= Loc.of_pos pos}

--- a/meja/src/parsetypes.ml
+++ b/meja/src/parsetypes.ml
@@ -21,7 +21,7 @@ type field_decl = {fld_ident: str; fld_type: type_expr; fld_loc: Location.t}
 
 type ctor_args =
   | Ctor_tuple of type_expr list
-  | Ctor_record of int * field_decl list
+  | Ctor_record of field_decl list
 
 type ctor_decl =
   { ctor_ident: str

--- a/meja/src/parsetypes.ml
+++ b/meja/src/parsetypes.ml
@@ -86,6 +86,8 @@ and expression_desc =
 
 type signature_item = {sig_desc: signature_desc; sig_loc: Location.t}
 
+and signature = signature_item list
+
 and signature_desc =
   | Psig_value of str * type_expr
   | Psig_instance of str * type_expr
@@ -97,8 +99,6 @@ and signature_desc =
   | Psig_request of type_expr * ctor_decl
   | Psig_multiple of signature
 
-and signature = signature_item list
-
 and module_sig = {msig_desc: module_sig_desc; msig_loc: Location.t}
 
 and module_sig_desc =
@@ -108,6 +108,8 @@ and module_sig_desc =
   | Pmty_functor of str * module_sig * module_sig
 
 type statement = {stmt_desc: statement_desc; stmt_loc: Location.t}
+
+and statements = statement list
 
 and statement_desc =
   | Pstmt_value of pattern * expression
@@ -119,11 +121,11 @@ and statement_desc =
   | Pstmt_typeext of variant * ctor_decl list
   | Pstmt_request of
       type_expr * ctor_decl * (pattern option * expression) option
-  | Pstmt_multiple of statement list
+  | Pstmt_multiple of statements
 
 and module_expr = {mod_desc: module_desc; mod_loc: Location.t}
 
 and module_desc =
-  | Pmod_struct of statement list
+  | Pmod_struct of statements
   | Pmod_name of lid
   | Pmod_functor of str * module_sig * module_expr

--- a/meja/src/parsetypes_iter.ml
+++ b/meja/src/parsetypes_iter.ml
@@ -93,6 +93,7 @@ let type_decl_desc iter = function
       ()
   | TExtend (name, decl, ctors) ->
       iter.location iter name.loc ;
+      iter.longident iter name.txt ;
       iter.type0_decl iter decl ;
       List.iter ~f:(iter.ctor_decl iter) ctors
   | TForward _ ->

--- a/meja/src/parsetypes_iter.ml
+++ b/meja/src/parsetypes_iter.ml
@@ -1,0 +1,316 @@
+open Core_kernel
+open Parsetypes
+open Ast_types
+
+type iterator =
+  { type_expr: iterator -> type_expr -> unit
+  ; type_desc: iterator -> type_desc -> unit
+  ; variant: iterator -> variant -> unit
+  ; field_decl: iterator -> field_decl -> unit
+  ; ctor_args: iterator -> ctor_args -> unit
+  ; ctor_decl: iterator -> ctor_decl -> unit
+  ; type_decl: iterator -> type_decl -> unit
+  ; type_decl_desc: iterator -> type_decl_desc -> unit
+  ; literal: iterator -> literal -> unit
+  ; pattern: iterator -> pattern -> unit
+  ; pattern_desc: iterator -> pattern_desc -> unit
+  ; expression: iterator -> expression -> unit
+  ; expression_desc: iterator -> expression_desc -> unit
+  ; signature_item: iterator -> signature_item -> unit
+  ; signature: iterator -> signature -> unit
+  ; signature_desc: iterator -> signature_desc -> unit
+  ; module_sig: iterator -> module_sig -> unit
+  ; module_sig_desc: iterator -> module_sig_desc -> unit
+  ; statement: iterator -> statement -> unit
+  ; statements: iterator -> statements -> unit
+  ; statement_desc: iterator -> statement_desc -> unit
+  ; module_expr: iterator -> module_expr -> unit
+  ; module_desc: iterator -> module_desc -> unit
+  ; location: iterator -> Location.t -> unit
+  ; longident: iterator -> Longident.t -> unit
+  ; type0_decl: iterator -> Type0.type_decl -> unit }
+
+let type_expr iter {type_desc; type_loc} =
+  iter.location iter type_loc ;
+  iter.type_desc iter type_desc
+
+let type_desc iter = function
+  | Ptyp_var (name, _) ->
+      Option.iter ~f:(fun name -> iter.location iter name.Location.loc) name
+  | Ptyp_tuple typs ->
+      List.iter ~f:(iter.type_expr iter) typs
+  | Ptyp_arrow (typ1, typ2, _, _) ->
+      iter.type_expr iter typ1 ; iter.type_expr iter typ2
+  | Ptyp_ctor variant ->
+      iter.variant iter variant
+  | Ptyp_poly (vars, typ) ->
+      List.iter ~f:(iter.type_expr iter) vars ;
+      iter.type_expr iter typ
+
+let variant iter {var_ident; var_params; var_implicit_params} =
+  iter.location iter var_ident.loc ;
+  iter.longident iter var_ident.txt ;
+  List.iter ~f:(iter.type_expr iter) var_params ;
+  List.iter ~f:(iter.type_expr iter) var_implicit_params
+
+let field_decl iter {fld_ident; fld_type; fld_loc} =
+  iter.location iter fld_loc ;
+  iter.location iter fld_ident.loc ;
+  iter.type_expr iter fld_type
+
+let ctor_args iter = function
+  | Ctor_tuple typs ->
+      List.iter ~f:(iter.type_expr iter) typs
+  | Ctor_record fields ->
+      List.iter ~f:(iter.field_decl iter) fields
+
+let ctor_decl iter {ctor_ident; ctor_args; ctor_ret; ctor_loc} =
+  iter.location iter ctor_loc ;
+  iter.location iter ctor_ident.loc ;
+  iter.ctor_args iter ctor_args ;
+  Option.iter ~f:(iter.type_expr iter) ctor_ret
+
+let type_decl iter
+    {tdec_ident; tdec_params; tdec_implicit_params; tdec_desc; tdec_loc} =
+  iter.location iter tdec_loc ;
+  iter.location iter tdec_ident.loc ;
+  List.iter ~f:(iter.type_expr iter) tdec_params ;
+  List.iter ~f:(iter.type_expr iter) tdec_implicit_params ;
+  iter.type_decl_desc iter tdec_desc
+
+let type_decl_desc iter = function
+  | TAbstract ->
+      ()
+  | TAlias typ ->
+      iter.type_expr iter typ
+  | TUnfold typ ->
+      iter.type_expr iter typ
+  | TRecord fields ->
+      List.iter ~f:(iter.field_decl iter) fields
+  | TVariant ctors ->
+      List.iter ~f:(iter.ctor_decl iter) ctors
+  | TOpen ->
+      ()
+  | TExtend (name, decl, ctors) ->
+      iter.location iter name.loc ;
+      iter.type0_decl iter decl ;
+      List.iter ~f:(iter.ctor_decl iter) ctors
+  | TForward _ ->
+      ()
+
+let literal (_iter : iterator) (_ : literal) = ()
+
+let pattern iter {pat_desc; pat_loc} =
+  iter.location iter pat_loc ;
+  iter.pattern_desc iter pat_desc
+
+let pattern_desc iter = function
+  | Ppat_any ->
+      ()
+  | Ppat_variable name ->
+      iter.location iter name.loc
+  | Ppat_constraint (pat, typ) ->
+      iter.type_expr iter typ ; iter.pattern iter pat
+  | Ppat_tuple pats ->
+      List.iter ~f:(iter.pattern iter) pats
+  | Ppat_or (p1, p2) ->
+      iter.pattern iter p1 ; iter.pattern iter p2
+  | Ppat_int _ ->
+      ()
+  | Ppat_record fields ->
+      List.iter fields ~f:(fun (name, pat) ->
+          iter.location iter name.loc ;
+          iter.longident iter name.txt ;
+          iter.pattern iter pat )
+  | Ppat_ctor (name, arg) ->
+      iter.location iter name.loc ;
+      iter.longident iter name.txt ;
+      Option.iter ~f:(iter.pattern iter) arg
+
+let expression iter {exp_desc; exp_loc} =
+  iter.location iter exp_loc ;
+  iter.expression_desc iter exp_desc
+
+let expression_desc iter = function
+  | Pexp_apply (e, args) ->
+      iter.expression iter e ;
+      List.iter args ~f:(fun (_label, e) -> iter.expression iter e)
+  | Pexp_variable name ->
+      iter.location iter name.loc ;
+      iter.longident iter name.txt
+  | Pexp_literal l ->
+      iter.literal iter l
+  | Pexp_fun (_label, p, e, _explicit) ->
+      iter.pattern iter p ; iter.expression iter e
+  | Pexp_newtype (name, e) ->
+      iter.location iter name.loc ;
+      iter.expression iter e
+  | Pexp_seq (e1, e2) ->
+      iter.expression iter e1 ; iter.expression iter e2
+  | Pexp_let (p, e1, e2) ->
+      iter.pattern iter p ; iter.expression iter e1 ; iter.expression iter e2
+  | Pexp_constraint (e, typ) ->
+      iter.type_expr iter typ ; iter.expression iter e
+  | Pexp_tuple es ->
+      List.iter ~f:(iter.expression iter) es
+  | Pexp_match (e, cases) ->
+      iter.expression iter e ;
+      List.iter cases ~f:(fun (p, e) ->
+          iter.pattern iter p ; iter.expression iter e )
+  | Pexp_field (e, name) ->
+      iter.location iter name.loc ;
+      iter.longident iter name.txt ;
+      iter.expression iter e
+  | Pexp_record (bindings, default) ->
+      Option.iter ~f:(iter.expression iter) default ;
+      List.iter bindings ~f:(fun (name, e) ->
+          iter.location iter name.loc ;
+          iter.longident iter name.txt ;
+          iter.expression iter e )
+  | Pexp_ctor (name, arg) ->
+      iter.location iter name.loc ;
+      iter.longident iter name.txt ;
+      Option.iter ~f:(iter.expression iter) arg
+  | Pexp_unifiable {expression; name; id= _} ->
+      iter.location iter name.loc ;
+      Option.iter ~f:(iter.expression iter) expression
+  | Pexp_if (e1, e2, e3) ->
+      iter.expression iter e1 ;
+      iter.expression iter e2 ;
+      Option.iter ~f:(iter.expression iter) e3
+
+let signature iter = List.iter ~f:(iter.signature_item iter)
+
+let signature_item iter {sig_desc; sig_loc} =
+  iter.location iter sig_loc ;
+  iter.signature_desc iter sig_desc
+
+let signature_desc iter = function
+  | Psig_value (name, typ) | Psig_instance (name, typ) ->
+      iter.location iter name.loc ;
+      iter.type_expr iter typ
+  | Psig_type decl ->
+      iter.type_decl iter decl
+  | Psig_module (name, msig) | Psig_modtype (name, msig) ->
+      iter.location iter name.loc ;
+      iter.module_sig iter msig
+  | Psig_open name ->
+      iter.location iter name.loc ;
+      iter.longident iter name.txt
+  | Psig_typeext (typ, ctors) ->
+      iter.variant iter typ ;
+      List.iter ~f:(iter.ctor_decl iter) ctors
+  | Psig_request (typ, ctor) ->
+      iter.type_expr iter typ ; iter.ctor_decl iter ctor
+  | Psig_multiple sigs ->
+      iter.signature iter sigs
+
+let module_sig iter {msig_desc; msig_loc} =
+  iter.location iter msig_loc ;
+  iter.module_sig_desc iter msig_desc
+
+let module_sig_desc iter = function
+  | Pmty_sig sigs ->
+      iter.signature iter sigs
+  | Pmty_name name ->
+      iter.location iter name.loc ;
+      iter.longident iter name.txt
+  | Pmty_abstract ->
+      ()
+  | Pmty_functor (name, fsig, msig) ->
+      iter.location iter name.loc ;
+      iter.module_sig iter fsig ;
+      iter.module_sig iter msig
+
+let statements iter = List.iter ~f:(iter.statement iter)
+
+let statement iter {stmt_desc; stmt_loc} =
+  iter.location iter stmt_loc ;
+  iter.statement_desc iter stmt_desc
+
+let statement_desc iter = function
+  | Pstmt_value (p, e) ->
+      iter.pattern iter p ; iter.expression iter e
+  | Pstmt_instance (name, e) ->
+      iter.location iter name.loc ;
+      iter.expression iter e
+  | Pstmt_type decl ->
+      iter.type_decl iter decl
+  | Pstmt_module (name, me) ->
+      iter.location iter name.loc ;
+      iter.module_expr iter me
+  | Pstmt_modtype (name, mty) ->
+      iter.location iter name.loc ;
+      iter.module_sig iter mty
+  | Pstmt_open name ->
+      iter.location iter name.loc ;
+      iter.longident iter name.txt
+  | Pstmt_typeext (typ, ctors) ->
+      iter.variant iter typ ;
+      List.iter ~f:(iter.ctor_decl iter) ctors
+  | Pstmt_request (typ, ctor, handler) ->
+      iter.type_expr iter typ ;
+      iter.ctor_decl iter ctor ;
+      Option.iter handler ~f:(fun (p, e) ->
+          Option.iter ~f:(iter.pattern iter) p ;
+          iter.expression iter e )
+  | Pstmt_multiple stmts ->
+      iter.statements iter stmts
+
+let module_expr iter {mod_desc; mod_loc} =
+  iter.location iter mod_loc ;
+  iter.module_desc iter mod_desc
+
+let module_desc iter = function
+  | Pmod_struct stmts ->
+      iter.statements iter stmts
+  | Pmod_name name ->
+      iter.location iter name.loc ;
+      iter.longident iter name.txt
+  | Pmod_functor (name, fsig, me) ->
+      iter.location iter name.loc ;
+      iter.module_sig iter fsig ;
+      iter.module_expr iter me
+
+let location (_iter : iterator) (_ : Location.t) = ()
+
+let longident iter = function
+  | Longident.Lident _ ->
+      ()
+  | Ldot (l, _) ->
+      iter.longident iter l
+  | Lapply (l1, l2) ->
+      iter.longident iter l1 ; iter.longident iter l2
+
+(** Stub. This isn't part of the parsetypes, so we don't do anything by
+    default.
+*)
+let type0_decl (_iter : iterator) (_ : Type0.type_decl) = ()
+
+let default_iterator =
+  { type_expr
+  ; type_desc
+  ; variant
+  ; field_decl
+  ; ctor_args
+  ; ctor_decl
+  ; type_decl
+  ; type_decl_desc
+  ; literal
+  ; pattern
+  ; pattern_desc
+  ; expression
+  ; expression_desc
+  ; signature_item
+  ; signature
+  ; signature_desc
+  ; module_sig
+  ; module_sig_desc
+  ; statement
+  ; statements
+  ; statement_desc
+  ; module_expr
+  ; module_desc
+  ; location
+  ; longident
+  ; type0_decl }

--- a/meja/src/parsetypes_map.ml
+++ b/meja/src/parsetypes_map.ml
@@ -1,0 +1,329 @@
+open Core_kernel
+open Parsetypes
+open Ast_types
+
+type mapper =
+  { type_expr: mapper -> type_expr -> type_expr
+  ; type_desc: mapper -> type_desc -> type_desc
+  ; variant: mapper -> variant -> variant
+  ; field_decl: mapper -> field_decl -> field_decl
+  ; ctor_args: mapper -> ctor_args -> ctor_args
+  ; ctor_decl: mapper -> ctor_decl -> ctor_decl
+  ; type_decl: mapper -> type_decl -> type_decl
+  ; type_decl_desc: mapper -> type_decl_desc -> type_decl_desc
+  ; literal: mapper -> literal -> literal
+  ; pattern: mapper -> pattern -> pattern
+  ; pattern_desc: mapper -> pattern_desc -> pattern_desc
+  ; expression: mapper -> expression -> expression
+  ; expression_desc: mapper -> expression_desc -> expression_desc
+  ; signature_item: mapper -> signature_item -> signature_item
+  ; signature: mapper -> signature -> signature
+  ; signature_desc: mapper -> signature_desc -> signature_desc
+  ; module_sig: mapper -> module_sig -> module_sig
+  ; module_sig_desc: mapper -> module_sig_desc -> module_sig_desc
+  ; statement: mapper -> statement -> statement
+  ; statements: mapper -> statements -> statements
+  ; statement_desc: mapper -> statement_desc -> statement_desc
+  ; module_expr: mapper -> module_expr -> module_expr
+  ; module_desc: mapper -> module_desc -> module_desc
+  ; location: mapper -> Location.t -> Location.t
+  ; longident: mapper -> Longident.t -> Longident.t
+  ; type0_decl: mapper -> Type0.type_decl -> Type0.type_decl }
+
+let lid mapper {Location.txt; loc} =
+  {Location.txt= mapper.longident mapper txt; loc= mapper.location mapper loc}
+
+let str mapper ({Location.txt; loc} : str) =
+  {Location.txt; loc= mapper.location mapper loc}
+
+let type_expr mapper {type_desc; type_loc} =
+  let type_loc = mapper.location mapper type_loc in
+  let type_desc = mapper.type_desc mapper type_desc in
+  {type_desc; type_loc}
+
+let type_desc mapper typ =
+  match typ with
+  | Ptyp_var (name, explicit) ->
+      Ptyp_var (Option.map ~f:(str mapper) name, explicit)
+  | Ptyp_tuple typs ->
+      Ptyp_tuple (List.map ~f:(mapper.type_expr mapper) typs)
+  | Ptyp_arrow (typ1, typ2, explicit, label) ->
+      Ptyp_arrow
+        ( mapper.type_expr mapper typ1
+        , mapper.type_expr mapper typ2
+        , explicit
+        , label )
+  | Ptyp_ctor variant ->
+      Ptyp_ctor (mapper.variant mapper variant)
+  | Ptyp_poly (vars, typ) ->
+      Ptyp_poly
+        ( List.map ~f:(mapper.type_expr mapper) vars
+        , mapper.type_expr mapper typ )
+
+let variant mapper {var_ident; var_params; var_implicit_params} =
+  { var_ident= lid mapper var_ident
+  ; var_params= List.map ~f:(mapper.type_expr mapper) var_params
+  ; var_implicit_params=
+      List.map ~f:(mapper.type_expr mapper) var_implicit_params }
+
+let field_decl mapper {fld_ident; fld_type; fld_loc} =
+  { fld_loc= mapper.location mapper fld_loc
+  ; fld_ident= str mapper fld_ident
+  ; fld_type= mapper.type_expr mapper fld_type }
+
+let ctor_args mapper = function
+  | Ctor_tuple typs ->
+      Ctor_tuple (List.map ~f:(mapper.type_expr mapper) typs)
+  | Ctor_record fields ->
+      Ctor_record (List.map ~f:(mapper.field_decl mapper) fields)
+
+let ctor_decl mapper {ctor_ident; ctor_args; ctor_ret; ctor_loc} =
+  { ctor_loc= mapper.location mapper ctor_loc
+  ; ctor_ident= str mapper ctor_ident
+  ; ctor_args= mapper.ctor_args mapper ctor_args
+  ; ctor_ret= Option.map ~f:(mapper.type_expr mapper) ctor_ret }
+
+let type_decl mapper
+    {tdec_ident; tdec_params; tdec_implicit_params; tdec_desc; tdec_loc} =
+  { tdec_loc= mapper.location mapper tdec_loc
+  ; tdec_ident= str mapper tdec_ident
+  ; tdec_params= List.map ~f:(mapper.type_expr mapper) tdec_params
+  ; tdec_implicit_params=
+      List.map ~f:(mapper.type_expr mapper) tdec_implicit_params
+  ; tdec_desc= mapper.type_decl_desc mapper tdec_desc }
+
+let type_decl_desc mapper = function
+  | TAbstract ->
+      TAbstract
+  | TAlias typ ->
+      TAlias (mapper.type_expr mapper typ)
+  | TUnfold typ ->
+      TUnfold (mapper.type_expr mapper typ)
+  | TRecord fields ->
+      TRecord (List.map ~f:(mapper.field_decl mapper) fields)
+  | TVariant ctors ->
+      TVariant (List.map ~f:(mapper.ctor_decl mapper) ctors)
+  | TOpen ->
+      TOpen
+  | TExtend (name, decl, ctors) ->
+      TExtend
+        ( lid mapper name
+        , mapper.type0_decl mapper decl
+        , List.map ~f:(mapper.ctor_decl mapper) ctors )
+  | TForward i ->
+      TForward i
+
+let literal (_iter : mapper) (l : literal) = l
+
+let pattern mapper {pat_desc; pat_loc} =
+  { pat_loc= mapper.location mapper pat_loc
+  ; pat_desc= mapper.pattern_desc mapper pat_desc }
+
+let pattern_desc mapper = function
+  | Ppat_any ->
+      Ppat_any
+  | Ppat_variable name ->
+      Ppat_variable (str mapper name)
+  | Ppat_constraint (pat, typ) ->
+      Ppat_constraint (mapper.pattern mapper pat, mapper.type_expr mapper typ)
+  | Ppat_tuple pats ->
+      Ppat_tuple (List.map ~f:(mapper.pattern mapper) pats)
+  | Ppat_or (p1, p2) ->
+      Ppat_or (mapper.pattern mapper p1, mapper.pattern mapper p2)
+  | Ppat_int i ->
+      Ppat_int i
+  | Ppat_record fields ->
+      Ppat_record
+        (List.map fields ~f:(fun (name, pat) ->
+             (lid mapper name, mapper.pattern mapper pat) ))
+  | Ppat_ctor (name, arg) ->
+      Ppat_ctor (lid mapper name, Option.map ~f:(mapper.pattern mapper) arg)
+
+let expression mapper {exp_desc; exp_loc} =
+  { exp_loc= mapper.location mapper exp_loc
+  ; exp_desc= mapper.expression_desc mapper exp_desc }
+
+let expression_desc mapper = function
+  | Pexp_apply (e, args) ->
+      Pexp_apply
+        ( mapper.expression mapper e
+        , List.map args ~f:(fun (label, e) ->
+              (label, mapper.expression mapper e) ) )
+  | Pexp_variable name ->
+      Pexp_variable (lid mapper name)
+  | Pexp_literal l ->
+      Pexp_literal (mapper.literal mapper l)
+  | Pexp_fun (label, p, e, explicit) ->
+      Pexp_fun
+        (label, mapper.pattern mapper p, mapper.expression mapper e, explicit)
+  | Pexp_newtype (name, e) ->
+      Pexp_newtype (str mapper name, mapper.expression mapper e)
+  | Pexp_seq (e1, e2) ->
+      Pexp_seq (mapper.expression mapper e1, mapper.expression mapper e2)
+  | Pexp_let (p, e1, e2) ->
+      Pexp_let
+        ( mapper.pattern mapper p
+        , mapper.expression mapper e1
+        , mapper.expression mapper e2 )
+  | Pexp_constraint (e, typ) ->
+      Pexp_constraint (mapper.expression mapper e, mapper.type_expr mapper typ)
+  | Pexp_tuple es ->
+      Pexp_tuple (List.map ~f:(mapper.expression mapper) es)
+  | Pexp_match (e, cases) ->
+      Pexp_match
+        ( mapper.expression mapper e
+        , List.map cases ~f:(fun (p, e) ->
+              (mapper.pattern mapper p, mapper.expression mapper e) ) )
+  | Pexp_field (e, name) ->
+      Pexp_field (mapper.expression mapper e, lid mapper name)
+  | Pexp_record (bindings, default) ->
+      Pexp_record
+        ( List.map bindings ~f:(fun (name, e) ->
+              (lid mapper name, mapper.expression mapper e) )
+        , Option.map ~f:(mapper.expression mapper) default )
+  | Pexp_ctor (name, arg) ->
+      Pexp_ctor (lid mapper name, Option.map ~f:(mapper.expression mapper) arg)
+  | Pexp_unifiable {expression; name; id} ->
+      Pexp_unifiable
+        { id
+        ; name= str mapper name
+        ; expression= Option.map ~f:(mapper.expression mapper) expression }
+  | Pexp_if (e1, e2, e3) ->
+      Pexp_if
+        ( mapper.expression mapper e1
+        , mapper.expression mapper e2
+        , Option.map ~f:(mapper.expression mapper) e3 )
+
+let signature mapper = List.map ~f:(mapper.signature_item mapper)
+
+let signature_item mapper {sig_desc; sig_loc} =
+  { sig_loc= mapper.location mapper sig_loc
+  ; sig_desc= mapper.signature_desc mapper sig_desc }
+
+let signature_desc mapper = function
+  | Psig_value (name, typ) ->
+      Psig_value (str mapper name, mapper.type_expr mapper typ)
+  | Psig_instance (name, typ) ->
+      Psig_instance (str mapper name, mapper.type_expr mapper typ)
+  | Psig_type decl ->
+      Psig_type (mapper.type_decl mapper decl)
+  | Psig_module (name, msig) ->
+      Psig_module (str mapper name, mapper.module_sig mapper msig)
+  | Psig_modtype (name, msig) ->
+      Psig_modtype (str mapper name, mapper.module_sig mapper msig)
+  | Psig_open name ->
+      Psig_open (lid mapper name)
+  | Psig_typeext (typ, ctors) ->
+      Psig_typeext
+        (mapper.variant mapper typ, List.map ~f:(mapper.ctor_decl mapper) ctors)
+  | Psig_request (typ, ctor) ->
+      Psig_request (mapper.type_expr mapper typ, mapper.ctor_decl mapper ctor)
+  | Psig_multiple sigs ->
+      Psig_multiple (mapper.signature mapper sigs)
+
+let module_sig mapper {msig_desc; msig_loc} =
+  { msig_loc= mapper.location mapper msig_loc
+  ; msig_desc= mapper.module_sig_desc mapper msig_desc }
+
+let module_sig_desc mapper = function
+  | Pmty_sig sigs ->
+      Pmty_sig (mapper.signature mapper sigs)
+  | Pmty_name name ->
+      Pmty_name (lid mapper name)
+  | Pmty_abstract ->
+      Pmty_abstract
+  | Pmty_functor (name, fsig, msig) ->
+      Pmty_functor
+        ( str mapper name
+        , mapper.module_sig mapper fsig
+        , mapper.module_sig mapper msig )
+
+let statements mapper = List.map ~f:(mapper.statement mapper)
+
+let statement mapper {stmt_desc; stmt_loc} =
+  { stmt_loc= mapper.location mapper stmt_loc
+  ; stmt_desc= mapper.statement_desc mapper stmt_desc }
+
+let statement_desc mapper = function
+  | Pstmt_value (p, e) ->
+      Pstmt_value (mapper.pattern mapper p, mapper.expression mapper e)
+  | Pstmt_instance (name, e) ->
+      Pstmt_instance (str mapper name, mapper.expression mapper e)
+  | Pstmt_type decl ->
+      Pstmt_type (mapper.type_decl mapper decl)
+  | Pstmt_module (name, me) ->
+      Pstmt_module (str mapper name, mapper.module_expr mapper me)
+  | Pstmt_modtype (name, mty) ->
+      Pstmt_modtype (str mapper name, mapper.module_sig mapper mty)
+  | Pstmt_open name ->
+      Pstmt_open (lid mapper name)
+  | Pstmt_typeext (typ, ctors) ->
+      Pstmt_typeext
+        (mapper.variant mapper typ, List.map ~f:(mapper.ctor_decl mapper) ctors)
+  | Pstmt_request (typ, ctor, handler) ->
+      Pstmt_request
+        ( mapper.type_expr mapper typ
+        , mapper.ctor_decl mapper ctor
+        , Option.map handler ~f:(fun (p, e) ->
+              ( Option.map ~f:(mapper.pattern mapper) p
+              , mapper.expression mapper e ) ) )
+  | Pstmt_multiple stmts ->
+      Pstmt_multiple (mapper.statements mapper stmts)
+
+let module_expr mapper {mod_desc; mod_loc} =
+  { mod_loc= mapper.location mapper mod_loc
+  ; mod_desc= mapper.module_desc mapper mod_desc }
+
+let module_desc mapper = function
+  | Pmod_struct stmts ->
+      Pmod_struct (mapper.statements mapper stmts)
+  | Pmod_name name ->
+      Pmod_name (lid mapper name)
+  | Pmod_functor (name, fsig, me) ->
+      Pmod_functor
+        ( str mapper name
+        , mapper.module_sig mapper fsig
+        , mapper.module_expr mapper me )
+
+let location (_iter : mapper) (loc : Location.t) = loc
+
+let longident mapper = function
+  | Longident.Lident str ->
+      Longident.Lident str
+  | Ldot (l, str) ->
+      Ldot (mapper.longident mapper l, str)
+  | Lapply (l1, l2) ->
+      Lapply (mapper.longident mapper l1, mapper.longident mapper l2)
+
+(** Stub. This isn't part of the parsetypes, so we don't do anything by
+    default.
+*)
+let type0_decl (_iter : mapper) (decl : Type0.type_decl) = decl
+
+let default_iterator =
+  { type_expr
+  ; type_desc
+  ; variant
+  ; field_decl
+  ; ctor_args
+  ; ctor_decl
+  ; type_decl
+  ; type_decl_desc
+  ; literal
+  ; pattern
+  ; pattern_desc
+  ; expression
+  ; expression_desc
+  ; signature_item
+  ; signature
+  ; signature_desc
+  ; module_sig
+  ; module_sig_desc
+  ; statement
+  ; statements
+  ; statement_desc
+  ; module_expr
+  ; module_desc
+  ; location
+  ; longident
+  ; type0_decl }

--- a/meja/src/pprint.ml
+++ b/meja/src/pprint.ml
@@ -51,7 +51,7 @@ let ctor_args fmt = function
       ()
   | Ctor_tuple typs ->
       tuple fmt typs
-  | Ctor_record (_, fields) ->
+  | Ctor_record fields ->
       fprintf fmt "{@[<2>%a@]}"
         (pp_print_list ~pp_sep:comma_sep field_decl)
         fields

--- a/meja/src/typedast.ml
+++ b/meja/src/typedast.ml
@@ -41,6 +41,8 @@ and expression_desc =
 
 type signature_item = {sig_desc: signature_desc; sig_loc: Location.t}
 
+and signature = signature_item list
+
 and signature_desc =
   | Tsig_value of str * type_expr
   | Tsig_instance of str * type_expr
@@ -50,17 +52,19 @@ and signature_desc =
   | Tsig_open of lid
   | Tsig_typeext of variant * ctor_decl list
   | Tsig_request of type_expr * ctor_decl
-  | Tsig_multiple of signature_item list
+  | Tsig_multiple of signature
 
 and module_sig = {msig_desc: module_sig_desc; msig_loc: Location.t}
 
 and module_sig_desc =
-  | Tmty_sig of signature_item list
+  | Tmty_sig of signature
   | Tmty_name of lid
   | Tmty_abstract
   | Tmty_functor of str * module_sig * module_sig
 
 type statement = {stmt_desc: statement_desc; stmt_loc: Location.t}
+
+and statements = statement list
 
 and statement_desc =
   | Tstmt_value of pattern * expression
@@ -72,11 +76,11 @@ and statement_desc =
   | Tstmt_typeext of variant * ctor_decl list
   | Tstmt_request of
       type_expr * ctor_decl * (pattern option * expression) option
-  | Tstmt_multiple of statement list
+  | Tstmt_multiple of statements
 
 and module_expr = {mod_desc: module_desc; mod_loc: Location.t}
 
 and module_desc =
-  | Tmod_struct of statement list
+  | Tmod_struct of statements
   | Tmod_name of lid
   | Tmod_functor of str * module_sig * module_expr

--- a/meja/src/typedast_iter.ml
+++ b/meja/src/typedast_iter.ml
@@ -95,6 +95,7 @@ let type_decl_desc iter = function
       ()
   | TExtend (name, decl, ctors) ->
       iter.location iter name.loc ;
+      iter.longident iter name.txt ;
       iter.type0_decl iter decl ;
       List.iter ~f:(iter.ctor_decl iter) ctors
   | TForward _ ->

--- a/meja/src/typedast_iter.ml
+++ b/meja/src/typedast_iter.ml
@@ -1,0 +1,324 @@
+open Core_kernel
+open Typedast
+open Ast_types
+
+type iterator =
+  { type_expr: iterator -> Parsetypes.type_expr -> unit
+  ; type_desc: iterator -> Parsetypes.type_desc -> unit
+  ; variant: iterator -> Parsetypes.variant -> unit
+  ; field_decl: iterator -> Parsetypes.field_decl -> unit
+  ; ctor_args: iterator -> Parsetypes.ctor_args -> unit
+  ; ctor_decl: iterator -> Parsetypes.ctor_decl -> unit
+  ; type_decl: iterator -> Parsetypes.type_decl -> unit
+  ; type_decl_desc: iterator -> Parsetypes.type_decl_desc -> unit
+  ; literal: iterator -> literal -> unit
+  ; pattern: iterator -> pattern -> unit
+  ; pattern_desc: iterator -> pattern_desc -> unit
+  ; expression: iterator -> expression -> unit
+  ; expression_desc: iterator -> expression_desc -> unit
+  ; signature_item: iterator -> signature_item -> unit
+  ; signature: iterator -> signature -> unit
+  ; signature_desc: iterator -> signature_desc -> unit
+  ; module_sig: iterator -> module_sig -> unit
+  ; module_sig_desc: iterator -> module_sig_desc -> unit
+  ; statement: iterator -> statement -> unit
+  ; statements: iterator -> statements -> unit
+  ; statement_desc: iterator -> statement_desc -> unit
+  ; module_expr: iterator -> module_expr -> unit
+  ; module_desc: iterator -> module_desc -> unit
+  ; location: iterator -> Location.t -> unit
+  ; longident: iterator -> Longident.t -> unit
+  ; type0_expr: iterator -> Type0.type_expr -> unit
+  ; type0_decl: iterator -> Type0.type_decl -> unit }
+
+let type_expr iter Parsetypes.{type_desc; type_loc} =
+  iter.location iter type_loc ;
+  iter.type_desc iter type_desc
+
+let type_desc iter = function
+  | Parsetypes.Ptyp_var (name, _) ->
+      Option.iter ~f:(fun name -> iter.location iter name.Location.loc) name
+  | Ptyp_tuple typs ->
+      List.iter ~f:(iter.type_expr iter) typs
+  | Ptyp_arrow (typ1, typ2, _, _) ->
+      iter.type_expr iter typ1 ; iter.type_expr iter typ2
+  | Ptyp_ctor variant ->
+      iter.variant iter variant
+  | Ptyp_poly (vars, typ) ->
+      List.iter ~f:(iter.type_expr iter) vars ;
+      iter.type_expr iter typ
+
+let variant iter Parsetypes.{var_ident; var_params; var_implicit_params} =
+  iter.location iter var_ident.loc ;
+  iter.longident iter var_ident.txt ;
+  List.iter ~f:(iter.type_expr iter) var_params ;
+  List.iter ~f:(iter.type_expr iter) var_implicit_params
+
+let field_decl iter Parsetypes.{fld_ident; fld_type; fld_loc} =
+  iter.location iter fld_loc ;
+  iter.location iter fld_ident.loc ;
+  iter.type_expr iter fld_type
+
+let ctor_args iter = function
+  | Parsetypes.Ctor_tuple typs ->
+      List.iter ~f:(iter.type_expr iter) typs
+  | Ctor_record fields ->
+      List.iter ~f:(iter.field_decl iter) fields
+
+let ctor_decl iter Parsetypes.{ctor_ident; ctor_args; ctor_ret; ctor_loc} =
+  iter.location iter ctor_loc ;
+  iter.location iter ctor_ident.loc ;
+  iter.ctor_args iter ctor_args ;
+  Option.iter ~f:(iter.type_expr iter) ctor_ret
+
+let type_decl iter
+    Parsetypes.
+      {tdec_ident; tdec_params; tdec_implicit_params; tdec_desc; tdec_loc} =
+  iter.location iter tdec_loc ;
+  iter.location iter tdec_ident.loc ;
+  List.iter ~f:(iter.type_expr iter) tdec_params ;
+  List.iter ~f:(iter.type_expr iter) tdec_implicit_params ;
+  iter.type_decl_desc iter tdec_desc
+
+let type_decl_desc iter = function
+  | Parsetypes.TAbstract ->
+      ()
+  | TAlias typ ->
+      iter.type_expr iter typ
+  | TUnfold typ ->
+      iter.type_expr iter typ
+  | TRecord fields ->
+      List.iter ~f:(iter.field_decl iter) fields
+  | TVariant ctors ->
+      List.iter ~f:(iter.ctor_decl iter) ctors
+  | TOpen ->
+      ()
+  | TExtend (name, decl, ctors) ->
+      iter.location iter name.loc ;
+      iter.type0_decl iter decl ;
+      List.iter ~f:(iter.ctor_decl iter) ctors
+  | TForward _ ->
+      ()
+
+let literal (_iter : iterator) (_ : literal) = ()
+
+let pattern iter {pat_desc; pat_loc; pat_type} =
+  iter.location iter pat_loc ;
+  iter.type0_expr iter pat_type ;
+  iter.pattern_desc iter pat_desc
+
+let pattern_desc iter = function
+  | Tpat_any ->
+      ()
+  | Tpat_variable name ->
+      iter.location iter name.loc
+  | Tpat_constraint (pat, typ) ->
+      iter.type_expr iter typ ; iter.pattern iter pat
+  | Tpat_tuple pats ->
+      List.iter ~f:(iter.pattern iter) pats
+  | Tpat_or (p1, p2) ->
+      iter.pattern iter p1 ; iter.pattern iter p2
+  | Tpat_int _ ->
+      ()
+  | Tpat_record fields ->
+      List.iter fields ~f:(fun (name, pat) ->
+          iter.location iter name.loc ;
+          iter.longident iter name.txt ;
+          iter.pattern iter pat )
+  | Tpat_ctor (name, arg) ->
+      iter.location iter name.loc ;
+      iter.longident iter name.txt ;
+      Option.iter ~f:(iter.pattern iter) arg
+
+let expression iter {exp_desc; exp_loc; exp_type} =
+  iter.location iter exp_loc ;
+  iter.type0_expr iter exp_type ;
+  iter.expression_desc iter exp_desc
+
+let expression_desc iter = function
+  | Texp_apply (e, args) ->
+      iter.expression iter e ;
+      List.iter args ~f:(fun (_label, e) -> iter.expression iter e)
+  | Texp_variable name ->
+      iter.location iter name.loc ;
+      iter.longident iter name.txt
+  | Texp_literal l ->
+      iter.literal iter l
+  | Texp_fun (_label, p, e, _explicit) ->
+      iter.pattern iter p ; iter.expression iter e
+  | Texp_newtype (name, e) ->
+      iter.location iter name.loc ;
+      iter.expression iter e
+  | Texp_seq (e1, e2) ->
+      iter.expression iter e1 ; iter.expression iter e2
+  | Texp_let (p, e1, e2) ->
+      iter.pattern iter p ; iter.expression iter e1 ; iter.expression iter e2
+  | Texp_constraint (e, typ) ->
+      iter.type_expr iter typ ; iter.expression iter e
+  | Texp_tuple es ->
+      List.iter ~f:(iter.expression iter) es
+  | Texp_match (e, cases) ->
+      iter.expression iter e ;
+      List.iter cases ~f:(fun (p, e) ->
+          iter.pattern iter p ; iter.expression iter e )
+  | Texp_field (e, name) ->
+      iter.location iter name.loc ;
+      iter.longident iter name.txt ;
+      iter.expression iter e
+  | Texp_record (bindings, default) ->
+      Option.iter ~f:(iter.expression iter) default ;
+      List.iter bindings ~f:(fun (name, e) ->
+          iter.location iter name.loc ;
+          iter.longident iter name.txt ;
+          iter.expression iter e )
+  | Texp_ctor (name, arg) ->
+      iter.location iter name.loc ;
+      iter.longident iter name.txt ;
+      Option.iter ~f:(iter.expression iter) arg
+  | Texp_unifiable {expression; name; id= _} ->
+      iter.location iter name.loc ;
+      Option.iter ~f:(iter.expression iter) expression
+  | Texp_if (e1, e2, e3) ->
+      iter.expression iter e1 ;
+      iter.expression iter e2 ;
+      Option.iter ~f:(iter.expression iter) e3
+
+let signature iter = List.iter ~f:(iter.signature_item iter)
+
+let signature_item iter {sig_desc; sig_loc} =
+  iter.location iter sig_loc ;
+  iter.signature_desc iter sig_desc
+
+let signature_desc iter = function
+  | Tsig_value (name, typ) | Tsig_instance (name, typ) ->
+      iter.location iter name.loc ;
+      iter.type_expr iter typ
+  | Tsig_type decl ->
+      iter.type_decl iter decl
+  | Tsig_module (name, msig) | Tsig_modtype (name, msig) ->
+      iter.location iter name.loc ;
+      iter.module_sig iter msig
+  | Tsig_open name ->
+      iter.location iter name.loc ;
+      iter.longident iter name.txt
+  | Tsig_typeext (typ, ctors) ->
+      iter.variant iter typ ;
+      List.iter ~f:(iter.ctor_decl iter) ctors
+  | Tsig_request (typ, ctor) ->
+      iter.type_expr iter typ ; iter.ctor_decl iter ctor
+  | Tsig_multiple sigs ->
+      iter.signature iter sigs
+
+let module_sig iter {msig_desc; msig_loc} =
+  iter.location iter msig_loc ;
+  iter.module_sig_desc iter msig_desc
+
+let module_sig_desc iter = function
+  | Tmty_sig sigs ->
+      iter.signature iter sigs
+  | Tmty_name name ->
+      iter.location iter name.loc ;
+      iter.longident iter name.txt
+  | Tmty_abstract ->
+      ()
+  | Tmty_functor (name, fsig, msig) ->
+      iter.location iter name.loc ;
+      iter.module_sig iter fsig ;
+      iter.module_sig iter msig
+
+let statements iter = List.iter ~f:(iter.statement iter)
+
+let statement iter {stmt_desc; stmt_loc} =
+  iter.location iter stmt_loc ;
+  iter.statement_desc iter stmt_desc
+
+let statement_desc iter = function
+  | Tstmt_value (p, e) ->
+      iter.pattern iter p ; iter.expression iter e
+  | Tstmt_instance (name, e) ->
+      iter.location iter name.loc ;
+      iter.expression iter e
+  | Tstmt_type decl ->
+      iter.type_decl iter decl
+  | Tstmt_module (name, me) ->
+      iter.location iter name.loc ;
+      iter.module_expr iter me
+  | Tstmt_modtype (name, mty) ->
+      iter.location iter name.loc ;
+      iter.module_sig iter mty
+  | Tstmt_open name ->
+      iter.location iter name.loc ;
+      iter.longident iter name.txt
+  | Tstmt_typeext (typ, ctors) ->
+      iter.variant iter typ ;
+      List.iter ~f:(iter.ctor_decl iter) ctors
+  | Tstmt_request (typ, ctor, handler) ->
+      iter.type_expr iter typ ;
+      iter.ctor_decl iter ctor ;
+      Option.iter handler ~f:(fun (p, e) ->
+          Option.iter ~f:(iter.pattern iter) p ;
+          iter.expression iter e )
+  | Tstmt_multiple stmts ->
+      iter.statements iter stmts
+
+let module_expr iter {mod_desc; mod_loc} =
+  iter.location iter mod_loc ;
+  iter.module_desc iter mod_desc
+
+let module_desc iter = function
+  | Tmod_struct stmts ->
+      iter.statements iter stmts
+  | Tmod_name name ->
+      iter.location iter name.loc ;
+      iter.longident iter name.txt
+  | Tmod_functor (name, fsig, me) ->
+      iter.location iter name.loc ;
+      iter.module_sig iter fsig ;
+      iter.module_expr iter me
+
+let location (_iter : iterator) (_ : Location.t) = ()
+
+let longident iter = function
+  | Longident.Lident _ ->
+      ()
+  | Ldot (l, _) ->
+      iter.longident iter l
+  | Lapply (l1, l2) ->
+      iter.longident iter l1 ; iter.longident iter l2
+
+(** Stub. This isn't part of the typedast, so we don't do anything by default.
+*)
+let type0_decl (_iter : iterator) (_ : Type0.type_decl) = ()
+
+(** Stub. This isn't part of the typedast, so we don't do anything by default.
+*)
+let type0_expr (_iter : iterator) (_ : Type0.type_expr) = ()
+
+let default_iterator =
+  { type_expr
+  ; type_desc
+  ; variant
+  ; field_decl
+  ; ctor_args
+  ; ctor_decl
+  ; type_decl
+  ; type_decl_desc
+  ; literal
+  ; pattern
+  ; pattern_desc
+  ; expression
+  ; expression_desc
+  ; signature_item
+  ; signature
+  ; signature_desc
+  ; module_sig
+  ; module_sig_desc
+  ; statement
+  ; statements
+  ; statement_desc
+  ; module_expr
+  ; module_desc
+  ; location
+  ; longident
+  ; type0_decl
+  ; type0_expr }

--- a/meja/src/typedast_map.ml
+++ b/meja/src/typedast_map.ml
@@ -1,0 +1,340 @@
+open Core_kernel
+open Typedast
+open Ast_types
+
+type mapper =
+  { type_expr: mapper -> Parsetypes.type_expr -> Parsetypes.type_expr
+  ; type_desc: mapper -> Parsetypes.type_desc -> Parsetypes.type_desc
+  ; variant: mapper -> Parsetypes.variant -> Parsetypes.variant
+  ; field_decl: mapper -> Parsetypes.field_decl -> Parsetypes.field_decl
+  ; ctor_args: mapper -> Parsetypes.ctor_args -> Parsetypes.ctor_args
+  ; ctor_decl: mapper -> Parsetypes.ctor_decl -> Parsetypes.ctor_decl
+  ; type_decl: mapper -> Parsetypes.type_decl -> Parsetypes.type_decl
+  ; type_decl_desc:
+      mapper -> Parsetypes.type_decl_desc -> Parsetypes.type_decl_desc
+  ; literal: mapper -> literal -> literal
+  ; pattern: mapper -> pattern -> pattern
+  ; pattern_desc: mapper -> pattern_desc -> pattern_desc
+  ; expression: mapper -> expression -> expression
+  ; expression_desc: mapper -> expression_desc -> expression_desc
+  ; signature_item: mapper -> signature_item -> signature_item
+  ; signature: mapper -> signature -> signature
+  ; signature_desc: mapper -> signature_desc -> signature_desc
+  ; module_sig: mapper -> module_sig -> module_sig
+  ; module_sig_desc: mapper -> module_sig_desc -> module_sig_desc
+  ; statement: mapper -> statement -> statement
+  ; statements: mapper -> statements -> statements
+  ; statement_desc: mapper -> statement_desc -> statement_desc
+  ; module_expr: mapper -> module_expr -> module_expr
+  ; module_desc: mapper -> module_desc -> module_desc
+  ; location: mapper -> Location.t -> Location.t
+  ; longident: mapper -> Longident.t -> Longident.t
+  ; type0_decl: mapper -> Type0.type_decl -> Type0.type_decl
+  ; type0_expr: mapper -> Type0.type_expr -> Type0.type_expr }
+
+let lid mapper {Location.txt; loc} =
+  {Location.txt= mapper.longident mapper txt; loc= mapper.location mapper loc}
+
+let str mapper ({Location.txt; loc} : str) =
+  {Location.txt; loc= mapper.location mapper loc}
+
+let type_expr mapper Parsetypes.{type_desc; type_loc} =
+  let type_loc = mapper.location mapper type_loc in
+  let type_desc = mapper.type_desc mapper type_desc in
+  {Parsetypes.type_desc; type_loc}
+
+let type_desc mapper typ =
+  match typ with
+  | Parsetypes.Ptyp_var (name, explicit) ->
+      Parsetypes.Ptyp_var (Option.map ~f:(str mapper) name, explicit)
+  | Ptyp_tuple typs ->
+      Ptyp_tuple (List.map ~f:(mapper.type_expr mapper) typs)
+  | Ptyp_arrow (typ1, typ2, explicit, label) ->
+      Ptyp_arrow
+        ( mapper.type_expr mapper typ1
+        , mapper.type_expr mapper typ2
+        , explicit
+        , label )
+  | Ptyp_ctor variant ->
+      Ptyp_ctor (mapper.variant mapper variant)
+  | Ptyp_poly (vars, typ) ->
+      Ptyp_poly
+        ( List.map ~f:(mapper.type_expr mapper) vars
+        , mapper.type_expr mapper typ )
+
+let variant mapper Parsetypes.{var_ident; var_params; var_implicit_params} =
+  { Parsetypes.var_ident= lid mapper var_ident
+  ; var_params= List.map ~f:(mapper.type_expr mapper) var_params
+  ; var_implicit_params=
+      List.map ~f:(mapper.type_expr mapper) var_implicit_params }
+
+let field_decl mapper Parsetypes.{fld_ident; fld_type; fld_loc} =
+  { Parsetypes.fld_loc= mapper.location mapper fld_loc
+  ; fld_ident= str mapper fld_ident
+  ; fld_type= mapper.type_expr mapper fld_type }
+
+let ctor_args mapper = function
+  | Parsetypes.Ctor_tuple typs ->
+      Parsetypes.Ctor_tuple (List.map ~f:(mapper.type_expr mapper) typs)
+  | Ctor_record fields ->
+      Ctor_record (List.map ~f:(mapper.field_decl mapper) fields)
+
+let ctor_decl mapper Parsetypes.{ctor_ident; ctor_args; ctor_ret; ctor_loc} =
+  { Parsetypes.ctor_loc= mapper.location mapper ctor_loc
+  ; ctor_ident= str mapper ctor_ident
+  ; ctor_args= mapper.ctor_args mapper ctor_args
+  ; ctor_ret= Option.map ~f:(mapper.type_expr mapper) ctor_ret }
+
+let type_decl mapper
+    Parsetypes.
+      {tdec_ident; tdec_params; tdec_implicit_params; tdec_desc; tdec_loc} =
+  { Parsetypes.tdec_loc= mapper.location mapper tdec_loc
+  ; tdec_ident= str mapper tdec_ident
+  ; tdec_params= List.map ~f:(mapper.type_expr mapper) tdec_params
+  ; tdec_implicit_params=
+      List.map ~f:(mapper.type_expr mapper) tdec_implicit_params
+  ; tdec_desc= mapper.type_decl_desc mapper tdec_desc }
+
+let type_decl_desc mapper = function
+  | Parsetypes.TAbstract ->
+      Parsetypes.TAbstract
+  | TAlias typ ->
+      TAlias (mapper.type_expr mapper typ)
+  | TUnfold typ ->
+      TUnfold (mapper.type_expr mapper typ)
+  | TRecord fields ->
+      TRecord (List.map ~f:(mapper.field_decl mapper) fields)
+  | TVariant ctors ->
+      TVariant (List.map ~f:(mapper.ctor_decl mapper) ctors)
+  | TOpen ->
+      TOpen
+  | TExtend (name, decl, ctors) ->
+      TExtend
+        ( lid mapper name
+        , mapper.type0_decl mapper decl
+        , List.map ~f:(mapper.ctor_decl mapper) ctors )
+  | TForward i ->
+      TForward i
+
+let literal (_iter : mapper) (l : literal) = l
+
+let pattern mapper {pat_desc; pat_loc; pat_type} =
+  { pat_loc= mapper.location mapper pat_loc
+  ; pat_desc= mapper.pattern_desc mapper pat_desc
+  ; pat_type= mapper.type0_expr mapper pat_type }
+
+let pattern_desc mapper = function
+  | Tpat_any ->
+      Tpat_any
+  | Tpat_variable name ->
+      Tpat_variable (str mapper name)
+  | Tpat_constraint (pat, typ) ->
+      Tpat_constraint (mapper.pattern mapper pat, mapper.type_expr mapper typ)
+  | Tpat_tuple pats ->
+      Tpat_tuple (List.map ~f:(mapper.pattern mapper) pats)
+  | Tpat_or (p1, p2) ->
+      Tpat_or (mapper.pattern mapper p1, mapper.pattern mapper p2)
+  | Tpat_int i ->
+      Tpat_int i
+  | Tpat_record fields ->
+      Tpat_record
+        (List.map fields ~f:(fun (name, pat) ->
+             (lid mapper name, mapper.pattern mapper pat) ))
+  | Tpat_ctor (name, arg) ->
+      Tpat_ctor (lid mapper name, Option.map ~f:(mapper.pattern mapper) arg)
+
+let expression mapper {exp_desc; exp_loc; exp_type} =
+  { exp_loc= mapper.location mapper exp_loc
+  ; exp_desc= mapper.expression_desc mapper exp_desc
+  ; exp_type= mapper.type0_expr mapper exp_type }
+
+let expression_desc mapper = function
+  | Texp_apply (e, args) ->
+      Texp_apply
+        ( mapper.expression mapper e
+        , List.map args ~f:(fun (label, e) ->
+              (label, mapper.expression mapper e) ) )
+  | Texp_variable name ->
+      Texp_variable (lid mapper name)
+  | Texp_literal l ->
+      Texp_literal (mapper.literal mapper l)
+  | Texp_fun (label, p, e, explicit) ->
+      Texp_fun
+        (label, mapper.pattern mapper p, mapper.expression mapper e, explicit)
+  | Texp_newtype (name, e) ->
+      Texp_newtype (str mapper name, mapper.expression mapper e)
+  | Texp_seq (e1, e2) ->
+      Texp_seq (mapper.expression mapper e1, mapper.expression mapper e2)
+  | Texp_let (p, e1, e2) ->
+      Texp_let
+        ( mapper.pattern mapper p
+        , mapper.expression mapper e1
+        , mapper.expression mapper e2 )
+  | Texp_constraint (e, typ) ->
+      Texp_constraint (mapper.expression mapper e, mapper.type_expr mapper typ)
+  | Texp_tuple es ->
+      Texp_tuple (List.map ~f:(mapper.expression mapper) es)
+  | Texp_match (e, cases) ->
+      Texp_match
+        ( mapper.expression mapper e
+        , List.map cases ~f:(fun (p, e) ->
+              (mapper.pattern mapper p, mapper.expression mapper e) ) )
+  | Texp_field (e, name) ->
+      Texp_field (mapper.expression mapper e, lid mapper name)
+  | Texp_record (bindings, default) ->
+      Texp_record
+        ( List.map bindings ~f:(fun (name, e) ->
+              (lid mapper name, mapper.expression mapper e) )
+        , Option.map ~f:(mapper.expression mapper) default )
+  | Texp_ctor (name, arg) ->
+      Texp_ctor (lid mapper name, Option.map ~f:(mapper.expression mapper) arg)
+  | Texp_unifiable {expression; name; id} ->
+      Texp_unifiable
+        { id
+        ; name= str mapper name
+        ; expression= Option.map ~f:(mapper.expression mapper) expression }
+  | Texp_if (e1, e2, e3) ->
+      Texp_if
+        ( mapper.expression mapper e1
+        , mapper.expression mapper e2
+        , Option.map ~f:(mapper.expression mapper) e3 )
+
+let signature mapper = List.map ~f:(mapper.signature_item mapper)
+
+let signature_item mapper {sig_desc; sig_loc} =
+  { sig_loc= mapper.location mapper sig_loc
+  ; sig_desc= mapper.signature_desc mapper sig_desc }
+
+let signature_desc mapper = function
+  | Tsig_value (name, typ) ->
+      Tsig_value (str mapper name, mapper.type_expr mapper typ)
+  | Tsig_instance (name, typ) ->
+      Tsig_instance (str mapper name, mapper.type_expr mapper typ)
+  | Tsig_type decl ->
+      Tsig_type (mapper.type_decl mapper decl)
+  | Tsig_module (name, msig) ->
+      Tsig_module (str mapper name, mapper.module_sig mapper msig)
+  | Tsig_modtype (name, msig) ->
+      Tsig_modtype (str mapper name, mapper.module_sig mapper msig)
+  | Tsig_open name ->
+      Tsig_open (lid mapper name)
+  | Tsig_typeext (typ, ctors) ->
+      Tsig_typeext
+        (mapper.variant mapper typ, List.map ~f:(mapper.ctor_decl mapper) ctors)
+  | Tsig_request (typ, ctor) ->
+      Tsig_request (mapper.type_expr mapper typ, mapper.ctor_decl mapper ctor)
+  | Tsig_multiple sigs ->
+      Tsig_multiple (mapper.signature mapper sigs)
+
+let module_sig mapper {msig_desc; msig_loc} =
+  { msig_loc= mapper.location mapper msig_loc
+  ; msig_desc= mapper.module_sig_desc mapper msig_desc }
+
+let module_sig_desc mapper = function
+  | Tmty_sig sigs ->
+      Tmty_sig (mapper.signature mapper sigs)
+  | Tmty_name name ->
+      Tmty_name (lid mapper name)
+  | Tmty_abstract ->
+      Tmty_abstract
+  | Tmty_functor (name, fsig, msig) ->
+      Tmty_functor
+        ( str mapper name
+        , mapper.module_sig mapper fsig
+        , mapper.module_sig mapper msig )
+
+let statements mapper = List.map ~f:(mapper.statement mapper)
+
+let statement mapper {stmt_desc; stmt_loc} =
+  { stmt_loc= mapper.location mapper stmt_loc
+  ; stmt_desc= mapper.statement_desc mapper stmt_desc }
+
+let statement_desc mapper = function
+  | Tstmt_value (p, e) ->
+      Tstmt_value (mapper.pattern mapper p, mapper.expression mapper e)
+  | Tstmt_instance (name, e) ->
+      Tstmt_instance (str mapper name, mapper.expression mapper e)
+  | Tstmt_type decl ->
+      Tstmt_type (mapper.type_decl mapper decl)
+  | Tstmt_module (name, me) ->
+      Tstmt_module (str mapper name, mapper.module_expr mapper me)
+  | Tstmt_modtype (name, mty) ->
+      Tstmt_modtype (str mapper name, mapper.module_sig mapper mty)
+  | Tstmt_open name ->
+      Tstmt_open (lid mapper name)
+  | Tstmt_typeext (typ, ctors) ->
+      Tstmt_typeext
+        (mapper.variant mapper typ, List.map ~f:(mapper.ctor_decl mapper) ctors)
+  | Tstmt_request (typ, ctor, handler) ->
+      Tstmt_request
+        ( mapper.type_expr mapper typ
+        , mapper.ctor_decl mapper ctor
+        , Option.map handler ~f:(fun (p, e) ->
+              ( Option.map ~f:(mapper.pattern mapper) p
+              , mapper.expression mapper e ) ) )
+  | Tstmt_multiple stmts ->
+      Tstmt_multiple (mapper.statements mapper stmts)
+
+let module_expr mapper {mod_desc; mod_loc} =
+  { mod_loc= mapper.location mapper mod_loc
+  ; mod_desc= mapper.module_desc mapper mod_desc }
+
+let module_desc mapper = function
+  | Tmod_struct stmts ->
+      Tmod_struct (mapper.statements mapper stmts)
+  | Tmod_name name ->
+      Tmod_name (lid mapper name)
+  | Tmod_functor (name, fsig, me) ->
+      Tmod_functor
+        ( str mapper name
+        , mapper.module_sig mapper fsig
+        , mapper.module_expr mapper me )
+
+let location (_iter : mapper) (loc : Location.t) = loc
+
+let longident mapper = function
+  | Longident.Lident str ->
+      Longident.Lident str
+  | Ldot (l, str) ->
+      Ldot (mapper.longident mapper l, str)
+  | Lapply (l1, l2) ->
+      Lapply (mapper.longident mapper l1, mapper.longident mapper l2)
+
+(** Stub. This isn't part of the parsetypes, so we don't do anything by
+    default.
+*)
+let type0_decl (_iter : mapper) (decl : Type0.type_decl) = decl
+
+(** Stub. This isn't part of the parsetypes, so we don't do anything by
+    default.
+*)
+let type0_expr (_iter : mapper) (typ : Type0.type_expr) = typ
+
+let default_iterator =
+  { type_expr
+  ; type_desc
+  ; variant
+  ; field_decl
+  ; ctor_args
+  ; ctor_decl
+  ; type_decl
+  ; type_decl_desc
+  ; literal
+  ; pattern
+  ; pattern_desc
+  ; expression
+  ; expression_desc
+  ; signature_item
+  ; signature
+  ; signature_desc
+  ; module_sig
+  ; module_sig_desc
+  ; statement
+  ; statements
+  ; statement_desc
+  ; module_expr
+  ; module_desc
+  ; location
+  ; longident
+  ; type0_decl
+  ; type0_expr }

--- a/meja/src/typet.ml
+++ b/meja/src/typet.ml
@@ -316,7 +316,7 @@ module TypeDecl = struct
                             (env, arg) )
                       in
                       (env, Type0.Ctor_tuple args)
-                  | Ctor_record (_, fields) ->
+                  | Ctor_record fields ->
                       let env, fields =
                         List.fold_map ~init:env fields
                           ~f:(import_field ?must_find)

--- a/meja/src/typet.ml
+++ b/meja/src/typet.ml
@@ -156,21 +156,19 @@ module Type = struct
         {typ with type_loc= loc}
     | Ptyp_tuple typs ->
         let typs = List.map ~f typs in
-        {typ with type_desc= Ptyp_tuple typs; type_loc= loc}
+        {type_desc= Ptyp_tuple typs; type_loc= loc}
     | Ptyp_arrow (typ1, typ2, explicit, label) ->
-        { typ with
-          type_desc= Ptyp_arrow (f typ1, f typ2, explicit, label)
-        ; type_loc= loc }
+        {type_desc= Ptyp_arrow (f typ1, f typ2, explicit, label); type_loc= loc}
     | Ptyp_ctor variant ->
         let variant =
           { variant with
             var_params= List.map ~f variant.var_params
           ; var_implicit_params= List.map ~f variant.var_implicit_params }
         in
-        {typ with type_desc= Ptyp_ctor variant; type_loc= loc}
+        {type_desc= Ptyp_ctor variant; type_loc= loc}
     | Ptyp_poly (typs, typ) ->
         let typs = List.map ~f typs in
-        {typ with type_desc= Ptyp_poly (typs, f typ); type_loc= loc}
+        {type_desc= Ptyp_poly (typs, f typ); type_loc= loc}
 end
 
 module TypeDecl = struct
@@ -446,7 +444,6 @@ let pp_decl_typ ppf decl =
           { var_ident= mk_lid decl.tdec_ident
           ; var_params= decl.tdec_params
           ; var_implicit_params= decl.tdec_implicit_params }
-    ; type_id= -1
     ; type_loc= Location.none }
 
 let report_error ppf = function


### PR DESCRIPTION
This PR
* removes an unused field `type_id` from `Parsetypes`
* removes an unused field in `Parsetypes.Ctor_record`
* removes `Parsetypes.typ_debug_print`
* adds an iterator and a mapper for each of `Parsetypes` and `Typedast`

The mapper will most importantly be used to convert Meja names into OCaml names in the typed AST, and OCaml names to Meja names when converting back to a parsed AST.

The `Typedast` iterator will be used to generate an environment from a typed AST serialised to a file, as well as making it cleaner and less error-prone to extract information from it for codegen (e.g. `request`, where the current method is extremely brittle).

At the moment, I don't have a planned use for the `Parsetypes` iterator, but I expect it will be useful for debugging parser problems, which I currently have to hook into the typechecker for.