### PR TITLE
Rename compress/hash to merge

### DIFF
--- a/examples/merkle_update/merkle_update.ml
+++ b/examples/merkle_update/merkle_update.ml
@@ -40,7 +40,7 @@ module Hash = struct
   end)
 
   (* Don't do this at home *)
-  let hash ~height:_ x y = hash x y
+  let merge ~height:_ x y = hash x y
 end
 
 (* Second, we specify the type of values which we'll store in the merkle tree.
@@ -133,7 +133,7 @@ let tree_start =
     Merkle_tree.create (Value.random ())
       ~hash:(fun xo ->
         Knapsack.hash_to_bits knapsack (Option.value ~default:[] xo) )
-      ~compress:(fun x y -> Knapsack.hash_to_bits knapsack (x @ y))
+      ~merge:(fun x y -> Knapsack.hash_to_bits knapsack (x @ y))
   in
   Merkle_tree.add_many t0
     (List.init (num_entries - 1) ~f:(fun _ -> Value.random ()))

--- a/src/merkle_tree.ml
+++ b/src/merkle_tree.ml
@@ -311,9 +311,7 @@ let implied_root ~merge addr0 entry_hash path0 =
     | [] ->
         acc
     | h :: hs ->
-        go
-          (if ith_bit addr0 i then merge h acc else merge acc h)
-          (i + 1) hs
+        go (if ith_bit addr0 i then merge h acc else merge acc h) (i + 1) hs
   in
   go entry_hash 0 path0
 

--- a/src/merkle_tree.mli
+++ b/src/merkle_tree.mli
@@ -7,7 +7,7 @@ module Address : sig
 end
 
 module Free_hash : sig
-  type 'a t = Hash_value of 'a | Hash_empty | Compress of 'a t * 'a t
+  type 'a t = Hash_value of 'a | Hash_empty | Merge of 'a t * 'a t
   [@@deriving sexp]
 
   val diff : 'a t -> 'a t -> bool list option
@@ -15,7 +15,7 @@ module Free_hash : sig
   val run :
        'a t
     -> hash:('a option -> 'hash)
-    -> compress:('hash -> 'hash -> 'hash)
+    -> merge:('hash -> 'hash -> 'hash)
     -> 'hash
 end
 
@@ -23,7 +23,7 @@ val depth : (_, _) t -> int
 
 val create :
      hash:('a option -> 'hash)
-  -> compress:('hash -> 'hash -> 'hash)
+  -> merge:('hash -> 'hash -> 'hash)
   -> 'a
   -> ('hash, 'a) t
 
@@ -40,7 +40,7 @@ val get_exn : (_, 'a) t -> Address.t -> 'a
 val get_path : ('hash, 'a) t -> Address.t -> 'hash list
 
 val implied_root :
-     compress:('hash -> 'hash -> 'hash)
+     merge:('hash -> 'hash -> 'hash)
   -> Address.t
   -> 'hash
   -> 'hash list
@@ -67,7 +67,7 @@ module Checked
 
         val typ : (var, value) Impl.Typ.t
 
-        val hash : height:int -> var -> var -> (var, _) Impl.Checked.t
+        val merge : height:int -> var -> var -> (var, _) Impl.Checked.t
 
         val if_ :
           Impl.Boolean.var -> then_:var -> else_:var -> (var, _) Impl.Checked.t
@@ -156,7 +156,7 @@ module Run : sig
 
           val typ : (var, value) Impl.Typ.t
 
-          val hash : height:int -> var -> var -> var
+          val merge : height:int -> var -> var -> var
 
           val if_ : Impl.Boolean.var -> then_:var -> else_:var -> var
 

--- a/src/merkle_tree.mli
+++ b/src/merkle_tree.mli
@@ -40,11 +40,7 @@ val get_exn : (_, 'a) t -> Address.t -> 'a
 val get_path : ('hash, 'a) t -> Address.t -> 'hash list
 
 val implied_root :
-     merge:('hash -> 'hash -> 'hash)
-  -> Address.t
-  -> 'hash
-  -> 'hash list
-  -> 'hash
+  merge:('hash -> 'hash -> 'hash) -> Address.t -> 'hash -> 'hash list -> 'hash
 
 val get_free_path : (_, 'a) t -> Address.t -> 'a Free_hash.t list
 


### PR DESCRIPTION
The Merkle tree code here used `hash` or `compress` to indicate where hashes were combined for the hash of an interior node.

Change that to `merge`, which is the terminology used in the `CodaProtocol/coda` codebase.

Tested with `make` and `make tests`.