### PR TITLE
[Meja] Expose a typed version of Parsetypes.type_expr, etc.

### DIFF
--- a/meja/ocaml/of_ocaml/of_ocaml_4.07.1.ml
+++ b/meja/ocaml/of_ocaml/of_ocaml_4.07.1.ml
@@ -79,15 +79,15 @@ let to_ctor_decl {cd_id; cd_args; cd_res; cd_loc; _} =
 let to_type_decl_desc decl =
   match (decl.type_manifest, decl.type_kind) with
   | Some typ, _ ->
-      TAlias (to_type_expr ~loc:decl.type_loc typ)
+      Pdec_alias (to_type_expr ~loc:decl.type_loc typ)
   | None, Type_abstract ->
-      TAbstract
+      Pdec_abstract
   | None, Type_open ->
-      TOpen
+      Pdec_open
   | None, Type_record (labels, _) ->
-      TRecord (List.map labels ~f:to_field_decl)
+      Pdec_record (List.map labels ~f:to_field_decl)
   | None, Type_variant ctors ->
-      TVariant (List.map ctors ~f:to_ctor_decl)
+      Pdec_variant (List.map ctors ~f:to_ctor_decl)
 
 let can_create_signature_item item =
   match item with Sig_typext _ | Sig_class _ -> false | _ -> true

--- a/meja/ocaml/to_ocaml.ml
+++ b/meja/ocaml/to_ocaml.ml
@@ -67,8 +67,6 @@ let of_type_decl decl =
       failwith "Cannot convert TExtend to OCaml"
   | Pdec_unfold _ ->
       failwith "Cannot convert TUnfold to OCaml"
-  | Pdec_forward _ ->
-      failwith "Cannot convert TForward to OCaml"
 
 let rec of_pattern_desc ?loc = function
   | Ppat_any ->

--- a/meja/ocaml/to_ocaml.ml
+++ b/meja/ocaml/to_ocaml.ml
@@ -51,23 +51,23 @@ let of_type_decl decl =
       (decl.tdec_params @ decl.tdec_implicit_params)
   in
   match decl.tdec_desc with
-  | TAbstract ->
+  | Pdec_abstract ->
       Type.mk name ~loc ~params
-  | TAlias typ ->
+  | Pdec_alias typ ->
       Type.mk name ~loc ~params ~manifest:(of_type_expr typ)
-  | TRecord fields ->
+  | Pdec_record fields ->
       Type.mk name ~loc ~params
         ~kind:(Parsetree.Ptype_record (List.map ~f:of_field_decl fields))
-  | TVariant ctors ->
+  | Pdec_variant ctors ->
       Type.mk name ~loc ~params
         ~kind:(Parsetree.Ptype_variant (List.map ~f:of_ctor_decl ctors))
-  | TOpen ->
+  | Pdec_open ->
       Type.mk name ~loc ~params ~kind:Parsetree.Ptype_open
-  | TExtend _ ->
+  | Pdec_extend _ ->
       failwith "Cannot convert TExtend to OCaml"
-  | TUnfold _ ->
+  | Pdec_unfold _ ->
       failwith "Cannot convert TUnfold to OCaml"
-  | TForward _ ->
+  | Pdec_forward _ ->
       failwith "Cannot convert TForward to OCaml"
 
 let rec of_pattern_desc ?loc = function

--- a/meja/src/ast_build.ml
+++ b/meja/src/ast_build.ml
@@ -75,25 +75,25 @@ module Type_decl = struct
     ; tdec_loc= loc }
 
   let abstract ?loc ?params ?implicits name =
-    mk ?loc ?params ?implicits name TAbstract
+    mk ?loc ?params ?implicits name Pdec_abstract
 
   let alias ?loc ?params ?implicits name typ =
-    mk ?loc ?params ?implicits name (TAlias typ)
+    mk ?loc ?params ?implicits name (Pdec_alias typ)
 
   let unfold ?loc ?params ?implicits name typ =
-    mk ?loc ?params ?implicits name (TUnfold typ)
+    mk ?loc ?params ?implicits name (Pdec_unfold typ)
 
   let record ?loc ?params ?implicits name fields =
-    mk ?loc ?params ?implicits name (TRecord fields)
+    mk ?loc ?params ?implicits name (Pdec_record fields)
 
   let variant ?loc ?params ?implicits name ctors =
-    mk ?loc ?params ?implicits name (TVariant ctors)
+    mk ?loc ?params ?implicits name (Pdec_variant ctors)
 
   let open_ ?loc ?params ?implicits name =
-    mk ?loc ?params ?implicits name TOpen
+    mk ?loc ?params ?implicits name Pdec_open
 
   let forward ?loc ?params ?implicits name =
-    mk ?loc ?params ?implicits name (TForward (ref None))
+    mk ?loc ?params ?implicits name (Pdec_forward (ref None))
 
   module Field = struct
     let mk ?(loc = Location.none) name typ : Parsetypes.field_decl =

--- a/meja/src/ast_build.ml
+++ b/meja/src/ast_build.ml
@@ -92,9 +92,6 @@ module Type_decl = struct
   let open_ ?loc ?params ?implicits name =
     mk ?loc ?params ?implicits name Pdec_open
 
-  let forward ?loc ?params ?implicits name =
-    mk ?loc ?params ?implicits name (Pdec_forward (ref None))
-
   module Field = struct
     let mk ?(loc = Location.none) name typ : Parsetypes.field_decl =
       {fld_ident= Loc.mk ~loc name; fld_type= typ; fld_loc= loc}

--- a/meja/src/codegen.ml
+++ b/meja/src/codegen.ml
@@ -36,7 +36,7 @@ let typ_of_decl ~loc (decl : type_decl) =
   let name = decl.tdec_ident.txt in
   try
     match decl.tdec_desc with
-    | TRecord fields ->
+    | Pdec_record fields ->
         let vars = ref String.Set.empty in
         let find_name name =
           let rec find_name i =

--- a/meja/src/envi.ml
+++ b/meja/src/envi.ml
@@ -1143,6 +1143,14 @@ module Type = struct
     | Tpoly (typs, typ) ->
         mk (Tpoly (typs, constr_map env ~f typ)) env
 
+  let get_preferred_constr_name env typ =
+    match typ.type_desc with
+    | Tctor variant ->
+        List.find_map env.scope_stack
+          ~f:(Scope.get_preferred_type_name variant.var_decl.tdec_id)
+    | _ ->
+        None
+
   let normalise_constr_names env typ =
     constr_map env typ ~f:(fun variant ->
         match

--- a/meja/src/parser_impl.mly
+++ b/meja/src/parser_impl.mly
@@ -231,19 +231,19 @@ field_decl:
 
 type_kind:
   | (* empty *)
-    { TAbstract }
+    { Pdec_abstract }
   | EQUAL k = type_kind_body
     { k }
 
 type_kind_body:
   | t = type_expr
-    { TAlias t }
+    { Pdec_alias t }
   | LBRACE fields = list(field_decl, COMMA) RBRACE
-    { TRecord (List.rev fields) }
+    { Pdec_record (List.rev fields) }
   | maybe(BAR) ctors = list(ctor_decl, BAR)
-    { TVariant (List.rev ctors) }
+    { Pdec_variant (List.rev ctors) }
   | DOTDOT
-    { TOpen }
+    { Pdec_open }
 
 ctor_decl_args:
   | (* empty *)

--- a/meja/src/parsetypes.ml
+++ b/meja/src/parsetypes.ml
@@ -37,15 +37,15 @@ type type_decl =
   ; tdec_loc: Location.t }
 
 and type_decl_desc =
-  | TAbstract
-  | TAlias of type_expr
-  | TUnfold of type_expr
-  | TRecord of field_decl list
-  | TVariant of ctor_decl list
-  | TOpen
-  | TExtend of Path.t Location.loc * Type0.type_decl * ctor_decl list
+  | Pdec_abstract
+  | Pdec_alias of type_expr
+  | Pdec_unfold of type_expr
+  | Pdec_record of field_decl list
+  | Pdec_variant of ctor_decl list
+  | Pdec_open
+  | Pdec_extend of Path.t Location.loc * Type0.type_decl * ctor_decl list
       (** Internal; this should never be present in the AST. *)
-  | TForward of int option ref
+  | Pdec_forward of int option ref
       (** Forward declaration for types loaded from cmi files. *)
 
 type literal = Int of int | Bool of bool | Field of string | String of string

--- a/meja/src/parsetypes.ml
+++ b/meja/src/parsetypes.ml
@@ -1,4 +1,3 @@
-open Core_kernel
 open Ast_types
 
 type type_expr = {type_desc: type_desc; type_loc: Location.t}
@@ -45,8 +44,6 @@ and type_decl_desc =
   | Pdec_open
   | Pdec_extend of Path.t Location.loc * Type0.type_decl * ctor_decl list
       (** Internal; this should never be present in the AST. *)
-  | Pdec_forward of int option ref
-      (** Forward declaration for types loaded from cmi files. *)
 
 type literal = Int of int | Bool of bool | Field of string | String of string
 

--- a/meja/src/parsetypes_iter.ml
+++ b/meja/src/parsetypes_iter.ml
@@ -97,8 +97,9 @@ let type_decl_desc iter = function
       ()
   | Pdec_extend (_name, _decl, _ctors) ->
       assert false
-      (* TODO: re-enable this when the Type0 iterator is merged. *)
-      (*lid iter name ;
+
+(* TODO: re-enable this when the Type0 iterator is merged. *)
+(*lid iter name ;
       iter.type0_decl iter decl ;
       List.iter ~f:(iter.ctor_decl iter) ctors*)
 

--- a/meja/src/parsetypes_iter.ml
+++ b/meja/src/parsetypes_iter.ml
@@ -101,8 +101,6 @@ let type_decl_desc iter = function
       (*lid iter name ;
       iter.type0_decl iter decl ;
       List.iter ~f:(iter.ctor_decl iter) ctors*)
-  | Pdec_forward _ ->
-      ()
 
 let literal (_iter : iterator) (_ : literal) = ()
 

--- a/meja/src/parsetypes_iter.ml
+++ b/meja/src/parsetypes_iter.ml
@@ -83,25 +83,25 @@ let type_decl iter
   iter.type_decl_desc iter tdec_desc
 
 let type_decl_desc iter = function
-  | TAbstract ->
+  | Pdec_abstract ->
       ()
-  | TAlias typ ->
+  | Pdec_alias typ ->
       iter.type_expr iter typ
-  | TUnfold typ ->
+  | Pdec_unfold typ ->
       iter.type_expr iter typ
-  | TRecord fields ->
+  | Pdec_record fields ->
       List.iter ~f:(iter.field_decl iter) fields
-  | TVariant ctors ->
+  | Pdec_variant ctors ->
       List.iter ~f:(iter.ctor_decl iter) ctors
-  | TOpen ->
+  | Pdec_open ->
       ()
-  | TExtend (_name, _decl, _ctors) ->
+  | Pdec_extend (_name, _decl, _ctors) ->
       assert false
       (* TODO: re-enable this when the Type0 iterator is merged. *)
       (*lid iter name ;
       iter.type0_decl iter decl ;
       List.iter ~f:(iter.ctor_decl iter) ctors*)
-  | TForward _ ->
+  | Pdec_forward _ ->
       ()
 
 let literal (_iter : iterator) (_ : literal) = ()

--- a/meja/src/parsetypes_map.ml
+++ b/meja/src/parsetypes_map.ml
@@ -114,8 +114,6 @@ let type_decl_desc mapper = function
         ( path mapper name
         , mapper.type0.type_decl mapper.type0 decl
         , List.map ~f:(mapper.ctor_decl mapper) ctors )
-  | Pdec_forward i ->
-      Pdec_forward i
 
 let literal (_iter : mapper) (l : literal) = l
 

--- a/meja/src/parsetypes_map.ml
+++ b/meja/src/parsetypes_map.ml
@@ -97,25 +97,25 @@ let type_decl mapper
   ; tdec_desc= mapper.type_decl_desc mapper tdec_desc }
 
 let type_decl_desc mapper = function
-  | TAbstract ->
-      TAbstract
-  | TAlias typ ->
-      TAlias (mapper.type_expr mapper typ)
-  | TUnfold typ ->
-      TUnfold (mapper.type_expr mapper typ)
-  | TRecord fields ->
-      TRecord (List.map ~f:(mapper.field_decl mapper) fields)
-  | TVariant ctors ->
-      TVariant (List.map ~f:(mapper.ctor_decl mapper) ctors)
-  | TOpen ->
-      TOpen
-  | TExtend (name, decl, ctors) ->
-      TExtend
+  | Pdec_abstract ->
+      Pdec_abstract
+  | Pdec_alias typ ->
+      Pdec_alias (mapper.type_expr mapper typ)
+  | Pdec_unfold typ ->
+      Pdec_unfold (mapper.type_expr mapper typ)
+  | Pdec_record fields ->
+      Pdec_record (List.map ~f:(mapper.field_decl mapper) fields)
+  | Pdec_variant ctors ->
+      Pdec_variant (List.map ~f:(mapper.ctor_decl mapper) ctors)
+  | Pdec_open ->
+      Pdec_open
+  | Pdec_extend (name, decl, ctors) ->
+      Pdec_extend
         ( path mapper name
         , mapper.type0.type_decl mapper.type0 decl
         , List.map ~f:(mapper.ctor_decl mapper) ctors )
-  | TForward i ->
-      TForward i
+  | Pdec_forward i ->
+      Pdec_forward i
 
 let literal (_iter : mapper) (l : literal) = l
 

--- a/meja/src/pprint.ml
+++ b/meja/src/pprint.ml
@@ -65,23 +65,23 @@ let ctor_decl fmt decl =
       ()
 
 let type_decl_desc fmt = function
-  | TAbstract ->
+  | Pdec_abstract ->
       ()
-  | TAlias typ | TUnfold typ ->
+  | Pdec_alias typ | Pdec_unfold typ ->
       fprintf fmt "@ =@ @[<hv>%a@]" type_expr typ
-  | TRecord fields ->
+  | Pdec_record fields ->
       fprintf fmt "@ =@ {@[<hv2>%a@]}"
         (pp_print_list ~pp_sep:comma_sep field_decl)
         fields
-  | TVariant ctors ->
+  | Pdec_variant ctors ->
       fprintf fmt "@ =@ %a" (pp_print_list ~pp_sep:bar_sep ctor_decl) ctors
-  | TOpen ->
+  | Pdec_open ->
       fprintf fmt "@ =@ .."
-  | TExtend (name, _, ctors) ->
+  | Pdec_extend (name, _, ctors) ->
       fprintf fmt "@ /*@[%a +=@ %a@]*/" Path.pp name.txt
         (pp_print_list ~pp_sep:bar_sep ctor_decl)
         ctors
-  | TForward i ->
+  | Pdec_forward i ->
       let print_id fmt i =
         match i with
         | Some i ->

--- a/meja/src/pprint.ml
+++ b/meja/src/pprint.ml
@@ -81,15 +81,6 @@ let type_decl_desc fmt = function
       fprintf fmt "@ /*@[%a +=@ %a@]*/" Path.pp name.txt
         (pp_print_list ~pp_sep:bar_sep ctor_decl)
         ctors
-  | Pdec_forward i ->
-      let print_id fmt i =
-        match i with
-        | Some i ->
-            pp_print_int fmt i
-        | None ->
-            pp_print_char fmt '?'
-      in
-      fprintf fmt "@ /* forward declaration %a */" print_id !i
 
 let type_decl fmt decl =
   fprintf fmt "type %s" decl.tdec_ident.txt ;

--- a/meja/src/type0_map.ml
+++ b/meja/src/type0_map.ml
@@ -122,9 +122,11 @@ let type_decl_desc mapper desc =
   | TAlias typ ->
       let typ' = mapper.type_expr mapper typ in
       if phys_equal typ' typ then desc else TAlias typ'
-  | TUnfold typ ->
-      let typ' = mapper.type_expr mapper typ in
-      if phys_equal typ' typ then desc else TUnfold typ'
+  | TUnfold _typ ->
+      (* This can cause infinite recursion with newtypes, disabled for now. *)
+      (*let typ' = mapper.type_expr mapper typ in
+      if phys_equal typ' typ then desc else TUnfold typ'*)
+      desc
   | TRecord flds ->
       let same = ref true in
       let flds = map_list flds ~same ~f:(mapper.field_decl mapper) in

--- a/meja/src/typechecker.ml
+++ b/meja/src/typechecker.ml
@@ -438,7 +438,7 @@ let rec check_pattern ~add env typ pat =
       let p, env = check_pattern ~add env ctyp p in
       let normalised_ctyp = Envi.Type.normalise_constr_names env ctyp in
       let constr_typ =
-        Untype_ast.type_expr ~loc:constr_typ.type_loc normalised_ctyp
+        Untype_ast.Type0.type_expr ~loc:constr_typ.type_loc normalised_ctyp
       in
       ( { Typedast.pat_loc= loc
         ; pat_type= typ
@@ -719,7 +719,7 @@ let rec get_expression env expected exp =
       let e, env = get_expression env typ e in
       check_type ~loc env e.exp_type typ ;
       let typ' =
-        Untype_ast.type_expr ~loc:typ'.type_loc
+        Untype_ast.Type0.type_expr ~loc:typ'.type_loc
           (Envi.Type.normalise_constr_names env typ)
       in
       ({exp_loc= loc; exp_type= typ; exp_desc= Texp_constraint (e, typ')}, env)
@@ -1022,7 +1022,8 @@ and check_binding ?(toplevel = false) (env : Envi.t) p e : 's =
         ; pat_desc= Tpat_variable name }
       in
       let typ =
-        Untype_ast.type_expr ~loc (Envi.Type.normalise_constr_names env ctyp)
+        Untype_ast.Type0.type_expr ~loc
+          (Envi.Type.normalise_constr_names env ctyp)
       in
       let p =
         { Typedast.pat_loc= p.pat_loc
@@ -1062,7 +1063,7 @@ let type_extension ~loc variant ctors env =
     { Parsetypes.tdec_ident= Location.mkloc (Ident.name tdec_ident) loc
     ; tdec_params= var_params
     ; tdec_implicit_params=
-        List.map ~f:(Untype_ast.type_expr ~loc) tdec_implicit_params
+        List.map ~f:(Untype_ast.Type0.type_expr ~loc) tdec_implicit_params
     ; tdec_desc= TExtend (Location.mkloc path var_ident.loc, decl, ctors)
     ; tdec_loc= loc }
   in
@@ -1269,7 +1270,7 @@ let rec check_statement env stmt =
       let decl, env = Typet.TypeDecl.import decl env in
       let stmt =
         { Typedast.stmt_loc= loc
-        ; stmt_desc= Tstmt_type (Untype_ast.type_decl ~loc decl) }
+        ; stmt_desc= Tstmt_type (Untype_ast.Type0.type_decl ~loc decl) }
       in
       (env, stmt)
   | Pstmt_type decl ->
@@ -1323,7 +1324,7 @@ let rec check_statement env stmt =
       let ctor_decl =
         match ctors with
         | [ctor] ->
-            { (Untype_ast.ctor_decl ~loc ctor) with
+            { (Untype_ast.Type0.ctor_decl ~loc ctor) with
               ctor_ret=
                 Some
                   (Type.mk ~loc

--- a/meja/src/typechecker.ml
+++ b/meja/src/typechecker.ml
@@ -677,7 +677,7 @@ let rec get_expression env expected exp =
         { tdec_ident= name
         ; tdec_params= []
         ; tdec_implicit_params= []
-        ; tdec_desc= TUnfold (Ast_build.Type.none ())
+        ; tdec_desc= Pdec_unfold (Ast_build.Type.none ())
         ; tdec_loc= loc }
       in
       let decl, env = Typet.TypeDecl.import decl env in
@@ -1064,7 +1064,7 @@ let type_extension ~loc variant ctors env =
     ; tdec_params= var_params
     ; tdec_implicit_params=
         List.map ~f:(Untype_ast.Type0.type_expr ~loc) tdec_implicit_params
-    ; tdec_desc= TExtend (Location.mkloc path var_ident.loc, decl, ctors)
+    ; tdec_desc= Pdec_extend (Location.mkloc path var_ident.loc, decl, ctors)
     ; tdec_loc= loc }
   in
   let decl, env = Typet.TypeDecl.import decl env in

--- a/meja/src/typechecker.ml
+++ b/meja/src/typechecker.ml
@@ -434,6 +434,7 @@ let rec check_pattern ~add env typ pat =
       , env )
   | Ppat_constraint (p, constr_typ) ->
       let ctyp, env = Typet.Type.import constr_typ env in
+      let ctyp = ctyp.type_type in
       check_type ~loc env typ ctyp ;
       let p, env = check_pattern ~add env ctyp p in
       let normalised_ctyp = Envi.Type.normalise_constr_names env ctyp in
@@ -715,6 +716,7 @@ let rec get_expression env expected exp =
       , env )
   | Pexp_constraint (e, typ') ->
       let typ, env = Typet.Type.import typ' env in
+      let typ = typ.type_type in
       check_type ~loc env expected typ ;
       let e, env = get_expression env typ e in
       check_type ~loc env e.exp_type typ ;
@@ -1009,6 +1011,7 @@ and check_binding ?(toplevel = false) (env : Envi.t) p e : 's =
       (p, e, env)
   | Ppat_constraint (({pat_desc= Ppat_variable str; _} as p'), typ), _ ->
       let ctyp, env = Typet.Type.import typ env in
+      let ctyp = ctyp.type_type in
       check_type ~loc env e.exp_type ctyp ;
       let ctyp =
         if Set.is_empty typ_vars then ctyp
@@ -1090,6 +1093,7 @@ let rec check_signature_item env item =
   | Psig_value (name, typ) ->
       let env = Envi.open_expr_scope env in
       let typ', env = Typet.Type.import typ env in
+      let typ' = typ'.type_type in
       let env = Envi.close_expr_scope env in
       Envi.Type.update_depths env typ' ;
       let name = map_loc ~f:(Ident.create ~mode) name in
@@ -1098,6 +1102,7 @@ let rec check_signature_item env item =
   | Psig_instance (name, typ) ->
       let env = Envi.open_expr_scope env in
       let typ', env = Typet.Type.import typ env in
+      let typ' = typ'.type_type in
       let env = Envi.close_expr_scope env in
       Envi.Type.update_depths env typ' ;
       let name = map_loc ~f:(Ident.create ~mode) name in

--- a/meja/src/typedast.ml
+++ b/meja/src/typedast.ml
@@ -1,4 +1,52 @@
 open Ast_types
+
+type type_expr = {type_desc: type_desc; type_loc: Location.t}
+
+and type_desc =
+  (* A type variable. Name is None when not yet chosen. *)
+  | Ttyp_var of str option * explicitness
+  | Ttyp_tuple of type_expr list
+  | Ttyp_arrow of type_expr * type_expr * explicitness * Asttypes.arg_label
+  (* A type name. *)
+  | Ttyp_ctor of variant
+  | Ttyp_poly of type_expr list * type_expr
+
+and variant =
+  { var_ident: lid
+  ; var_params: type_expr list
+  ; var_implicit_params: type_expr list }
+
+type field_decl = {fld_ident: str; fld_type: type_expr; fld_loc: Location.t}
+
+type ctor_args =
+  | Ttor_tuple of type_expr list
+  | Ttor_record of int * field_decl list
+
+type ctor_decl =
+  { ctor_ident: str
+  ; ctor_args: ctor_args
+  ; ctor_ret: type_expr option
+  ; ctor_loc: Location.t }
+
+type type_decl =
+  { tdec_ident: str
+  ; tdec_params: type_expr list
+  ; tdec_implicit_params: type_expr list
+  ; tdec_desc: type_decl_desc
+  ; tdec_loc: Location.t }
+
+and type_decl_desc =
+  | Tdec_abstract
+  | Tdec_alias of type_expr
+  | Tdec_unfold of type_expr
+  | Tdec_record of field_decl list
+  | Tdec_variant of ctor_decl list
+  | Tdec_open
+  | Tdec_extend of lid * Type0.type_decl * ctor_decl list
+      (** Internal; this should never be present in the AST. *)
+  | Tdec_forward of int option ref
+      (** Forward declaration for types loaded from cmi files. *)
+
 open Parsetypes
 
 type ident = Ident.t Location.loc

--- a/meja/src/typedast.ml
+++ b/meja/src/typedast.ml
@@ -1,5 +1,9 @@
 open Ast_types
 
+type ident = Ident.t Location.loc
+
+type path = Path.t Location.loc
+
 type type_expr = {type_desc: type_desc; type_loc: Location.t}
 
 and type_desc =
@@ -20,7 +24,7 @@ type field_decl = {fld_ident: str; fld_type: type_expr; fld_loc: Location.t}
 
 type ctor_args =
   | Tctor_tuple of type_expr list
-  | Tctor_record of int * field_decl list
+  | Tctor_record of field_decl list
 
 type ctor_decl =
   { ctor_ident: str
@@ -42,16 +46,12 @@ and type_decl_desc =
   | Tdec_record of field_decl list
   | Tdec_variant of ctor_decl list
   | Tdec_open
-  | Tdec_extend of lid * Type0.type_decl * ctor_decl list
+  | Tdec_extend of path * Type0.type_decl * ctor_decl list
       (** Internal; this should never be present in the AST. *)
   | Tdec_forward of int option ref
       (** Forward declaration for types loaded from cmi files. *)
 
 open Parsetypes
-
-type ident = Ident.t Location.loc
-
-type path = Path.t Location.loc
 
 type literal = Int of int | Bool of bool | Field of string | String of string
 

--- a/meja/src/typedast.ml
+++ b/meja/src/typedast.ml
@@ -48,8 +48,6 @@ and type_decl_desc =
   | Tdec_open
   | Tdec_extend of path * Type0.type_decl * ctor_decl list
       (** Internal; this should never be present in the AST. *)
-  | Tdec_forward of int option ref
-      (** Forward declaration for types loaded from cmi files. *)
 
 open Parsetypes
 

--- a/meja/src/typedast.ml
+++ b/meja/src/typedast.ml
@@ -19,8 +19,8 @@ and variant =
 type field_decl = {fld_ident: str; fld_type: type_expr; fld_loc: Location.t}
 
 type ctor_args =
-  | Ttor_tuple of type_expr list
-  | Ttor_record of int * field_decl list
+  | Tctor_tuple of type_expr list
+  | Tctor_record of int * field_decl list
 
 type ctor_decl =
   { ctor_ident: str

--- a/meja/src/typedast.ml
+++ b/meja/src/typedast.ml
@@ -4,7 +4,8 @@ type ident = Ident.t Location.loc
 
 type path = Path.t Location.loc
 
-type type_expr = {type_desc: type_desc; type_loc: Location.t}
+type type_expr =
+  {type_desc: type_desc; type_loc: Location.t; type_type: Type0.type_expr}
 
 and type_desc =
   (* A type variable. Name is None when not yet chosen. *)

--- a/meja/src/typedast.ml
+++ b/meja/src/typedast.ml
@@ -17,7 +17,7 @@ and type_desc =
   | Ttyp_poly of type_expr list * type_expr
 
 and variant =
-  { var_ident: lid
+  { var_ident: path
   ; var_params: type_expr list
   ; var_implicit_params: type_expr list }
 
@@ -49,8 +49,6 @@ and type_decl_desc =
   | Tdec_open
   | Tdec_extend of path * Type0.type_decl * ctor_decl list
       (** Internal; this should never be present in the AST. *)
-
-open Parsetypes
 
 type literal = Int of int | Bool of bool | Field of string | String of string
 
@@ -97,12 +95,12 @@ and signature = signature_item list
 and signature_desc =
   | Tsig_value of ident * type_expr
   | Tsig_instance of ident * type_expr
-  | Tsig_type of type_decl
+  | Tsig_type of Parsetypes.type_decl
   | Tsig_module of ident * module_sig
   | Tsig_modtype of ident * module_sig
   | Tsig_open of path
-  | Tsig_typeext of variant * ctor_decl list
-  | Tsig_request of type_expr * ctor_decl
+  | Tsig_typeext of Parsetypes.variant * Parsetypes.ctor_decl list
+  | Tsig_request of Parsetypes.type_expr * Parsetypes.ctor_decl
   | Tsig_multiple of signature
 
 and module_sig = {msig_desc: module_sig_desc; msig_loc: Location.t}
@@ -120,13 +118,15 @@ and statements = statement list
 and statement_desc =
   | Tstmt_value of pattern * expression
   | Tstmt_instance of ident * expression
-  | Tstmt_type of type_decl
+  | Tstmt_type of Parsetypes.type_decl
   | Tstmt_module of ident * module_expr
   | Tstmt_modtype of ident * module_sig
   | Tstmt_open of path
-  | Tstmt_typeext of variant * ctor_decl list
+  | Tstmt_typeext of Parsetypes.variant * Parsetypes.ctor_decl list
   | Tstmt_request of
-      type_expr * ctor_decl * (pattern option * expression) option
+      Parsetypes.type_expr
+      * Parsetypes.ctor_decl
+      * (pattern option * expression) option
   | Tstmt_multiple of statements
 
 and module_expr = {mod_desc: module_desc; mod_loc: Location.t}

--- a/meja/src/typedast_iter.ml
+++ b/meja/src/typedast_iter.ml
@@ -93,23 +93,23 @@ let type_decl iter
   iter.type_decl_desc iter tdec_desc
 
 let type_decl_desc iter = function
-  | Parsetypes.TAbstract ->
+  | Parsetypes.Pdec_abstract ->
       ()
-  | TAlias typ ->
+  | Pdec_alias typ ->
       iter.type_expr iter typ
-  | TUnfold typ ->
+  | Pdec_unfold typ ->
       iter.type_expr iter typ
-  | TRecord fields ->
+  | Pdec_record fields ->
       List.iter ~f:(iter.field_decl iter) fields
-  | TVariant ctors ->
+  | Pdec_variant ctors ->
       List.iter ~f:(iter.ctor_decl iter) ctors
-  | TOpen ->
+  | Pdec_open ->
       ()
-  | TExtend (name, decl, ctors) ->
+  | Pdec_extend (name, decl, ctors) ->
       path iter name ;
       iter.type0_decl iter decl ;
       List.iter ~f:(iter.ctor_decl iter) ctors
-  | TForward _ ->
+  | Pdec_forward _ ->
       ()
 
 let literal (_iter : iterator) (_ : literal) = ()

--- a/meja/src/typedast_iter.ml
+++ b/meja/src/typedast_iter.ml
@@ -66,7 +66,7 @@ let type_desc iter = function
       iter.type_expr iter typ
 
 let variant iter {var_ident; var_params; var_implicit_params} =
-  lid iter var_ident ;
+  path iter var_ident ;
   List.iter ~f:(iter.type_expr iter) var_params ;
   List.iter ~f:(iter.type_expr iter) var_implicit_params
 
@@ -150,7 +150,7 @@ let pattern_desc iter = function
   | Tpat_variable name ->
       ident iter name
   | Tpat_constraint (pat, typ) ->
-      iter.ptype_expr iter typ ; iter.pattern iter pat
+      iter.type_expr iter typ ; iter.pattern iter pat
   | Tpat_tuple pats ->
       List.iter ~f:(iter.pattern iter) pats
   | Tpat_or (p1, p2) ->
@@ -186,7 +186,7 @@ let expression_desc iter = function
   | Texp_let (p, e1, e2) ->
       iter.pattern iter p ; iter.expression iter e1 ; iter.expression iter e2
   | Texp_constraint (e, typ) ->
-      iter.ptype_expr iter typ ; iter.expression iter e
+      iter.type_expr iter typ ; iter.expression iter e
   | Texp_tuple es ->
       List.iter ~f:(iter.expression iter) es
   | Texp_match (e, cases) ->
@@ -218,7 +218,7 @@ let signature_item iter {sig_desc; sig_loc} =
 
 let signature_desc iter = function
   | Tsig_value (name, typ) | Tsig_instance (name, typ) ->
-      ident iter name ; iter.ptype_expr iter typ
+      ident iter name ; iter.type_expr iter typ
   | Tsig_type decl ->
       iter.type_decl iter decl
   | Tsig_module (name, msig) | Tsig_modtype (name, msig) ->

--- a/meja/src/typedast_iter.ml
+++ b/meja/src/typedast_iter.ml
@@ -109,8 +109,6 @@ let type_decl_desc iter = function
       path iter name ;
       iter.type0_decl iter decl ;
       List.iter ~f:(iter.ctor_decl iter) ctors
-  | Pdec_forward _ ->
-      ()
 
 let literal (_iter : iterator) (_ : literal) = ()
 

--- a/meja/src/typedast_map.ml
+++ b/meja/src/typedast_map.ml
@@ -103,25 +103,25 @@ let type_decl mapper
   ; tdec_desc= mapper.type_decl_desc mapper tdec_desc }
 
 let type_decl_desc mapper = function
-  | Parsetypes.TAbstract ->
-      Parsetypes.TAbstract
-  | TAlias typ ->
-      TAlias (mapper.type_expr mapper typ)
-  | TUnfold typ ->
-      TUnfold (mapper.type_expr mapper typ)
-  | TRecord fields ->
-      TRecord (List.map ~f:(mapper.field_decl mapper) fields)
-  | TVariant ctors ->
-      TVariant (List.map ~f:(mapper.ctor_decl mapper) ctors)
-  | TOpen ->
-      TOpen
-  | TExtend (name, decl, ctors) ->
-      TExtend
+  | Parsetypes.Pdec_abstract ->
+      Parsetypes.Pdec_abstract
+  | Pdec_alias typ ->
+      Pdec_alias (mapper.type_expr mapper typ)
+  | Pdec_unfold typ ->
+      Pdec_unfold (mapper.type_expr mapper typ)
+  | Pdec_record fields ->
+      Pdec_record (List.map ~f:(mapper.field_decl mapper) fields)
+  | Pdec_variant ctors ->
+      Pdec_variant (List.map ~f:(mapper.ctor_decl mapper) ctors)
+  | Pdec_open ->
+      Pdec_open
+  | Pdec_extend (name, decl, ctors) ->
+      Pdec_extend
         ( path mapper name
         , mapper.type0.type_decl mapper.type0 decl
         , List.map ~f:(mapper.ctor_decl mapper) ctors )
-  | TForward i ->
-      TForward i
+  | Pdec_forward i ->
+      Pdec_forward i
 
 let literal (_iter : mapper) (l : literal) = l
 

--- a/meja/src/typedast_map.ml
+++ b/meja/src/typedast_map.ml
@@ -74,7 +74,7 @@ let type_desc mapper typ =
         , mapper.type_expr mapper typ )
 
 let variant mapper {var_ident; var_params; var_implicit_params} =
-  { var_ident= lid mapper var_ident
+  { var_ident= path mapper var_ident
   ; var_params= List.map ~f:(mapper.type_expr mapper) var_params
   ; var_implicit_params=
       List.map ~f:(mapper.type_expr mapper) var_implicit_params }
@@ -168,7 +168,7 @@ let pattern_desc mapper = function
   | Tpat_variable name ->
       Tpat_variable (ident mapper name)
   | Tpat_constraint (pat, typ) ->
-      Tpat_constraint (mapper.pattern mapper pat, mapper.ptype_expr mapper typ)
+      Tpat_constraint (mapper.pattern mapper pat, mapper.type_expr mapper typ)
   | Tpat_tuple pats ->
       Tpat_tuple (List.map ~f:(mapper.pattern mapper) pats)
   | Tpat_or (p1, p2) ->
@@ -210,7 +210,7 @@ let expression_desc mapper = function
         , mapper.expression mapper e1
         , mapper.expression mapper e2 )
   | Texp_constraint (e, typ) ->
-      Texp_constraint (mapper.expression mapper e, mapper.ptype_expr mapper typ)
+      Texp_constraint (mapper.expression mapper e, mapper.type_expr mapper typ)
   | Texp_tuple es ->
       Texp_tuple (List.map ~f:(mapper.expression mapper) es)
   | Texp_match (e, cases) ->
@@ -246,9 +246,9 @@ let signature_item mapper {sig_desc; sig_loc} =
 
 let signature_desc mapper = function
   | Tsig_value (name, typ) ->
-      Tsig_value (ident mapper name, mapper.ptype_expr mapper typ)
+      Tsig_value (ident mapper name, mapper.type_expr mapper typ)
   | Tsig_instance (name, typ) ->
-      Tsig_instance (ident mapper name, mapper.ptype_expr mapper typ)
+      Tsig_instance (ident mapper name, mapper.type_expr mapper typ)
   | Tsig_type decl ->
       Tsig_type (mapper.type_decl mapper decl)
   | Tsig_module (name, msig) ->

--- a/meja/src/typedast_map.ml
+++ b/meja/src/typedast_map.ml
@@ -120,8 +120,6 @@ let type_decl_desc mapper = function
         ( path mapper name
         , mapper.type0.type_decl mapper.type0 decl
         , List.map ~f:(mapper.ctor_decl mapper) ctors )
-  | Pdec_forward i ->
-      Pdec_forward i
 
 let literal (_iter : mapper) (l : literal) = l
 

--- a/meja/src/typet.ml
+++ b/meja/src/typet.ml
@@ -374,8 +374,6 @@ module TypeDecl = struct
                         (List.map typs ~f:(Envi.Type.implicit_params env)) )))
           in
           ({decl with tdec_desc; tdec_implicit_params}, env)
-      | Pdec_forward _ ->
-          failwith "Cannot import a forward type declaration"
     in
     let env = close_expr_scope env in
     let () =

--- a/meja/src/typet.ml
+++ b/meja/src/typet.ml
@@ -237,7 +237,7 @@ module TypeDecl = struct
       let scope, env = Envi.pop_expr_scope env in
       let env =
         match tdec_desc with
-        | TExtend _ ->
+        | Pdec_extend _ ->
             env
         | _ ->
             map_current_scope ~f:(Scope.add_type_declaration decl) env
@@ -246,23 +246,23 @@ module TypeDecl = struct
     in
     let decl, env =
       match tdec_desc with
-      | TAbstract ->
+      | Pdec_abstract ->
           ({decl with tdec_implicit_params}, env)
-      | TAlias typ ->
+      | Pdec_alias typ ->
           let typ, env = Type.import ~must_find:true typ env in
           let tdec_implicit_params =
             add_implicits (Envi.Type.implicit_params env typ)
           in
           ({decl with tdec_desc= TAlias typ; tdec_implicit_params}, env)
-      | TUnfold typ ->
+      | Pdec_unfold typ ->
           let typ, env = Type.import ~must_find:false typ env in
           let tdec_implicit_params =
             add_implicits (Envi.Type.implicit_params env typ)
           in
           ({decl with tdec_desc= TUnfold typ; tdec_implicit_params}, env)
-      | TOpen ->
+      | Pdec_open ->
           ({decl with tdec_desc= TOpen}, env)
-      | TRecord fields ->
+      | Pdec_record fields ->
           let env, fields =
             List.fold_map ~init:env fields ~f:(import_field ~must_find:true)
           in
@@ -273,7 +273,7 @@ module TypeDecl = struct
                       Envi.Type.implicit_params env fld_type )))
           in
           ({decl with tdec_desc= TRecord fields; tdec_implicit_params}, env)
-      | TVariant ctors | TExtend (_, _, ctors) ->
+      | Pdec_variant ctors | Pdec_extend (_, _, ctors) ->
           let env, ctors =
             List.fold_map ~init:env ctors ~f:(fun env ctor ->
                 let scope, env = pop_expr_scope env in
@@ -283,9 +283,9 @@ module TypeDecl = struct
                       let env = open_expr_scope env in
                       let name =
                         match tdec_desc with
-                        | TVariant _ ->
+                        | Pdec_variant _ ->
                             Path.Pident tdec_ident.txt
-                        | TExtend (lid, _, _) ->
+                        | Pdec_extend (lid, _, _) ->
                             lid.txt
                         | _ ->
                             failwith
@@ -343,9 +343,9 @@ module TypeDecl = struct
           in
           let tdec_desc =
             match tdec_desc with
-            | TVariant _ ->
+            | Pdec_variant _ ->
                 Type0.TVariant ctors
-            | TExtend (id, decl, _) ->
+            | Pdec_extend (id, decl, _) ->
                 Type0.TExtend (id.txt, decl, ctors)
             | _ ->
                 failwith "Expected a TVariant or a TExtend"
@@ -374,7 +374,7 @@ module TypeDecl = struct
                         (List.map typs ~f:(Envi.Type.implicit_params env)) )))
           in
           ({decl with tdec_desc; tdec_implicit_params}, env)
-      | TForward _ ->
+      | Pdec_forward _ ->
           failwith "Cannot import a forward type declaration"
     in
     let env = close_expr_scope env in

--- a/meja/src/typet.ml
+++ b/meja/src/typet.ml
@@ -146,7 +146,7 @@ module Type = struct
               in
               (mk (Tctor variant) env, env)
         in
-        ( { type_desc= Ttyp_ctor {var_params; var_ident= variant.var_ident; var_implicit_params}
+        ( { type_desc= Ttyp_ctor {var_params; var_ident; var_implicit_params}
           ; type_loc= loc
           ; type_type= typ }
         , env )
@@ -212,7 +212,9 @@ module TypeDecl = struct
   let import_field ?must_find env {fld_ident; fld_type; fld_loc= _} =
     let mode = Envi.current_mode env in
     let fld_type, env = Type.import ?must_find fld_type env in
-    (env, {Type0.fld_ident= Ident.create ~mode fld_ident.txt; fld_type= fld_type.type_type })
+    ( env
+    , { Type0.fld_ident= Ident.create ~mode fld_ident.txt
+      ; fld_type= fld_type.type_type } )
 
   let import decl' env =
     let mode = Envi.current_mode env in

--- a/meja/src/typet.mli
+++ b/meja/src/typet.mli
@@ -1,7 +1,7 @@
 type error =
   | Unbound_type_var of Parsetypes.type_expr
   | Wrong_number_args of Path.t * int * int
-  | Wrong_number_implicit_args of Longident.t * int * int
+  | Wrong_number_implicit_args of Path.t * int * int
   | Expected_type_var of Parsetypes.type_expr
   | Constraints_not_satisfied of Parsetypes.type_expr * Parsetypes.type_decl
 
@@ -10,7 +10,7 @@ module Type : sig
        ?must_find:bool
     -> Parsetypes.type_expr
     -> Envi.t
-    -> Type0.type_expr * Envi.t
+    -> Typedast.type_expr * Envi.t
 
   val fold :
        init:'a

--- a/meja/src/untype_ast.ml
+++ b/meja/src/untype_ast.ml
@@ -106,8 +106,8 @@ let field_decl {Typedast.fld_ident; fld_type; fld_loc} =
 let ctor_args = function
   | Typedast.Tctor_tuple typs ->
       Parsetypes.Ctor_tuple (List.map ~f:type_expr typs)
-  | Tctor_record (i, fld) ->
-      Ctor_record (i, List.map ~f:field_decl fld)
+  | Tctor_record fld ->
+      Ctor_record (List.map ~f:field_decl fld)
 
 let ctor_decl {Typedast.ctor_ident; ctor_args= args; ctor_ret; ctor_loc} =
   { Parsetypes.ctor_ident

--- a/meja/src/untype_ast.ml
+++ b/meja/src/untype_ast.ml
@@ -74,7 +74,7 @@ module Type0 = struct
     | TExtend _ ->
         failwith "Cannot convert TExtend to a parsetree equivalent"
     | TForward _ ->
-        Type_decl.forward ?loc ?params ?implicits name
+        failwith "Cannot convert TForward to a parsetree equivalent"
 
   and type_decl ?loc decl =
     type_decl_desc ?loc
@@ -130,8 +130,6 @@ let type_decl_desc = function
       Pdec_open
   | Tdec_extend (lid, typ, ctor) ->
       Pdec_extend (lid, typ, List.map ~f:ctor_decl ctor)
-  | Tdec_forward i ->
-      Pdec_forward i
 
 let type_decl
     { Typedast.tdec_ident

--- a/meja/src/untype_ast.ml
+++ b/meja/src/untype_ast.ml
@@ -98,7 +98,8 @@ let rec type_desc = function
   | Ttyp_poly (vars, var) ->
       Ptyp_poly (List.map ~f:type_expr vars, type_expr var)
 
-and type_expr {type_desc= typ; type_loc} = {type_desc= type_desc typ; type_loc}
+and type_expr {type_desc= typ; type_loc; type_type= _} =
+  {type_desc= type_desc typ; type_loc}
 
 let field_decl {Typedast.fld_ident; fld_type; fld_loc} =
   {Parsetypes.fld_ident; fld_type= type_expr fld_type; fld_loc}

--- a/meja/src/untype_ast.ml
+++ b/meja/src/untype_ast.ml
@@ -91,15 +91,18 @@ let rec type_desc = function
       Ptyp_tuple (List.map ~f:type_expr typs)
   | Ttyp_arrow (typ1, typ2, explicit, label) ->
       Ptyp_arrow (type_expr typ1, type_expr typ2, explicit, label)
-  | Ttyp_ctor {var_ident; var_params; var_implicit_params} ->
-      let var_params = List.map ~f:type_expr var_params in
-      let var_implicit_params = List.map ~f:type_expr var_implicit_params in
-      Ptyp_ctor {var_ident; var_params; var_implicit_params}
+  | Ttyp_ctor var ->
+      Ptyp_ctor (variant var)
   | Ttyp_poly (vars, var) ->
       Ptyp_poly (List.map ~f:type_expr vars, type_expr var)
 
 and type_expr {type_desc= typ; type_loc; type_type= _} =
   {type_desc= type_desc typ; type_loc}
+
+and variant {Typedast.var_ident; var_params; var_implicit_params} =
+  let var_params = List.map ~f:type_expr var_params in
+  let var_implicit_params = List.map ~f:type_expr var_implicit_params in
+  {Parsetypes.var_ident; var_params; var_implicit_params}
 
 let field_decl {Typedast.fld_ident; fld_type; fld_loc} =
   {Parsetypes.fld_ident; fld_type= type_expr fld_type; fld_loc}

--- a/meja/src/untype_ast.ml
+++ b/meja/src/untype_ast.ml
@@ -100,9 +100,9 @@ and type_expr {type_desc= typ; type_loc; type_type= _} =
   {type_desc= type_desc typ; type_loc}
 
 and variant {Typedast.var_ident; var_params; var_implicit_params} =
-  let var_params = List.map ~f:type_expr var_params in
-  let var_implicit_params = List.map ~f:type_expr var_implicit_params in
-  {Parsetypes.var_ident; var_params; var_implicit_params}
+  { Parsetypes.var_ident= map_loc ~f:longident_of_path var_ident
+  ; var_params= List.map ~f:type_expr var_params
+  ; var_implicit_params= List.map ~f:type_expr var_implicit_params }
 
 let field_decl {Typedast.fld_ident; fld_type; fld_loc} =
   {Parsetypes.fld_ident; fld_type= type_expr fld_type; fld_loc}
@@ -153,7 +153,7 @@ let rec pattern_desc = function
   | Tpat_variable str ->
       Ppat_variable (map_loc ~f:Ident.name str)
   | Tpat_constraint (p, typ) ->
-      Ppat_constraint (pattern p, typ)
+      Ppat_constraint (pattern p, type_expr typ)
   | Tpat_tuple ps ->
       Ppat_tuple (List.map ~f:pattern ps)
   | Tpat_or (p1, p2) ->
@@ -198,7 +198,7 @@ let rec expression_desc = function
   | Texp_let (p, e1, e2) ->
       Pexp_let (pattern p, expression e1, expression e2)
   | Texp_constraint (e, typ) ->
-      Pexp_constraint (expression e, typ)
+      Pexp_constraint (expression e, type_expr typ)
   | Texp_tuple es ->
       Pexp_tuple (List.map ~f:expression es)
   | Texp_match (e, cases) ->
@@ -228,9 +228,9 @@ and expression e =
 
 let rec signature_desc = function
   | Typedast.Tsig_value (name, typ) ->
-      Parsetypes.Psig_value (map_loc ~f:Ident.name name, typ)
+      Parsetypes.Psig_value (map_loc ~f:Ident.name name, type_expr typ)
   | Tsig_instance (name, typ) ->
-      Psig_instance (map_loc ~f:Ident.name name, typ)
+      Psig_instance (map_loc ~f:Ident.name name, type_expr typ)
   | Tsig_type decl ->
       Psig_type decl
   | Tsig_module (name, msig) ->

--- a/meja/src/untype_ast.ml
+++ b/meja/src/untype_ast.ml
@@ -1,6 +1,5 @@
 open Core_kernel
 open Ast_types
-open Type0
 open Ast_build
 
 let rec longident_of_path = function
@@ -11,75 +10,79 @@ let rec longident_of_path = function
   | Papply (path1, path2) ->
       Lapply (longident_of_path path1, longident_of_path path2)
 
-let rec type_desc ?loc = function
-  | Tvar (None, explicit) ->
-      Type.none ?loc ~explicit ()
-  | Tvar (Some name, explicit) ->
-      Type.var ?loc ~explicit name
-  | Ttuple typs ->
-      Type.tuple ?loc (List.map ~f:(type_expr ?loc) typs)
-  | Tarrow (typ1, typ2, explicit, label) ->
-      Type.arrow ?loc ~explicit ~label (type_expr ?loc typ1)
-        (type_expr ?loc typ2)
-  | Tctor
-      { var_ident= ident
-      ; var_params= params
-      ; var_implicit_params= implicits
-      ; var_decl= _ } ->
-      let params = List.map ~f:(type_expr ?loc) params in
-      let implicits = List.map ~f:(type_expr ?loc) implicits in
-      Type.constr ?loc ~params ~implicits (longident_of_path ident)
-  | Tpoly (vars, var) ->
-      Type.poly ?loc (List.map ~f:(type_expr ?loc) vars) (type_expr ?loc var)
+module Type0 = struct
+  open Type0
 
-and type_expr ?loc typ = type_desc ?loc typ.type_desc
+  let rec type_desc ?loc = function
+    | Tvar (None, explicit) ->
+        Type.none ?loc ~explicit ()
+    | Tvar (Some name, explicit) ->
+        Type.var ?loc ~explicit name
+    | Ttuple typs ->
+        Type.tuple ?loc (List.map ~f:(type_expr ?loc) typs)
+    | Tarrow (typ1, typ2, explicit, label) ->
+        Type.arrow ?loc ~explicit ~label (type_expr ?loc typ1)
+          (type_expr ?loc typ2)
+    | Tctor
+        { var_ident= ident
+        ; var_params= params
+        ; var_implicit_params= implicits
+        ; var_decl= _ } ->
+        let params = List.map ~f:(type_expr ?loc) params in
+        let implicits = List.map ~f:(type_expr ?loc) implicits in
+        Type.constr ?loc ~params ~implicits (longident_of_path ident)
+    | Tpoly (vars, var) ->
+        Type.poly ?loc (List.map ~f:(type_expr ?loc) vars) (type_expr ?loc var)
 
-let field_decl ?loc fld =
-  Type_decl.Field.mk ?loc (Ident.name fld.fld_ident)
-    (type_expr ?loc fld.fld_type)
+  and type_expr ?loc typ = type_desc ?loc typ.type_desc
 
-let ctor_args ?loc ?ret name = function
-  | Ctor_tuple typs ->
-      Type_decl.Ctor.with_args ?loc ?ret name
-        (List.map ~f:(type_expr ?loc) typs)
-  | Ctor_record {tdec_desc= TRecord fields; _} ->
-      Type_decl.Ctor.with_record ?loc ?ret name
-        (List.map ~f:(field_decl ?loc) fields)
-  | Ctor_record _ ->
-      assert false
+  let field_decl ?loc fld =
+    Type_decl.Field.mk ?loc (Ident.name fld.fld_ident)
+      (type_expr ?loc fld.fld_type)
 
-let ctor_decl ?loc ctor =
-  ctor_args ?loc
-    (Ident.name ctor.ctor_ident)
-    ctor.ctor_args
-    ?ret:(Option.map ~f:(type_expr ?loc) ctor.ctor_ret)
+  let ctor_args ?loc ?ret name = function
+    | Ctor_tuple typs ->
+        Type_decl.Ctor.with_args ?loc ?ret name
+          (List.map ~f:(type_expr ?loc) typs)
+    | Ctor_record {tdec_desc= TRecord fields; _} ->
+        Type_decl.Ctor.with_record ?loc ?ret name
+          (List.map ~f:(field_decl ?loc) fields)
+    | Ctor_record _ ->
+        assert false
 
-let rec type_decl_desc ?loc ?params ?implicits name = function
-  | TAbstract ->
-      Type_decl.abstract ?loc ?params ?implicits name
-  | TAlias typ ->
-      Type_decl.alias ?loc ?params ?implicits name (type_expr typ)
-  | TUnfold typ ->
-      Type_decl.unfold ?loc ?params ?implicits name (type_expr typ)
-  | TRecord fields ->
-      Type_decl.record ?loc ?params ?implicits name
-        (List.map ~f:field_decl fields)
-  | TVariant ctors ->
-      Type_decl.variant ?loc ?params ?implicits name
-        (List.map ~f:ctor_decl ctors)
-  | TOpen ->
-      Type_decl.open_ ?loc ?params ?implicits name
-  | TExtend _ ->
-      failwith "Cannot convert TExtend to a parsetree equivalent"
-  | TForward _ ->
-      Type_decl.forward ?loc ?params ?implicits name
+  let ctor_decl ?loc ctor =
+    ctor_args ?loc
+      (Ident.name ctor.ctor_ident)
+      ctor.ctor_args
+      ?ret:(Option.map ~f:(type_expr ?loc) ctor.ctor_ret)
 
-and type_decl ?loc decl =
-  type_decl_desc ?loc
-    ~params:(List.map ~f:type_expr decl.tdec_params)
-    ~implicits:(List.map ~f:type_expr decl.tdec_implicit_params)
-    (Ident.name decl.tdec_ident)
-    decl.tdec_desc
+  let rec type_decl_desc ?loc ?params ?implicits name = function
+    | TAbstract ->
+        Type_decl.abstract ?loc ?params ?implicits name
+    | TAlias typ ->
+        Type_decl.alias ?loc ?params ?implicits name (type_expr typ)
+    | TUnfold typ ->
+        Type_decl.unfold ?loc ?params ?implicits name (type_expr typ)
+    | TRecord fields ->
+        Type_decl.record ?loc ?params ?implicits name
+          (List.map ~f:field_decl fields)
+    | TVariant ctors ->
+        Type_decl.variant ?loc ?params ?implicits name
+          (List.map ~f:ctor_decl ctors)
+    | TOpen ->
+        Type_decl.open_ ?loc ?params ?implicits name
+    | TExtend _ ->
+        failwith "Cannot convert TExtend to a parsetree equivalent"
+    | TForward _ ->
+        Type_decl.forward ?loc ?params ?implicits name
+
+  and type_decl ?loc decl =
+    type_decl_desc ?loc
+      ~params:(List.map ~f:type_expr decl.tdec_params)
+      ~implicits:(List.map ~f:type_expr decl.tdec_implicit_params)
+      (Ident.name decl.tdec_ident)
+      decl.tdec_desc
+end
 
 let rec pattern_desc = function
   | Typedast.Tpat_any ->

--- a/meja/tests/magic-field.ml
+++ b/meja/tests/magic-field.ml
@@ -17,8 +17,7 @@ type (_, 'field) variant_with_field_param =
   | A : (int, 'field) variant_with_field_param
   | B : ('field, 'field) variant_with_field_param
 
-let add3 (add : 'field -> 'field -> 'field) (x : 'field) (y : 'field)
-    (z : 'field) =
+let add3 (add : field -> field -> field) (x : field) (y : field) (z : field) =
   add (add x y) z
 
 let test_add3 (add : int -> int -> int) = add3 add 1 2 3


### PR DESCRIPTION
This PR
* moves the `Type0.*` conversion in `Untype_ast` into a `Type0` submodule
* renames some awkwardly-named `Parsetypes` constructors so that they don't clash with `Type0`'s
* removes the type forward-declarations from `Parsetypes`
  - only the `Type0` versions are ever used
* removes some unused constructor/record arguments
* adds `type_expr`, `type_desc`, etc. to `Typedast`, along with an extra `type_type` parameter that refers to the typechecker's `Type0.type_expr`
* make `Typet.import` return a `Typedast.type_expr`
* giving the wrong number of implicit arguments (not currently exposed by the parser) now throws a type error

This work is incomplete -- we should be using these `Typedast` versions in all places in the typed AST that we originally parsed a type -- but we need the mapper from #318 before we can fix-up the names in types the way that we can with `Type0.*`. At the moment, the `Typedast` version generated by `Typet.import` is just thrown away :(

Eventual benefits:
* user-typed type variables won't get overwritten when they unify in the typechecker
  - think `let f : 'a -> int -> int = fun (a, b) => {a + b;};`
* typechecker-generated variables won't be exposed in the OCaml AST
  - this currently causes some generated code that doesn't compile, because distinct type variables may end up with the same name under some circumstances
* we don't lose any location information after converting types
* typechecker types don't need to map exactly to parser types
  - in particular, the codegen stage can manipulate these AST types with access to the underlying type information but without having to worry about changing the typechecker's types