### PR TITLE
First-class support for arrays

### DIFF
--- a/src/monad_sequence.ml
+++ b/src/monad_sequence.ml
@@ -190,6 +190,14 @@ module Array
 
   let all_unit = iter ~f:(fun x -> x)
 
+  (* The following functions need to evaluate on every element, since
+     * we can't shortcut in the snark -- every constraint is either always
+       present or always absent -- so we need to evaluate [f] on every element
+     * [Bool.any]/[Bool.all] operate by calculating the sum of the array,
+       which requires an R1CS variable representing each element to be
+       available.
+  *)
+
   let existsi t ~f = mapi t ~f >>= Bool.any
 
   let exists t ~f = map t ~f >>= Bool.any

--- a/src/monad_sequence.ml
+++ b/src/monad_sequence.ml
@@ -117,6 +117,14 @@ module List
 
   let map t ~f = mapi t ~f:(fun _i x -> f x)
 
+  (* The following functions use [map] to evaluate [f] on every element, since
+     * we can't shortcut in the snark -- every constraint is either always
+       present or always absent -- so we need to apply [f] to all of them
+     * [Bool.any]/[Bool.all] operate by calculating the sum of the array,
+       which requires an R1CS variable representing each element to be
+       available.
+  *)
+
   let existsi t ~f = mapi t ~f >>= Bool.any
 
   let exists t ~f = map t ~f >>= Bool.any
@@ -190,9 +198,9 @@ module Array
 
   let all_unit = iter ~f:(fun x -> x)
 
-  (* The following functions need to evaluate on every element, since
+  (* The following functions use [map] to evaluate [f] on every element, since
      * we can't shortcut in the snark -- every constraint is either always
-       present or always absent -- so we need to evaluate [f] on every element
+       present or always absent -- so we need to apply [f] to all of them
      * [Bool.any]/[Bool.all] operate by calculating the sum of the array,
        which requires an R1CS variable representing each element to be
        available.

--- a/src/monad_sequence.ml
+++ b/src/monad_sequence.ml
@@ -17,7 +17,7 @@ module type S = sig
        'a t
     -> init:'b
     -> f:('b -> 'a -> ('b * 'c, 's) monad)
-    -> ('b * 'c list, 's) monad
+    -> ('b * 'c t, 's) monad
 
   val exists : 'a t -> f:('a -> (boolean, 's) monad) -> (boolean, 's) monad
 
@@ -116,6 +116,79 @@ module List
     go 0 [] t
 
   let map t ~f = mapi t ~f:(fun _i x -> f x)
+
+  let existsi t ~f = mapi t ~f >>= Bool.any
+
+  let exists t ~f = map t ~f >>= Bool.any
+
+  let for_alli t ~f = mapi t ~f >>= Bool.all
+
+  let for_all t ~f = map t ~f >>= Bool.all
+end
+
+module Array
+    (M : Monad_let.S2) (Bool : sig
+        type t
+
+        val any : t array -> (t, _) M.t
+
+        val all : t array -> (t, _) M.t
+    end) :
+  S
+  with type 'a t = 'a array
+   and type ('a, 's) monad := ('a, 's) M.t
+   and type boolean := Bool.t = struct
+  type 'a t = 'a array
+
+  open M.Let_syntax
+
+  let foldi t ~init ~f =
+    Array.foldi t ~init:(M.return init) ~f:(fun i acc x ->
+        let%bind acc = acc in
+        f i acc x )
+
+  let fold t ~init ~f =
+    Array.fold t ~init:(M.return init) ~f:(fun acc x ->
+        let%bind acc = acc in
+        f acc x )
+
+  let iteri t ~f = foldi t ~init:() ~f:(fun i () x -> f i x)
+
+  let iter t ~f = fold t ~init:() ~f:(fun () x -> f x)
+
+  let init n ~f =
+    let rec go arr i =
+      if i < 0 then M.return arr
+      else
+        let%bind x = f i in
+        Array.unsafe_set arr i x ;
+        go arr (i - 1)
+    in
+    if n < 0 then invalid_arg "Monad_sequence.Array.init"
+    else if n = 0 then M.return [||]
+    else
+      let%bind last = f (n - 1) in
+      let arr = Array.create ~len:n last in
+      go arr (n - 2)
+
+  let mapi t ~f =
+    init (Array.length t) ~f:(fun i -> f i (Array.unsafe_get t i))
+
+  let map t ~f = mapi t ~f:(fun _i x -> f x)
+
+  let fold_map t ~init ~f =
+    let res = ref init in
+    let%map t =
+      map t ~f:(fun x ->
+          let%map acc, y = f !res x in
+          res := acc ;
+          y )
+    in
+    (!res, t)
+
+  let all = map ~f:(fun x -> x)
+
+  let all_unit = iter ~f:(fun x -> x)
 
   let existsi t ~f = mapi t ~f >>= Bool.any
 

--- a/src/snark_intf.ml
+++ b/src/snark_intf.ml
@@ -497,6 +497,18 @@ module type Basic = sig
 
       val exactly_one : var list -> (unit, _) Checked.t
     end
+
+    module Array : sig
+      val any : var array -> (var, _) Checked.t
+
+      val all : var array -> (var, _) Checked.t
+
+      module Assert : sig
+        val any : var array -> (unit, _) Checked.t
+
+        val all : var array -> (unit, _) Checked.t
+      end
+    end
   end
 
   (** Checked computations.
@@ -529,6 +541,12 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
       Monad_sequence.S
       with type ('a, 's) monad := ('a, 's) t
        and type 'a t = 'a list
+       and type boolean := Boolean.var
+
+    module Array :
+      Monad_sequence.S
+      with type ('a, 's) monad := ('a, 's) t
+       and type 'a t = 'a array
        and type boolean := Boolean.var
 
     (** [Choose_preimage] is the request issued by
@@ -1663,15 +1681,27 @@ module type Run_basic = sig
     end
 
     module Assert : sig
-      val ( = ) : Boolean.var -> Boolean.var -> unit
+      val ( = ) : var -> var -> unit
 
-      val is_true : Boolean.var -> unit
+      val is_true : var -> unit
 
       val any : var list -> unit
 
       val all : var list -> unit
 
       val exactly_one : var list -> unit
+    end
+
+    module Array : sig
+      val any : var array -> var
+
+      val all : var array -> var
+
+      module Assert : sig
+        val any : var array -> unit
+
+        val all : var array -> unit
+      end
     end
   end
 


### PR DESCRIPTION
This PR
* adds a `Boolean.Array` module to `Snark_intf.*`
* adds a `Monad_sequence.Array` functor
* removes some unnecessary `Boolean.` prefixes for types in the `Boolean` module

This should make it much more straightforward to use `array`s, as well as making the matrix part of the tutorial much easier (although you would still need to construct `Monad_sequence.Array` for `Typ_monad.Store`/`Read`/`Alloc` manually to create the `Typ.t`).