### PR TITLE
[Meja] Unique identifiers

### DIFF
--- a/meja/meja.ml
+++ b/meja/meja.ml
@@ -177,13 +177,9 @@ let main =
                        Snarky.@.") ;
                   exit 1
               in
-              let env =
-                Envi.add_module (mkloc (Ident.create "Request")) m env
-              in
+              let env = Envi.add_module (Ident.create "Request") m env in
               let m, env = Envi.pop_module ~loc env in
-              let env =
-                Envi.add_module (mkloc (Ident.create "Snarky")) m env
-              in
+              let env = Envi.add_module (Ident.create "Snarky") m env in
               Envi.pop_module ~loc env
             in
             Envi.open_namespace_scope m env
@@ -222,7 +218,7 @@ let main =
           in
           let env, _typed_ast = Typechecker.check_signature env parse_ast in
           let m, env = Envi.pop_module ~loc:Location.none env in
-          let name = Location.(mkloc (Ident.create module_name) none) in
+          let name = Ident.create module_name in
           Envi.add_module name m env )
     in
     let file =

--- a/meja/meja.ml
+++ b/meja/meja.ml
@@ -177,9 +177,13 @@ let main =
                        Snarky.@.") ;
                   exit 1
               in
-              let env = Envi.add_module (mkloc "Request") m env in
+              let env =
+                Envi.add_module (mkloc (Ident.create "Request")) m env
+              in
               let m, env = Envi.pop_module ~loc env in
-              let env = Envi.add_module (mkloc "Snarky") m env in
+              let env =
+                Envi.add_module (mkloc (Ident.create "Snarky")) m env
+              in
               Envi.pop_module ~loc env
             in
             Envi.open_namespace_scope m env
@@ -218,7 +222,7 @@ let main =
           in
           let env, _typed_ast = Typechecker.check_signature env parse_ast in
           let m, env = Envi.pop_module ~loc:Location.none env in
-          let name = Location.(mkloc module_name none) in
+          let name = Location.(mkloc (Ident.create module_name) none) in
           Envi.add_module name m env )
     in
     let file =

--- a/meja/src/envi.ml
+++ b/meja/src/envi.ml
@@ -523,10 +523,10 @@ let add_type_variable name typ =
 let find_type_variable name env =
   List.find_map ~f:(Scope.find_type_variable name) env.scope_stack
 
-let add_module (name : ident) m =
+let add_module (name : Ident.t) m =
   map_current_scope ~f:(fun scope ->
-      let scope = Scope.add_module name.txt (Scope.Immediate m) scope in
-      let paths = Scope.extend_paths (Ident.name name.txt) m.Scope.paths in
+      let scope = Scope.add_module name (Scope.Immediate m) scope in
+      let paths = Scope.extend_paths (Ident.name name) m.Scope.paths in
       { scope with
         instances=
           Map.merge scope.instances m.instances ~f:(fun ~key:_ data ->
@@ -534,13 +534,13 @@ let add_module (name : ident) m =
               | `Left x ->
                   Some x
               | `Both (_, x) | `Right x ->
-                  Some (Longident.add_outer_module (Ident.name name.txt) x) )
+                  Some (Longident.add_outer_module (Ident.name name) x) )
       ; (* Prefer the shorter paths in the current module to those in the
            module we are adding. *)
         paths= Scope.join_paths paths scope.paths } )
 
-let add_deferred_module (name : ident) lid =
-  map_current_scope ~f:(Scope.add_module name.txt (Scope.Deferred lid))
+let add_deferred_module (name : Ident.t) lid =
+  map_current_scope ~f:(Scope.add_module name (Scope.Deferred lid))
 
 let register_external_module name x env =
   env.resolve_env.external_modules

--- a/meja/src/ident.ml
+++ b/meja/src/ident.ml
@@ -26,20 +26,20 @@ module Table = struct
 
   let is_empty = String.Map.is_empty
 
+  let remove_from_row ident =
+    List.filter ~f:(fun (ident2, _) -> not (Int.equal (compare ident ident2) 0))
+
   let add ~key:ident ~data tbl =
     Map.change tbl (name ident) ~f:(function
       | Some row ->
-          Some ((ident, data) :: row)
+          Some ((ident, data) :: remove_from_row ident row)
       | None ->
           Some [(ident, data)] )
 
   let remove ident tbl =
     Map.change tbl (name ident) ~f:(function
       | Some row ->
-          let row =
-            List.filter row ~f:(fun (ident2, _) ->
-                not (Int.equal (compare ident ident2) 0) )
-          in
+          let row = remove_from_row ident row in
           if List.is_empty row then None else Some row
       | None ->
           None )
@@ -57,4 +57,28 @@ module Table = struct
   let first_exn tbl = List.hd_exn (snd (Map.min_elt_exn tbl))
 
   let keys tbl = List.concat_map ~f:(List.map ~f:fst) (Map.data tbl)
+
+  let fold2_names tbl1 tbl2 ~init ~f =
+    Map.fold2 tbl1 tbl2 ~init ~f:(fun ~key ~data acc ->
+        let data =
+          match data with
+          | `Both ((_, v1) :: _, (_, v2) :: _) ->
+              `Both (v1, v2)
+          | `Left ((_, v1) :: _) ->
+              `Left v1
+          | `Right ((_, v2) :: _) ->
+              `Right v2
+          | _ ->
+              assert false
+        in
+        f ~key ~data acc )
+
+  let merge_skewed_names tbl1 tbl2 ~combine =
+    Map.merge_skewed tbl1 tbl2 ~combine:(fun ~key v1 v2 ->
+        let res = combine ~key (List.hd_exn v1) (List.hd_exn v2) in
+        if not (String.equal (name (fst res)) key) then
+          failwith
+            "merge_skewed_names: The name provided by combine does not match \
+             the key" ;
+        (res :: v1) @ v2 )
 end

--- a/meja/src/ident.ml
+++ b/meja/src/ident.ml
@@ -14,8 +14,17 @@ let name {ident_name= name; _} = name
 
 let compare {ident_id= id1; _} {ident_id= id2; _} = Int.compare id1 id2
 
+let pprint fmt {ident_name; _} = Ast_types.pp_name fmt ident_name
+
+let debug_print fmt {ident_name; ident_id} =
+  Format.fprintf fmt "%s/%i" ident_name ident_id
+
 module Table = struct
   type 'a t = (ident * 'a) list String.Map.t
+
+  let empty = String.Map.empty
+
+  let is_empty = String.Map.is_empty
 
   let add ~key:ident ~data tbl =
     Map.change tbl (name ident) ~f:(function
@@ -29,7 +38,7 @@ module Table = struct
       | Some row ->
           let row =
             List.filter row ~f:(fun (ident2, _) ->
-                Int.equal (compare ident ident2) 0 )
+                not (Int.equal (compare ident ident2) 0) )
           in
           if List.is_empty row then None else Some row
       | None ->
@@ -44,4 +53,8 @@ module Table = struct
         None
 
   let find_name name tbl = Option.bind ~f:List.hd (Map.find tbl name)
+
+  let first_exn tbl = List.hd_exn (snd (Map.min_elt_exn tbl))
+
+  let keys tbl = List.concat_map ~f:(List.map ~f:fst) (Map.data tbl)
 end

--- a/meja/src/ident.ml
+++ b/meja/src/ident.ml
@@ -1,0 +1,47 @@
+open Core_kernel
+
+type t = {ident_id: int; ident_name: string} [@@deriving sexp]
+
+type ident = t
+
+let current_id = ref 0
+
+let create name =
+  incr current_id ;
+  {ident_id= !current_id; ident_name= name}
+
+let name {ident_name= name; _} = name
+
+let compare {ident_id= id1; _} {ident_id= id2; _} = Int.compare id1 id2
+
+module Table = struct
+  type 'a t = (ident * 'a) list String.Map.t
+
+  let add ~key:ident ~data tbl =
+    Map.change tbl (name ident) ~f:(function
+      | Some row ->
+          Some ((ident, data) :: row)
+      | None ->
+          Some [(ident, data)] )
+
+  let remove ident tbl =
+    Map.change tbl (name ident) ~f:(function
+      | Some row ->
+          let row =
+            List.filter row ~f:(fun (ident2, _) ->
+                Int.equal (compare ident ident2) 0 )
+          in
+          if List.is_empty row then None else Some row
+      | None ->
+          None )
+
+  let find ident tbl =
+    match Map.find tbl (name ident) with
+    | Some row ->
+        List.find_map row ~f:(fun (ident2, data) ->
+            if Int.equal (compare ident ident2) 0 then Some data else None )
+    | None ->
+        None
+
+  let find_name name tbl = Option.bind ~f:List.hd (Map.find tbl name)
+end

--- a/meja/src/ident.mli
+++ b/meja/src/ident.mli
@@ -1,0 +1,40 @@
+(** Unique identifiers. *)
+type t [@@deriving sexp]
+
+type ident = t
+
+val create : string -> t
+(** Create a new unique name. *)
+
+val name : t -> string
+(** Retrieve the name passed to [create]. *)
+
+val compare : t -> t -> int
+(** Compare two names. This is 0 iff they originate from the same call to
+    [create].
+*)
+
+module Table : sig
+  (** An associative map from [ident]s, with direct name lookups. *)
+  type 'a t
+
+  val add : key:ident -> data:'a -> 'a t -> 'a t
+  (** [add ~key:ident ~data tbl] returns the table [tbl] extended with [ident]
+      associated to [data].
+      Any previous association with [ident] is replaced, and the name
+      [name ident] is also associated with [data].
+  *)
+
+  val remove : ident -> 'a t -> 'a t
+  (** Returns the table with the binding to the given ident removed. *)
+
+  val find : ident -> 'a t -> 'a option
+  (** Returns the value bound to the given ident in the table if it exists, or
+      [None] otherwise.
+  *)
+
+  val find_name : string -> 'a t -> (ident * 'a) option
+  (** [find_name name tbl] returns the most recently bound [ident] and its
+      associated value if it exists, or [None] otherwise.
+  *)
+end

--- a/meja/src/ident.mli
+++ b/meja/src/ident.mli
@@ -57,4 +57,29 @@ module Table : sig
 
   val keys : 'a t -> ident list
   (** Returns a list of the bound identifiers. *)
+
+  val fold2_names :
+       'v1 t
+    -> 'v2 t
+    -> init:'a
+    -> f:(   key:string
+          -> data:[`Both of 'v1 * 'v2 | `Left of 'v1 | `Right of 'v2]
+          -> 'a
+          -> 'a)
+    -> 'a
+  (** Fold over names in the two tables, in order of increasing key. *)
+
+  val merge_skewed_names :
+       'v t
+    -> 'v t
+    -> combine:(key:string -> ident * 'v -> ident * 'v -> ident * 'v)
+    -> 'v t
+  (** Merge the bindings in the two tables. When the same name is bound in
+      both, [combine] is used to decide the preferred binding.
+      Throws [Failure] if the result of [combine] has a different name to
+      [key].
+
+      When an [ident] is bound in both tables but does not appear in
+      [find_name] for its name, the bound value from the first table is chosen.
+  *)
 end

--- a/meja/src/ident.mli
+++ b/meja/src/ident.mli
@@ -14,9 +14,23 @@ val compare : t -> t -> int
     [create].
 *)
 
+val pprint : Format.formatter -> t -> unit
+(** Pretty print. Identifiers that do not begin with a letter or underscore
+    will be surrounded by parentheses.
+*)
+
+val debug_print : Format.formatter -> t -> unit
+(** Debug print. Prints the identifier and its internal ID. *)
+
 module Table : sig
   (** An associative map from [ident]s, with direct name lookups. *)
   type 'a t
+
+  val empty : 'a t
+  (** An empty table. *)
+
+  val is_empty : 'a t -> bool
+  (** Returns [true] if the table is empty, false otherwise. *)
 
   val add : key:ident -> data:'a -> 'a t -> 'a t
   (** [add ~key:ident ~data tbl] returns the table [tbl] extended with [ident]
@@ -37,4 +51,10 @@ module Table : sig
   (** [find_name name tbl] returns the most recently bound [ident] and its
       associated value if it exists, or [None] otherwise.
   *)
+
+  val first_exn : 'a t -> ident * 'a
+  (** Returns the binding to the first name (under lexical ordering). *)
+
+  val keys : 'a t -> ident list
+  (** Returns a list of the bound identifiers. *)
 end

--- a/meja/src/parsetypes_iter.ml
+++ b/meja/src/parsetypes_iter.ml
@@ -30,13 +30,18 @@ type iterator =
   ; longident: iterator -> Longident.t -> unit
   ; type0_decl: iterator -> Type0.type_decl -> unit }
 
+let lid iter {Location.txt; loc} =
+  iter.longident iter txt ; iter.location iter loc
+
+let str iter ({Location.txt= _; loc} : str) = iter.location iter loc
+
 let type_expr iter {type_desc; type_loc} =
   iter.location iter type_loc ;
   iter.type_desc iter type_desc
 
 let type_desc iter = function
   | Ptyp_var (name, _) ->
-      Option.iter ~f:(fun name -> iter.location iter name.Location.loc) name
+      Option.iter ~f:(str iter) name
   | Ptyp_tuple typs ->
       List.iter ~f:(iter.type_expr iter) typs
   | Ptyp_arrow (typ1, typ2, _, _) ->
@@ -48,14 +53,13 @@ let type_desc iter = function
       iter.type_expr iter typ
 
 let variant iter {var_ident; var_params; var_implicit_params} =
-  iter.location iter var_ident.loc ;
-  iter.longident iter var_ident.txt ;
+  lid iter var_ident ;
   List.iter ~f:(iter.type_expr iter) var_params ;
   List.iter ~f:(iter.type_expr iter) var_implicit_params
 
 let field_decl iter {fld_ident; fld_type; fld_loc} =
   iter.location iter fld_loc ;
-  iter.location iter fld_ident.loc ;
+  str iter fld_ident ;
   iter.type_expr iter fld_type
 
 let ctor_args iter = function
@@ -66,14 +70,14 @@ let ctor_args iter = function
 
 let ctor_decl iter {ctor_ident; ctor_args; ctor_ret; ctor_loc} =
   iter.location iter ctor_loc ;
-  iter.location iter ctor_ident.loc ;
+  str iter ctor_ident ;
   iter.ctor_args iter ctor_args ;
   Option.iter ~f:(iter.type_expr iter) ctor_ret
 
 let type_decl iter
     {tdec_ident; tdec_params; tdec_implicit_params; tdec_desc; tdec_loc} =
   iter.location iter tdec_loc ;
-  iter.location iter tdec_ident.loc ;
+  str iter tdec_ident ;
   List.iter ~f:(iter.type_expr iter) tdec_params ;
   List.iter ~f:(iter.type_expr iter) tdec_implicit_params ;
   iter.type_decl_desc iter tdec_desc
@@ -92,8 +96,7 @@ let type_decl_desc iter = function
   | TOpen ->
       ()
   | TExtend (name, decl, ctors) ->
-      iter.location iter name.loc ;
-      iter.longident iter name.txt ;
+      lid iter name ;
       iter.type0_decl iter decl ;
       List.iter ~f:(iter.ctor_decl iter) ctors
   | TForward _ ->
@@ -109,7 +112,7 @@ let pattern_desc iter = function
   | Ppat_any ->
       ()
   | Ppat_variable name ->
-      iter.location iter name.loc
+      str iter name
   | Ppat_constraint (pat, typ) ->
       iter.type_expr iter typ ; iter.pattern iter pat
   | Ppat_tuple pats ->
@@ -120,12 +123,9 @@ let pattern_desc iter = function
       ()
   | Ppat_record fields ->
       List.iter fields ~f:(fun (name, pat) ->
-          iter.location iter name.loc ;
-          iter.longident iter name.txt ;
-          iter.pattern iter pat )
+          lid iter name ; iter.pattern iter pat )
   | Ppat_ctor (name, arg) ->
-      iter.location iter name.loc ;
-      iter.longident iter name.txt ;
+      lid iter name ;
       Option.iter ~f:(iter.pattern iter) arg
 
 let expression iter {exp_desc; exp_loc} =
@@ -137,15 +137,13 @@ let expression_desc iter = function
       iter.expression iter e ;
       List.iter args ~f:(fun (_label, e) -> iter.expression iter e)
   | Pexp_variable name ->
-      iter.location iter name.loc ;
-      iter.longident iter name.txt
+      lid iter name
   | Pexp_literal l ->
       iter.literal iter l
   | Pexp_fun (_label, p, e, _explicit) ->
       iter.pattern iter p ; iter.expression iter e
   | Pexp_newtype (name, e) ->
-      iter.location iter name.loc ;
-      iter.expression iter e
+      str iter name ; iter.expression iter e
   | Pexp_seq (e1, e2) ->
       iter.expression iter e1 ; iter.expression iter e2
   | Pexp_let (p, e1, e2) ->
@@ -159,21 +157,16 @@ let expression_desc iter = function
       List.iter cases ~f:(fun (p, e) ->
           iter.pattern iter p ; iter.expression iter e )
   | Pexp_field (e, name) ->
-      iter.location iter name.loc ;
-      iter.longident iter name.txt ;
-      iter.expression iter e
+      lid iter name ; iter.expression iter e
   | Pexp_record (bindings, default) ->
       Option.iter ~f:(iter.expression iter) default ;
       List.iter bindings ~f:(fun (name, e) ->
-          iter.location iter name.loc ;
-          iter.longident iter name.txt ;
-          iter.expression iter e )
+          lid iter name ; iter.expression iter e )
   | Pexp_ctor (name, arg) ->
-      iter.location iter name.loc ;
-      iter.longident iter name.txt ;
+      lid iter name ;
       Option.iter ~f:(iter.expression iter) arg
   | Pexp_unifiable {expression; name; id= _} ->
-      iter.location iter name.loc ;
+      str iter name ;
       Option.iter ~f:(iter.expression iter) expression
   | Pexp_if (e1, e2, e3) ->
       iter.expression iter e1 ;
@@ -188,16 +181,13 @@ let signature_item iter {sig_desc; sig_loc} =
 
 let signature_desc iter = function
   | Psig_value (name, typ) | Psig_instance (name, typ) ->
-      iter.location iter name.loc ;
-      iter.type_expr iter typ
+      str iter name ; iter.type_expr iter typ
   | Psig_type decl ->
       iter.type_decl iter decl
   | Psig_module (name, msig) | Psig_modtype (name, msig) ->
-      iter.location iter name.loc ;
-      iter.module_sig iter msig
+      str iter name ; iter.module_sig iter msig
   | Psig_open name ->
-      iter.location iter name.loc ;
-      iter.longident iter name.txt
+      lid iter name
   | Psig_typeext (typ, ctors) ->
       iter.variant iter typ ;
       List.iter ~f:(iter.ctor_decl iter) ctors
@@ -214,14 +204,11 @@ let module_sig_desc iter = function
   | Pmty_sig sigs ->
       iter.signature iter sigs
   | Pmty_name name ->
-      iter.location iter name.loc ;
-      iter.longident iter name.txt
+      lid iter name
   | Pmty_abstract ->
       ()
   | Pmty_functor (name, fsig, msig) ->
-      iter.location iter name.loc ;
-      iter.module_sig iter fsig ;
-      iter.module_sig iter msig
+      str iter name ; iter.module_sig iter fsig ; iter.module_sig iter msig
 
 let statements iter = List.iter ~f:(iter.statement iter)
 
@@ -233,19 +220,15 @@ let statement_desc iter = function
   | Pstmt_value (p, e) ->
       iter.pattern iter p ; iter.expression iter e
   | Pstmt_instance (name, e) ->
-      iter.location iter name.loc ;
-      iter.expression iter e
+      str iter name ; iter.expression iter e
   | Pstmt_type decl ->
       iter.type_decl iter decl
   | Pstmt_module (name, me) ->
-      iter.location iter name.loc ;
-      iter.module_expr iter me
+      str iter name ; iter.module_expr iter me
   | Pstmt_modtype (name, mty) ->
-      iter.location iter name.loc ;
-      iter.module_sig iter mty
+      str iter name ; iter.module_sig iter mty
   | Pstmt_open name ->
-      iter.location iter name.loc ;
-      iter.longident iter name.txt
+      lid iter name
   | Pstmt_typeext (typ, ctors) ->
       iter.variant iter typ ;
       List.iter ~f:(iter.ctor_decl iter) ctors
@@ -266,12 +249,9 @@ let module_desc iter = function
   | Pmod_struct stmts ->
       iter.statements iter stmts
   | Pmod_name name ->
-      iter.location iter name.loc ;
-      iter.longident iter name.txt
+      lid iter name
   | Pmod_functor (name, fsig, me) ->
-      iter.location iter name.loc ;
-      iter.module_sig iter fsig ;
-      iter.module_expr iter me
+      str iter name ; iter.module_sig iter fsig ; iter.module_expr iter me
 
 let location (_iter : iterator) (_ : Location.t) = ()
 

--- a/meja/src/type0.ml
+++ b/meja/src/type0.ml
@@ -22,17 +22,17 @@ and variant =
   ; var_decl: type_decl }
 [@@deriving sexp]
 
-and field_decl = {fld_ident: string; fld_type: type_expr} [@@deriving sexp]
+and field_decl = {fld_ident: Ident.t; fld_type: type_expr} [@@deriving sexp]
 
 and ctor_args = Ctor_tuple of type_expr list | Ctor_record of type_decl
 [@@deriving sexp]
 
 and ctor_decl =
-  {ctor_ident: string; ctor_args: ctor_args; ctor_ret: type_expr option}
+  {ctor_ident: Ident.t; ctor_args: ctor_args; ctor_ret: type_expr option}
 [@@deriving sexp]
 
 and type_decl =
-  { tdec_ident: string
+  { tdec_ident: Ident.t
   ; tdec_params: type_expr list
   ; tdec_implicit_params: type_expr list
   ; tdec_desc: type_decl_desc

--- a/meja/src/typechecker.ml
+++ b/meja/src/typechecker.ml
@@ -1079,9 +1079,9 @@ let rec check_signature_item env item =
       let env =
         match m with
         | Envi.Scope.Immediate m ->
-            Envi.add_module name m env
+            Envi.add_module name.txt m env
         | Envi.Scope.Deferred path ->
-            Envi.add_deferred_module name path env
+            Envi.add_deferred_module name.txt path env
       in
       (env, {Typedast.sig_desc= Tsig_module (name, msig); sig_loc= loc})
   | Psig_modtype (name, signature) ->
@@ -1159,9 +1159,9 @@ and check_module_sig env path msig =
         let env =
           match f_instance with
           | Envi.Scope.Immediate f ->
-              Envi.add_module f_name f env
+              Envi.add_module f_name.txt f env
           | Envi.Scope.Deferred path ->
-              Envi.add_deferred_module f_name path env
+              Envi.add_deferred_module f_name.txt path env
         in
         (* TODO: check that f_instance matches f_mty *)
         let msig, m, _env = check_module_sig env path msig in
@@ -1225,7 +1225,7 @@ let rec check_statement env stmt =
       let env, m = check_module_expr env m in
       let m_env, env = Envi.pop_module ~loc env in
       let name = map_loc ~f:Ident.create name in
-      let env = Envi.add_module name m_env env in
+      let env = Envi.add_module name.txt m_env env in
       (env, {Typedast.stmt_loc= loc; stmt_desc= Tstmt_module (name, m)})
   | Pstmt_modtype (name, signature) ->
       let signature, m_env, env =
@@ -1364,9 +1364,9 @@ and check_module_expr env m =
         let env =
           match f_instance with
           | Envi.Scope.Immediate f ->
-              Envi.add_module f_name f env
+              Envi.add_module f_name.txt f env
           | Envi.Scope.Deferred path ->
-              Envi.add_deferred_module f_name path env
+              Envi.add_deferred_module f_name.txt path env
         in
         (* TODO: check that f_instance matches f' *)
         let env = Envi.open_absolute_module (Some path) env in

--- a/meja/src/typechecker.ml
+++ b/meja/src/typechecker.ml
@@ -359,20 +359,22 @@ let get_ctor (name : lid) env =
   let loc = name.loc in
   match (Envi.TypeDecl.find_of_constructor name env, name.txt) with
   | ( Some
-        ( ( { tdec_desc= TVariant ctors
+        ( _
+        , ( ( { tdec_desc= TVariant ctors
+              ; tdec_ident
+              ; tdec_params
+              ; tdec_implicit_params
+              ; _ } as decl )
+          , i ) )
+    , name )
+  | ( Some
+        ( _
+        , ( { tdec_desc= TExtend (name, decl, ctors)
             ; tdec_ident
             ; tdec_params
             ; tdec_implicit_params
-            ; _ } as decl )
-        , i )
-    , name )
-  | ( Some
-        ( { tdec_desc= TExtend (name, decl, ctors)
-          ; tdec_ident
-          ; tdec_params
-          ; tdec_implicit_params
-          ; _ }
-        , i )
+            ; _ }
+          , i ) )
     , _ ) ->
       let ctor = List.nth_exn ctors i in
       let make_name tdec_ident =

--- a/meja/src/typechecker.ml
+++ b/meja/src/typechecker.ml
@@ -427,7 +427,8 @@ let rec check_pattern ~add env typ pat =
   | Ppat_any ->
       ({Typedast.pat_loc= loc; pat_type= typ; pat_desc= Tpat_any}, env)
   | Ppat_variable str ->
-      let env = add str typ env in
+      let name = map_loc ~f:Ident.create str in
+      let env = add name.txt typ env in
       ({Typedast.pat_loc= loc; pat_type= typ; pat_desc= Tpat_variable str}, env)
   | Ppat_constraint (p, constr_typ) ->
       let ctyp, env = Typet.Type.import constr_typ env in
@@ -982,7 +983,8 @@ and check_binding ?(toplevel = false) (env : Envi.t) p e : 's =
         if Set.is_empty typ_vars then e.exp_type
         else Envi.Type.mk (Tpoly (Set.to_list typ_vars, e.exp_type)) env
       in
-      let env = Envi.add_name str typ env in
+      let name = map_loc ~f:Ident.create str in
+      let env = Envi.add_name name.txt typ env in
       let p =
         {Typedast.pat_loc= loc; pat_type= typ; pat_desc= Tpat_variable str}
       in
@@ -994,7 +996,8 @@ and check_binding ?(toplevel = false) (env : Envi.t) p e : 's =
         if Set.is_empty typ_vars then ctyp
         else Envi.Type.mk (Tpoly (Set.to_list typ_vars, ctyp)) env
       in
-      let env = Envi.add_name str ctyp env in
+      let name = map_loc ~f:Ident.create str in
+      let env = Envi.add_name name.txt ctyp env in
       let p' =
         { Typedast.pat_loc= p'.pat_loc
         ; pat_type= ctyp
@@ -1066,14 +1069,16 @@ let rec check_signature_item env item =
       let typ', env = Typet.Type.import typ env in
       let env = Envi.close_expr_scope env in
       Envi.Type.update_depths env typ' ;
-      let env = add_polymorphised name typ' env in
+      let name' = map_loc ~f:Ident.create name in
+      let env = add_polymorphised name'.txt typ' env in
       (env, {Typedast.sig_desc= Tsig_value (name, typ); sig_loc= loc})
   | Psig_instance (name, typ) ->
       let env = Envi.open_expr_scope env in
       let typ', env = Typet.Type.import typ env in
       let env = Envi.close_expr_scope env in
       Envi.Type.update_depths env typ' ;
-      let env = add_polymorphised name typ' env in
+      let name' = map_loc ~f:Ident.create name in
+      let env = add_polymorphised name'.txt typ' env in
       let env = Envi.add_implicit_instance name.txt typ' env in
       (env, {Typedast.sig_desc= Tsig_instance (name, typ); sig_loc= loc})
   | Psig_type decl ->

--- a/meja/src/typechecker.ml
+++ b/meja/src/typechecker.ml
@@ -317,8 +317,9 @@ let get_field (field : lid) env =
   let loc = field.loc in
   match Envi.TypeDecl.find_of_field field env with
   | Some
-      ( ({tdec_desc= TRecord field_decls; tdec_ident; tdec_params; _} as decl)
-      , i ) ->
+      ( _ident
+      , ( ({tdec_desc= TRecord field_decls; tdec_ident; tdec_params; _} as decl)
+        , i ) ) ->
       let vars, bound_vars, _ =
         Envi.Type.refresh_vars ~loc tdec_params Int.Map.empty env
       in
@@ -493,8 +494,10 @@ let rec check_pattern ~add env typ pat =
             (typ, field_decls, bound_vars, env)
         | _ -> (
           match Envi.TypeDecl.find_of_field field env with
-          | Some (({tdec_desc= TRecord field_decls; tdec_params; _} as decl), _)
-            ->
+          | Some
+              ( _ident
+              , (({tdec_desc= TRecord field_decls; tdec_params; _} as decl), _)
+              ) ->
               let vars, bound_vars, env =
                 Envi.Type.refresh_vars ~loc tdec_params Int.Map.empty env
               in
@@ -746,8 +749,10 @@ let rec get_expression env expected exp =
             None
         | Ldot (path, _) -> (
           match Envi.TypeDecl.find_of_field field env with
-          | Some (({tdec_desc= TRecord field_decls; tdec_params; _} as decl), i)
-            ->
+          | Some
+              ( _ident
+              , (({tdec_desc= TRecord field_decls; tdec_params; _} as decl), i)
+              ) ->
               let vars, bound_vars, env =
                 Envi.Type.refresh_vars ~loc tdec_params Int.Map.empty env
               in
@@ -798,8 +803,9 @@ let rec get_expression env expected exp =
           | _ -> (
             match Envi.TypeDecl.find_of_field field env with
             | Some
-                (({tdec_desc= TRecord field_decls; tdec_params; _} as decl), i)
-              ->
+                ( _ident
+                , ( ({tdec_desc= TRecord field_decls; tdec_params; _} as decl)
+                  , i ) ) ->
                 let vars, bound_vars, env =
                   Envi.Type.refresh_vars ~loc tdec_params Int.Map.empty env
                 in
@@ -842,8 +848,10 @@ let rec get_expression env expected exp =
             (typ, field_decls, bound_vars, env)
         | _ -> (
           match Envi.TypeDecl.find_of_field field env with
-          | Some (({tdec_desc= TRecord field_decls; tdec_params; _} as decl), _)
-            ->
+          | Some
+              ( _ident
+              , (({tdec_desc= TRecord field_decls; tdec_params; _} as decl), _)
+              ) ->
               let vars, bound_vars, env =
                 Envi.Type.refresh_vars ~loc tdec_params Int.Map.empty env
               in

--- a/meja/src/typedast.ml
+++ b/meja/src/typedast.ml
@@ -1,6 +1,8 @@
 open Ast_types
 open Parsetypes
 
+type ident = Ident.t Location.loc
+
 type literal = Int of int | Bool of bool | Field of string | String of string
 
 type pattern =
@@ -45,8 +47,8 @@ and signature_desc =
   | Tsig_value of str * type_expr
   | Tsig_instance of str * type_expr
   | Tsig_type of type_decl
-  | Tsig_module of str * module_sig
-  | Tsig_modtype of str * module_sig
+  | Tsig_module of ident * module_sig
+  | Tsig_modtype of ident * module_sig
   | Tsig_open of lid
   | Tsig_typeext of variant * ctor_decl list
   | Tsig_request of type_expr * ctor_decl
@@ -66,8 +68,8 @@ and statement_desc =
   | Tstmt_value of pattern * expression
   | Tstmt_instance of str * expression
   | Tstmt_type of type_decl
-  | Tstmt_module of str * module_expr
-  | Tstmt_modtype of str * module_sig
+  | Tstmt_module of ident * module_expr
+  | Tstmt_modtype of ident * module_sig
   | Tstmt_open of lid
   | Tstmt_typeext of variant * ctor_decl list
   | Tstmt_request of

--- a/meja/src/typedast_map.ml
+++ b/meja/src/typedast_map.ml
@@ -29,6 +29,7 @@ type mapper =
   ; module_desc: mapper -> module_desc -> module_desc
   ; location: mapper -> Location.t -> Location.t
   ; longident: mapper -> Longident.t -> Longident.t
+  ; ident: mapper -> Ident.t -> Ident.t
   ; type0_decl: mapper -> Type0.type_decl -> Type0.type_decl
   ; type0_expr: mapper -> Type0.type_expr -> Type0.type_expr }
 
@@ -37,6 +38,9 @@ let lid mapper {Location.txt; loc} =
 
 let str mapper ({Location.txt; loc} : str) =
   {Location.txt; loc= mapper.location mapper loc}
+
+let ident mapper ({Location.txt; loc} : Ident.t Location.loc) =
+  {Location.txt= mapper.ident mapper txt; loc= mapper.location mapper loc}
 
 let type_expr mapper Parsetypes.{type_desc; type_loc} =
   let type_loc = mapper.location mapper type_loc in
@@ -213,9 +217,9 @@ let signature_desc mapper = function
   | Tsig_type decl ->
       Tsig_type (mapper.type_decl mapper decl)
   | Tsig_module (name, msig) ->
-      Tsig_module (str mapper name, mapper.module_sig mapper msig)
+      Tsig_module (ident mapper name, mapper.module_sig mapper msig)
   | Tsig_modtype (name, msig) ->
-      Tsig_modtype (str mapper name, mapper.module_sig mapper msig)
+      Tsig_modtype (ident mapper name, mapper.module_sig mapper msig)
   | Tsig_open name ->
       Tsig_open (lid mapper name)
   | Tsig_typeext (typ, ctors) ->
@@ -257,9 +261,9 @@ let statement_desc mapper = function
   | Tstmt_type decl ->
       Tstmt_type (mapper.type_decl mapper decl)
   | Tstmt_module (name, me) ->
-      Tstmt_module (str mapper name, mapper.module_expr mapper me)
+      Tstmt_module (ident mapper name, mapper.module_expr mapper me)
   | Tstmt_modtype (name, mty) ->
-      Tstmt_modtype (str mapper name, mapper.module_sig mapper mty)
+      Tstmt_modtype (ident mapper name, mapper.module_sig mapper mty)
   | Tstmt_open name ->
       Tstmt_open (lid mapper name)
   | Tstmt_typeext (typ, ctors) ->
@@ -290,7 +294,7 @@ let module_desc mapper = function
         , mapper.module_sig mapper fsig
         , mapper.module_expr mapper me )
 
-let location (_iter : mapper) (loc : Location.t) = loc
+let location (_mapper : mapper) (loc : Location.t) = loc
 
 let longident mapper = function
   | Longident.Lident str ->
@@ -299,6 +303,8 @@ let longident mapper = function
       Ldot (mapper.longident mapper l, str)
   | Lapply (l1, l2) ->
       Lapply (mapper.longident mapper l1, mapper.longident mapper l2)
+
+let ident (_mapper : mapper) (ident : Ident.t) = ident
 
 (** Stub. This isn't part of the parsetypes, so we don't do anything by
     default.
@@ -336,5 +342,6 @@ let default_iterator =
   ; module_desc
   ; location
   ; longident
+  ; ident
   ; type0_decl
   ; type0_expr }

--- a/meja/src/typeprint.ml
+++ b/meja/src/typeprint.ml
@@ -43,7 +43,8 @@ and variant fmt v =
       fprintf fmt "@[<hv2>%a%a@]" Longident.pp v.var_ident tuple v.var_params
 
 let field_decl fmt decl =
-  fprintf fmt "%s:@ @[<hv>%a@]" decl.fld_ident type_expr decl.fld_type
+  fprintf fmt "%a:@ @[<hv>%a@]" Ident.pprint decl.fld_ident type_expr
+    decl.fld_type
 
 let ctor_args fmt = function
   | Ctor_tuple [] ->
@@ -58,7 +59,7 @@ let ctor_args fmt = function
       assert false
 
 let ctor_decl fmt decl =
-  fprintf fmt "%a%a" pp_name decl.ctor_ident ctor_args decl.ctor_args ;
+  fprintf fmt "%a%a" Ident.pprint decl.ctor_ident ctor_args decl.ctor_args ;
   match decl.ctor_ret with
   | Some typ ->
       fprintf fmt "@ :@ @[<hv>%a@]" type_expr typ
@@ -93,6 +94,6 @@ let type_decl_desc fmt = function
       fprintf fmt "@ /* forward declaration %a */" print_id !i
 
 let type_decl fmt decl =
-  fprintf fmt "type %s" decl.tdec_ident ;
+  fprintf fmt "type %a" Ident.pprint decl.tdec_ident ;
   (match decl.tdec_params with [] -> () | _ -> tuple fmt decl.tdec_params) ;
   type_decl_desc fmt decl.tdec_desc

--- a/meja/src/typet.ml
+++ b/meja/src/typet.ml
@@ -178,18 +178,19 @@ module TypeDecl = struct
 
   let import_field ?must_find env {fld_ident; fld_type; fld_loc= _} =
     let fld_type, env = Type.import ?must_find fld_type env in
-    (env, {Type0.fld_ident= fld_ident.txt; fld_type})
+    (env, {Type0.fld_ident= Ident.create fld_ident.txt; fld_type})
 
   let import decl' env =
     let {tdec_ident; tdec_params; tdec_implicit_params; tdec_desc; tdec_loc= _}
         =
       decl'
     in
-    let tdec_id =
+    let tdec_ident, tdec_id =
       match
-        Map.find env.resolve_env.type_env.predeclared_types tdec_ident.txt
+        IdTbl.find_name tdec_ident.txt
+          env.resolve_env.type_env.predeclared_types
       with
-      | Some (id, num_args, loc) ->
+      | Some (ident, (id, num_args, loc)) ->
           ( match !num_args with
           | Some num_args ->
               let given = List.length tdec_params in
@@ -204,11 +205,11 @@ module TypeDecl = struct
           let {type_env; _} = env.resolve_env in
           env.resolve_env.type_env
           <- { type_env with
-               predeclared_types=
-                 Map.remove type_env.predeclared_types tdec_ident.txt } ;
-          id
+               predeclared_types= IdTbl.remove ident type_env.predeclared_types
+             } ;
+          (Location.mkloc ident tdec_ident.loc, id)
       | None ->
-          next_id env
+          (map_loc ~f:Ident.create tdec_ident, next_id env)
     in
     let env = open_expr_scope env in
     let import_params env =
@@ -288,7 +289,7 @@ module TypeDecl = struct
                       let name =
                         match tdec_desc with
                         | TVariant _ ->
-                            Lident tdec_ident.txt
+                            Lident (Ident.name tdec_ident.txt)
                         | TExtend (lid, _, _) ->
                             lid.txt
                         | _ ->
@@ -333,15 +334,17 @@ module TypeDecl = struct
                         |> Set.to_list
                       in
                       let decl =
-                        mk ~name:ctor.ctor_ident.txt ~params (TRecord fields)
-                          env
+                        mk
+                          ~name:(Ident.create ctor.ctor_ident.txt)
+                          ~params (TRecord fields) env
                       in
                       (env, Type0.Ctor_record decl)
                 in
                 let env = push_scope scope (close_expr_scope env) in
                 ( env
-                , {Type0.ctor_ident= ctor.ctor_ident.txt; ctor_args; ctor_ret}
-                ) )
+                , { Type0.ctor_ident= Ident.create ctor.ctor_ident.txt
+                  ; ctor_args
+                  ; ctor_ret } ) )
           in
           let tdec_desc =
             match tdec_desc with

--- a/meja/src/untype_ast.ml
+++ b/meja/src/untype_ast.ml
@@ -1,4 +1,5 @@
 open Core_kernel
+open Ast_types
 open Type0
 open Ast_build
 
@@ -152,9 +153,9 @@ let rec signature_desc = function
   | Tsig_type decl ->
       Psig_type decl
   | Tsig_module (name, msig) ->
-      Psig_module (name, module_sig msig)
+      Psig_module (map_loc ~f:Ident.name name, module_sig msig)
   | Tsig_modtype (name, msig) ->
-      Psig_modtype (name, module_sig msig)
+      Psig_modtype (map_loc ~f:Ident.name name, module_sig msig)
   | Tsig_open path ->
       Psig_open path
   | Tsig_typeext (typ, ctors) ->
@@ -189,9 +190,9 @@ let rec statement_desc = function
   | Tstmt_type decl ->
       Pstmt_type decl
   | Tstmt_module (name, m) ->
-      Pstmt_module (name, module_expr m)
+      Pstmt_module (map_loc ~f:Ident.name name, module_expr m)
   | Tstmt_modtype (name, msig) ->
-      Pstmt_modtype (name, module_sig msig)
+      Pstmt_modtype (map_loc ~f:Ident.name name, module_sig msig)
   | Tstmt_open path ->
       Pstmt_open path
   | Tstmt_typeext (typ, ctors) ->

--- a/meja/src/untype_ast.ml
+++ b/meja/src/untype_ast.ml
@@ -26,7 +26,8 @@ let rec type_desc ?loc = function
 and type_expr ?loc typ = type_desc ?loc typ.type_desc
 
 let field_decl ?loc fld =
-  Type_decl.Field.mk ?loc fld.fld_ident (type_expr ?loc fld.fld_type)
+  Type_decl.Field.mk ?loc (Ident.name fld.fld_ident)
+    (type_expr ?loc fld.fld_type)
 
 let ctor_args ?loc ?ret name = function
   | Ctor_tuple typs ->
@@ -39,7 +40,9 @@ let ctor_args ?loc ?ret name = function
       assert false
 
 let ctor_decl ?loc ctor =
-  ctor_args ?loc ctor.ctor_ident ctor.ctor_args
+  ctor_args ?loc
+    (Ident.name ctor.ctor_ident)
+    ctor.ctor_args
     ?ret:(Option.map ~f:(type_expr ?loc) ctor.ctor_ret)
 
 let rec type_decl_desc ?loc ?params ?implicits name = function
@@ -66,7 +69,8 @@ and type_decl ?loc decl =
   type_decl_desc ?loc
     ~params:(List.map ~f:type_expr decl.tdec_params)
     ~implicits:(List.map ~f:type_expr decl.tdec_implicit_params)
-    decl.tdec_ident decl.tdec_desc
+    (Ident.name decl.tdec_ident)
+    decl.tdec_desc
 
 let rec pattern_desc = function
   | Typedast.Tpat_any ->


### PR DESCRIPTION
This PR introduces `Ident.t` for identifiers in the typechecker and the environment. It
* defines an `Ident` module (with an opaque type, since we'll want to adjust it later) for unique values with (potentially) identical user names
* adds `Ident.Table.t`, a kind of map where we can find the value associated with an `Ident.t` by either its name (a `string`) or directly using the `Ident.t`
* uses `Ident.Table.t`s in place of the maps in the environment
* uses `Ident.t`s for all of the types in `Type0`

This uniqueness information is currently thrown away, pending a restructuring of the `Envi.t` search mechanism. I'm going to do this separately, since it will involve a bigger change to make it OCaml compatible and start rejecting e.g.
```reason
module A = {
  module B = {
    let x = 15;
  };
};

open A;

module B = {};

let x = B.x;
```

The big wins for this are:
* we can move from numeric IDs to `Ident.t`s to uniquely identify information
  - this is especially important for loading compiled meja files into the environment
* we can identify and resolve name clashes in generated code and situations such as
```reason
let x = 15;
Prover {
  let x = 20;
};
let x = x + Prover {x;};
```
* we'll get easy support for functors (which is currently pretty broken)
* **EDIT:** we can also store which mode (prover/checked) the name is from, rather than splitting the environment, which will solve several pain points from the conference

I will also follow up adding a `Path.t` type (like `Longident.t` but using `Ident.t`s instead of `string`s), but this also needs the environment changes mentioned above, and then we can have complete coverage with unique names.