### PR TITLE
[Meja] Print curly braces around bracketed Pexp_seq/Pexp_let statements

### DIFF
--- a/meja/src/pprint.ml
+++ b/meja/src/pprint.ml
@@ -255,6 +255,8 @@ and expression_desc_bracket fmt exp =
   | Pexp_record _
   | Pexp_ctor _ ->
       expression_desc fmt exp
+  | Pexp_seq _ | Pexp_let _ ->
+      fprintf fmt "{@[<hv1>@,%a@,@]}" expression_desc exp
   | _ ->
       fprintf fmt "(@[<hv1>@,%a@,@])" expression_desc exp
 


### PR DESCRIPTION
This ensures that code parsed as e.g.
```reason
  ...
  let x = {let x = ref 1; incr x; incr x; let x = !x; x;};
  x;
  ...
```
gets correctly printed so that it can be parsed again.

Currently, master prints
```reason
  ...
  let x = (let x = ref 1; incr x; incr x; let x = !x; x);
  x;
  ...
```
which will not parse.