### PR TITLE
[Meja] Add a Path.t type built from Ident.t's

### DIFF
--- a/meja/meja.ml
+++ b/meja/meja.ml
@@ -165,7 +165,7 @@ let main =
               let mkloc s = Location.mkloc s loc in
               let env = Envi.open_absolute_module None env in
               let env = Envi.open_absolute_module None env in
-              let m =
+              let _path, m =
                 try
                   Envi.find_module ~loc
                     (mkloc (Longident.Lident "Snarky__Request"))

--- a/meja/meja.ml
+++ b/meja/meja.ml
@@ -177,9 +177,9 @@ let main =
                        Snarky.@.") ;
                   exit 1
               in
-              let env = Envi.add_module (mkloc "Request") m env in
+              let env = Envi.add_module (Ident.create "Request") m env in
               let m, env = Envi.pop_module ~loc env in
-              let env = Envi.add_module (mkloc "Snarky") m env in
+              let env = Envi.add_module (Ident.create "Snarky") m env in
               Envi.pop_module ~loc env
             in
             Envi.open_namespace_scope m env
@@ -218,7 +218,7 @@ let main =
           in
           let env, _typed_ast = Typechecker.check_signature env parse_ast in
           let m, env = Envi.pop_module ~loc:Location.none env in
-          let name = Location.(mkloc module_name none) in
+          let name = Ident.create module_name in
           Envi.add_module name m env )
     in
     let file =

--- a/meja/ocaml/loader.ml
+++ b/meja/ocaml/loader.ml
@@ -24,7 +24,7 @@ let load_directory env dirname =
       match Filename.split_extension file with
       | _, Some ("cmi" | "cmti") ->
           let filename = Filename.concat dirname file in
-          let module_name = modname_of_filename file in
+          let module_name = Ident.create (modname_of_filename file) in
           Envi.register_external_module module_name (Envi.Deferred filename)
             env
       | _ ->

--- a/meja/src/ident.ml
+++ b/meja/src/ident.ml
@@ -1,0 +1,84 @@
+open Core_kernel
+
+type t = {ident_id: int; ident_name: string} [@@deriving sexp]
+
+type ident = t
+
+let current_id = ref 0
+
+let create name =
+  incr current_id ;
+  {ident_id= !current_id; ident_name= name}
+
+let name {ident_name= name; _} = name
+
+let compare {ident_id= id1; _} {ident_id= id2; _} = Int.compare id1 id2
+
+let pprint fmt {ident_name; _} = Ast_types.pp_name fmt ident_name
+
+let debug_print fmt {ident_name; ident_id} =
+  Format.fprintf fmt "%s/%i" ident_name ident_id
+
+module Table = struct
+  type 'a t = (ident * 'a) list String.Map.t
+
+  let empty = String.Map.empty
+
+  let is_empty = String.Map.is_empty
+
+  let remove_from_row ident =
+    List.filter ~f:(fun (ident2, _) -> not (Int.equal (compare ident ident2) 0))
+
+  let add ~key:ident ~data tbl =
+    Map.change tbl (name ident) ~f:(function
+      | Some row ->
+          Some ((ident, data) :: remove_from_row ident row)
+      | None ->
+          Some [(ident, data)] )
+
+  let remove ident tbl =
+    Map.change tbl (name ident) ~f:(function
+      | Some row ->
+          let row = remove_from_row ident row in
+          if List.is_empty row then None else Some row
+      | None ->
+          None )
+
+  let find ident tbl =
+    match Map.find tbl (name ident) with
+    | Some row ->
+        List.find_map row ~f:(fun (ident2, data) ->
+            if Int.equal (compare ident ident2) 0 then Some data else None )
+    | None ->
+        None
+
+  let find_name name tbl = Option.bind ~f:List.hd (Map.find tbl name)
+
+  let first_exn tbl = List.hd_exn (snd (Map.min_elt_exn tbl))
+
+  let keys tbl = List.concat_map ~f:(List.map ~f:fst) (Map.data tbl)
+
+  let fold2_names tbl1 tbl2 ~init ~f =
+    Map.fold2 tbl1 tbl2 ~init ~f:(fun ~key ~data acc ->
+        let data =
+          match data with
+          | `Both ((_, v1) :: _, (_, v2) :: _) ->
+              `Both (v1, v2)
+          | `Left ((_, v1) :: _) ->
+              `Left v1
+          | `Right ((_, v2) :: _) ->
+              `Right v2
+          | _ ->
+              assert false
+        in
+        f ~key ~data acc )
+
+  let merge_skewed_names tbl1 tbl2 ~combine =
+    Map.merge_skewed tbl1 tbl2 ~combine:(fun ~key v1 v2 ->
+        let res = combine ~key (List.hd_exn v1) (List.hd_exn v2) in
+        if not (String.equal (name (fst res)) key) then
+          failwith
+            "merge_skewed_names: The name provided by combine does not match \
+             the key" ;
+        (res :: v1) @ v2 )
+end

--- a/meja/src/ident.ml
+++ b/meja/src/ident.ml
@@ -81,4 +81,7 @@ module Table = struct
             "merge_skewed_names: The name provided by combine does not match \
              the key" ;
         (res :: v1) @ v2 )
+
+  let map tbl ~f =
+    Map.map ~f:(List.map ~f:(fun (ident, data) -> (ident, f data))) tbl
 end

--- a/meja/src/ident.mli
+++ b/meja/src/ident.mli
@@ -1,0 +1,85 @@
+(** Unique identifiers. *)
+type t [@@deriving sexp]
+
+type ident = t
+
+val create : string -> t
+(** Create a new unique name. *)
+
+val name : t -> string
+(** Retrieve the name passed to [create]. *)
+
+val compare : t -> t -> int
+(** Compare two names. This is 0 iff they originate from the same call to
+    [create].
+*)
+
+val pprint : Format.formatter -> t -> unit
+(** Pretty print. Identifiers that do not begin with a letter or underscore
+    will be surrounded by parentheses.
+*)
+
+val debug_print : Format.formatter -> t -> unit
+(** Debug print. Prints the identifier and its internal ID. *)
+
+module Table : sig
+  (** An associative map from [ident]s, with direct name lookups. *)
+  type 'a t
+
+  val empty : 'a t
+  (** An empty table. *)
+
+  val is_empty : 'a t -> bool
+  (** Returns [true] if the table is empty, false otherwise. *)
+
+  val add : key:ident -> data:'a -> 'a t -> 'a t
+  (** [add ~key:ident ~data tbl] returns the table [tbl] extended with [ident]
+      associated to [data].
+      Any previous association with [ident] is replaced, and the name
+      [name ident] is also associated with [data].
+  *)
+
+  val remove : ident -> 'a t -> 'a t
+  (** Returns the table with the binding to the given ident removed. *)
+
+  val find : ident -> 'a t -> 'a option
+  (** Returns the value bound to the given ident in the table if it exists, or
+      [None] otherwise.
+  *)
+
+  val find_name : string -> 'a t -> (ident * 'a) option
+  (** [find_name name tbl] returns the most recently bound [ident] and its
+      associated value if it exists, or [None] otherwise.
+  *)
+
+  val first_exn : 'a t -> ident * 'a
+  (** Returns the binding to the first name (under lexical ordering). *)
+
+  val keys : 'a t -> ident list
+  (** Returns a list of the bound identifiers. *)
+
+  val fold2_names :
+       'v1 t
+    -> 'v2 t
+    -> init:'a
+    -> f:(   key:string
+          -> data:[`Both of 'v1 * 'v2 | `Left of 'v1 | `Right of 'v2]
+          -> 'a
+          -> 'a)
+    -> 'a
+  (** Fold over names in the two tables, in order of increasing key. *)
+
+  val merge_skewed_names :
+       'v t
+    -> 'v t
+    -> combine:(key:string -> ident * 'v -> ident * 'v -> ident * 'v)
+    -> 'v t
+  (** Merge the bindings in the two tables. When the same name is bound in
+      both, [combine] is used to decide the preferred binding.
+      Throws [Failure] if the result of [combine] has a different name to
+      [key].
+
+      When an [ident] is bound in both tables but does not appear in
+      [find_name] for its name, the bound value from the first table is chosen.
+  *)
+end

--- a/meja/src/ident.mli
+++ b/meja/src/ident.mli
@@ -82,4 +82,7 @@ module Table : sig
       When an [ident] is bound in both tables but does not appear in
       [find_name] for its name, the bound value from the first table is chosen.
   *)
+
+  val map : 'a t -> f:('a -> 'b) -> 'b t
+  (** Map over each of the values in the table. *)
 end

--- a/meja/src/parsetypes.ml
+++ b/meja/src/parsetypes.ml
@@ -43,7 +43,7 @@ and type_decl_desc =
   | TRecord of field_decl list
   | TVariant of ctor_decl list
   | TOpen
-  | TExtend of lid * Type0.type_decl * ctor_decl list
+  | TExtend of Path.t Location.loc * Type0.type_decl * ctor_decl list
       (** Internal; this should never be present in the AST. *)
   | TForward of int option ref
       (** Forward declaration for types loaded from cmi files. *)

--- a/meja/src/parsetypes_iter.ml
+++ b/meja/src/parsetypes_iter.ml
@@ -95,10 +95,12 @@ let type_decl_desc iter = function
       List.iter ~f:(iter.ctor_decl iter) ctors
   | TOpen ->
       ()
-  | TExtend (name, decl, ctors) ->
-      lid iter name ;
+  | TExtend (_name, _decl, _ctors) ->
+      assert false
+      (* TODO: re-enable this when the Type0 iterator is merged. *)
+      (*lid iter name ;
       iter.type0_decl iter decl ;
-      List.iter ~f:(iter.ctor_decl iter) ctors
+      List.iter ~f:(iter.ctor_decl iter) ctors*)
   | TForward _ ->
       ()
 

--- a/meja/src/parsetypes_iter.ml
+++ b/meja/src/parsetypes_iter.ml
@@ -30,13 +30,18 @@ type iterator =
   ; longident: iterator -> Longident.t -> unit
   ; type0_decl: iterator -> Type0.type_decl -> unit }
 
+let lid iter {Location.txt; loc} =
+  iter.longident iter txt ; iter.location iter loc
+
+let str iter ({Location.txt= _; loc} : str) = iter.location iter loc
+
 let type_expr iter {type_desc; type_loc} =
   iter.location iter type_loc ;
   iter.type_desc iter type_desc
 
 let type_desc iter = function
   | Ptyp_var (name, _) ->
-      Option.iter ~f:(fun name -> iter.location iter name.Location.loc) name
+      Option.iter ~f:(str iter) name
   | Ptyp_tuple typs ->
       List.iter ~f:(iter.type_expr iter) typs
   | Ptyp_arrow (typ1, typ2, _, _) ->
@@ -48,14 +53,13 @@ let type_desc iter = function
       iter.type_expr iter typ
 
 let variant iter {var_ident; var_params; var_implicit_params} =
-  iter.location iter var_ident.loc ;
-  iter.longident iter var_ident.txt ;
+  lid iter var_ident ;
   List.iter ~f:(iter.type_expr iter) var_params ;
   List.iter ~f:(iter.type_expr iter) var_implicit_params
 
 let field_decl iter {fld_ident; fld_type; fld_loc} =
   iter.location iter fld_loc ;
-  iter.location iter fld_ident.loc ;
+  str iter fld_ident ;
   iter.type_expr iter fld_type
 
 let ctor_args iter = function
@@ -66,14 +70,14 @@ let ctor_args iter = function
 
 let ctor_decl iter {ctor_ident; ctor_args; ctor_ret; ctor_loc} =
   iter.location iter ctor_loc ;
-  iter.location iter ctor_ident.loc ;
+  str iter ctor_ident ;
   iter.ctor_args iter ctor_args ;
   Option.iter ~f:(iter.type_expr iter) ctor_ret
 
 let type_decl iter
     {tdec_ident; tdec_params; tdec_implicit_params; tdec_desc; tdec_loc} =
   iter.location iter tdec_loc ;
-  iter.location iter tdec_ident.loc ;
+  str iter tdec_ident ;
   List.iter ~f:(iter.type_expr iter) tdec_params ;
   List.iter ~f:(iter.type_expr iter) tdec_implicit_params ;
   iter.type_decl_desc iter tdec_desc
@@ -92,8 +96,7 @@ let type_decl_desc iter = function
   | TOpen ->
       ()
   | TExtend (name, decl, ctors) ->
-      iter.location iter name.loc ;
-      iter.longident iter name.txt ;
+      lid iter name ;
       iter.type0_decl iter decl ;
       List.iter ~f:(iter.ctor_decl iter) ctors
   | TForward _ ->
@@ -109,7 +112,7 @@ let pattern_desc iter = function
   | Ppat_any ->
       ()
   | Ppat_variable name ->
-      iter.location iter name.loc
+      str iter name
   | Ppat_constraint (pat, typ) ->
       iter.type_expr iter typ ; iter.pattern iter pat
   | Ppat_tuple pats ->
@@ -120,12 +123,9 @@ let pattern_desc iter = function
       ()
   | Ppat_record fields ->
       List.iter fields ~f:(fun (name, pat) ->
-          iter.location iter name.loc ;
-          iter.longident iter name.txt ;
-          iter.pattern iter pat )
+          lid iter name ; iter.pattern iter pat )
   | Ppat_ctor (name, arg) ->
-      iter.location iter name.loc ;
-      iter.longident iter name.txt ;
+      lid iter name ;
       Option.iter ~f:(iter.pattern iter) arg
 
 let expression iter {exp_desc; exp_loc} =
@@ -137,15 +137,13 @@ let expression_desc iter = function
       iter.expression iter e ;
       List.iter args ~f:(fun (_label, e) -> iter.expression iter e)
   | Pexp_variable name ->
-      iter.location iter name.loc ;
-      iter.longident iter name.txt
+      lid iter name
   | Pexp_literal l ->
       iter.literal iter l
   | Pexp_fun (_label, p, e, _explicit) ->
       iter.pattern iter p ; iter.expression iter e
   | Pexp_newtype (name, e) ->
-      iter.location iter name.loc ;
-      iter.expression iter e
+      str iter name ; iter.expression iter e
   | Pexp_seq (e1, e2) ->
       iter.expression iter e1 ; iter.expression iter e2
   | Pexp_let (p, e1, e2) ->
@@ -159,21 +157,16 @@ let expression_desc iter = function
       List.iter cases ~f:(fun (p, e) ->
           iter.pattern iter p ; iter.expression iter e )
   | Pexp_field (e, name) ->
-      iter.location iter name.loc ;
-      iter.longident iter name.txt ;
-      iter.expression iter e
+      lid iter name ; iter.expression iter e
   | Pexp_record (bindings, default) ->
       Option.iter ~f:(iter.expression iter) default ;
       List.iter bindings ~f:(fun (name, e) ->
-          iter.location iter name.loc ;
-          iter.longident iter name.txt ;
-          iter.expression iter e )
+          lid iter name ; iter.expression iter e )
   | Pexp_ctor (name, arg) ->
-      iter.location iter name.loc ;
-      iter.longident iter name.txt ;
+      lid iter name ;
       Option.iter ~f:(iter.expression iter) arg
   | Pexp_unifiable {expression; name; id= _} ->
-      iter.location iter name.loc ;
+      str iter name ;
       Option.iter ~f:(iter.expression iter) expression
   | Pexp_if (e1, e2, e3) ->
       iter.expression iter e1 ;
@@ -188,16 +181,13 @@ let signature_item iter {sig_desc; sig_loc} =
 
 let signature_desc iter = function
   | Psig_value (name, typ) | Psig_instance (name, typ) ->
-      iter.location iter name.loc ;
-      iter.type_expr iter typ
+      str iter name ; iter.type_expr iter typ
   | Psig_type decl ->
       iter.type_decl iter decl
   | Psig_module (name, msig) | Psig_modtype (name, msig) ->
-      iter.location iter name.loc ;
-      iter.module_sig iter msig
+      str iter name ; iter.module_sig iter msig
   | Psig_open name ->
-      iter.location iter name.loc ;
-      iter.longident iter name.txt
+      lid iter name
   | Psig_typeext (typ, ctors) ->
       iter.variant iter typ ;
       List.iter ~f:(iter.ctor_decl iter) ctors
@@ -214,14 +204,11 @@ let module_sig_desc iter = function
   | Pmty_sig sigs ->
       iter.signature iter sigs
   | Pmty_name name ->
-      iter.location iter name.loc ;
-      iter.longident iter name.txt
+      lid iter name
   | Pmty_abstract ->
       ()
   | Pmty_functor (name, fsig, msig) ->
-      iter.location iter name.loc ;
-      iter.module_sig iter fsig ;
-      iter.module_sig iter msig
+      str iter name ; iter.module_sig iter fsig ; iter.module_sig iter msig
 
 let statements iter = List.iter ~f:(iter.statement iter)
 
@@ -233,19 +220,15 @@ let statement_desc iter = function
   | Pstmt_value (p, e) ->
       iter.pattern iter p ; iter.expression iter e
   | Pstmt_instance (name, e) ->
-      iter.location iter name.loc ;
-      iter.expression iter e
+      str iter name ; iter.expression iter e
   | Pstmt_type decl ->
       iter.type_decl iter decl
   | Pstmt_module (name, me) ->
-      iter.location iter name.loc ;
-      iter.module_expr iter me
+      str iter name ; iter.module_expr iter me
   | Pstmt_modtype (name, mty) ->
-      iter.location iter name.loc ;
-      iter.module_sig iter mty
+      str iter name ; iter.module_sig iter mty
   | Pstmt_open name ->
-      iter.location iter name.loc ;
-      iter.longident iter name.txt
+      lid iter name
   | Pstmt_typeext (typ, ctors) ->
       iter.variant iter typ ;
       List.iter ~f:(iter.ctor_decl iter) ctors
@@ -266,12 +249,9 @@ let module_desc iter = function
   | Pmod_struct stmts ->
       iter.statements iter stmts
   | Pmod_name name ->
-      iter.location iter name.loc ;
-      iter.longident iter name.txt
+      lid iter name
   | Pmod_functor (name, fsig, me) ->
-      iter.location iter name.loc ;
-      iter.module_sig iter fsig ;
-      iter.module_expr iter me
+      str iter name ; iter.module_sig iter fsig ; iter.module_expr iter me
 
 let location (_iter : iterator) (_ : Location.t) = ()
 

--- a/meja/src/parsetypes_map.ml
+++ b/meja/src/parsetypes_map.ml
@@ -105,11 +105,13 @@ let type_decl_desc mapper = function
       TVariant (List.map ~f:(mapper.ctor_decl mapper) ctors)
   | TOpen ->
       TOpen
-  | TExtend (name, decl, ctors) ->
-      TExtend
+  | TExtend (_name, _decl, _ctors) ->
+      assert false
+      (* TODO: re-enable this when the Type0 iterator is merged. *)
+      (*TExtend
         ( lid mapper name
         , mapper.type0_decl mapper decl
-        , List.map ~f:(mapper.ctor_decl mapper) ctors )
+        , List.map ~f:(mapper.ctor_decl mapper) ctors )*)
   | TForward i ->
       TForward i
 

--- a/meja/src/path.ml
+++ b/meja/src/path.ml
@@ -1,8 +1,12 @@
 open Core_kernel
 
+(** Paths formed from unique identifiers. *)
 type t = Pident of Ident.t | Pdot of t * string | Papply of t * t
 [@@deriving sexp]
 
+(** Pretty print. Identifiers that do not begin with a letter or underscore
+    will be surrounded by parentheses.
+*)
 let rec pp ppf lid =
   let open Format in
   match lid with
@@ -13,6 +17,7 @@ let rec pp ppf lid =
   | Papply (path1, path2) ->
       fprintf ppf "%a(%a)" pp path1 pp path2
 
+(** Create a new path by prefixing the path with [name]. *)
 let rec add_outer_module name path =
   match path with
   | Pident name2 ->
@@ -22,6 +27,9 @@ let rec add_outer_module name path =
   | Papply _ ->
       failwith "Unhandled Papply in add_outer_module"
 
+(** Compare two paths. This can be 0 only when the two values' [Ident.t]
+    children were created in the same call to [Ident.create].
+*)
 let rec compare lid1 lid2 =
   let nonzero_or x f = if Int.equal x 0 then f () else x in
   match (lid1, lid2) with

--- a/meja/src/path.ml
+++ b/meja/src/path.ml
@@ -1,0 +1,23 @@
+open Core_kernel
+
+type t = Pident of Ident.t | Pdot of t * string | Papply of t * t
+[@@deriving sexp]
+
+let rec pp ppf lid =
+  let open Format in
+  match lid with
+  | Pident name ->
+      Ident.pprint ppf name
+  | Pdot (path, name) ->
+      fprintf ppf "%a.%s" pp path name
+  | Papply (path1, path2) ->
+      fprintf ppf "%a(%a)" pp path1 pp path2
+
+let rec add_outer_module name path =
+  match path with
+  | Pident name2 ->
+      Pdot (Pident name, Ident.name name2)
+  | Pdot (path, name2) ->
+      Pdot (add_outer_module name path, name2)
+  | Papply _ ->
+      failwith "Unhandled Papply in add_outer_module"

--- a/meja/src/path.ml
+++ b/meja/src/path.ml
@@ -21,3 +21,21 @@ let rec add_outer_module name path =
       Pdot (add_outer_module name path, name2)
   | Papply _ ->
       failwith "Unhandled Papply in add_outer_module"
+
+let rec compare lid1 lid2 =
+  let nonzero_or x f = if Int.equal x 0 then f () else x in
+  match (lid1, lid2) with
+  | Pident name1, Pident name2 ->
+      Ident.compare name1 name2
+  | Pdot (lid1, name1), Pdot (lid2, name2) ->
+      nonzero_or (String.compare name1 name2) (fun () -> compare lid1 lid2)
+  | Papply (lid1a, lid1b), Papply (lid2a, lid2b) ->
+      nonzero_or (compare lid1a lid2a) (fun () -> compare lid1b lid2b)
+  | Pident _, _ ->
+      -1
+  | _, Pident _ ->
+      1
+  | Pdot _, _ ->
+      -1
+  | _, Pdot _ ->
+      1

--- a/meja/src/pprint.ml
+++ b/meja/src/pprint.ml
@@ -78,7 +78,7 @@ let type_decl_desc fmt = function
   | TOpen ->
       fprintf fmt "@ =@ .."
   | TExtend (name, _, ctors) ->
-      fprintf fmt "@ /*@[%a +=@ %a@]*/" Longident.pp name.txt
+      fprintf fmt "@ /*@[%a +=@ %a@]*/" Path.pp name.txt
         (pp_print_list ~pp_sep:bar_sep ctor_decl)
         ctors
   | TForward i ->

--- a/meja/src/type0.ml
+++ b/meja/src/type0.ml
@@ -22,17 +22,17 @@ and variant =
   ; var_decl: type_decl }
 [@@deriving sexp]
 
-and field_decl = {fld_ident: string; fld_type: type_expr} [@@deriving sexp]
+and field_decl = {fld_ident: Ident.t; fld_type: type_expr} [@@deriving sexp]
 
 and ctor_args = Ctor_tuple of type_expr list | Ctor_record of type_decl
 [@@deriving sexp]
 
 and ctor_decl =
-  {ctor_ident: string; ctor_args: ctor_args; ctor_ret: type_expr option}
+  {ctor_ident: Ident.t; ctor_args: ctor_args; ctor_ret: type_expr option}
 [@@deriving sexp]
 
 and type_decl =
-  { tdec_ident: string
+  { tdec_ident: Ident.t
   ; tdec_params: type_expr list
   ; tdec_implicit_params: type_expr list
   ; tdec_desc: type_decl_desc

--- a/meja/src/type0.ml
+++ b/meja/src/type0.ml
@@ -16,7 +16,7 @@ and type_desc =
 [@@deriving sexp]
 
 and variant =
-  { var_ident: Longident.t
+  { var_ident: Path.t
   ; var_params: type_expr list
   ; var_implicit_params: type_expr list
   ; var_decl: type_decl }
@@ -86,7 +86,7 @@ let rec typ_debug_print fmt typ =
       print "%a{%a} -> %a" print_label label typ_debug_print typ1
         typ_debug_print typ2
   | Tctor {var_ident= name; var_params= params; _} ->
-      print "%a (%a)" Longident.pp name (print_list typ_debug_print) params
+      print "%a (%a)" Path.pp name (print_list typ_debug_print) params
   | Ttuple typs ->
       print "(%a)" (print_list typ_debug_print) typs ) ;
   print " @%i)" typ.type_depth

--- a/meja/src/type0.ml
+++ b/meja/src/type0.ml
@@ -46,7 +46,7 @@ and type_decl_desc =
   | TRecord of field_decl list
   | TVariant of ctor_decl list
   | TOpen
-  | TExtend of Longident.t * type_decl * ctor_decl list
+  | TExtend of Path.t * type_decl * ctor_decl list
       (** Internal; this should never be present in the AST. *)
   | TForward of int option ref
       (** Forward declaration for types loaded from cmi files. *)

--- a/meja/src/typechecker.ml
+++ b/meja/src/typechecker.ml
@@ -694,7 +694,8 @@ let rec get_expression env expected exp =
       Envi.Type.update_depths env body.exp_type ;
       ( { exp_loc= loc
         ; exp_type= body.exp_type
-        ; exp_desc= Texp_newtype (name, body) }
+        ; exp_desc= Texp_newtype (Location.mkloc decl.tdec_ident name.loc, body)
+        }
       , env )
   | Pexp_seq (e1, e2) ->
       let e1, env = get_expression env Initial_env.Type.unit e1 in

--- a/meja/src/typechecker.ml
+++ b/meja/src/typechecker.ml
@@ -1109,9 +1109,11 @@ let rec check_signature_item env item =
       let env = Envi.add_module_type name.txt m_env env in
       (env, {Typedast.sig_desc= Tsig_modtype (name, signature); sig_loc= loc})
   | Psig_open name ->
-      let _path, m = Envi.find_module ~loc name env in
+      let path, m = Envi.find_module ~loc name env in
       let env = Envi.open_namespace_scope m env in
-      (env, {Typedast.sig_desc= Tsig_open name; sig_loc= loc})
+      ( env
+      , { Typedast.sig_desc= Tsig_open (Location.mkloc path name.loc)
+        ; sig_loc= loc } )
   | Psig_typeext (variant, ctors) ->
       let env, _variant, _ctors = type_extension ~loc variant ctors env in
       (env, {Typedast.sig_desc= Tsig_typeext (variant, ctors); sig_loc= loc})
@@ -1257,9 +1259,10 @@ let rec check_statement env stmt =
       ( env
       , {Typedast.stmt_loc= loc; stmt_desc= Tstmt_modtype (name, signature)} )
   | Pstmt_open name ->
-      let _path, m = Envi.find_module ~loc name env in
+      let path, m = Envi.find_module ~loc name env in
       ( Envi.open_namespace_scope m env
-      , {Typedast.stmt_loc= loc; stmt_desc= Tstmt_open name} )
+      , { Typedast.stmt_loc= loc
+        ; stmt_desc= Tstmt_open (Location.mkloc path name.loc) } )
   | Pstmt_typeext (variant, ctors) ->
       let env, _variant, _ctors = type_extension ~loc variant ctors env in
       (env, {Typedast.stmt_loc= loc; stmt_desc= Tstmt_typeext (variant, ctors)})

--- a/meja/src/typechecker.ml
+++ b/meja/src/typechecker.ml
@@ -1029,7 +1029,7 @@ and check_binding ?(toplevel = false) (env : Envi.t) p e : 's =
 
 let type_extension ~loc variant ctors env =
   let {Parsetypes.var_ident; var_params; var_implicit_params= _} = variant in
-  let ( _path
+  let ( path
       , ({tdec_ident; tdec_params; tdec_implicit_params; tdec_desc; _} as decl)
       ) =
     match Envi.raw_find_type_declaration var_ident env with
@@ -1053,7 +1053,7 @@ let type_extension ~loc variant ctors env =
     ; tdec_params= var_params
     ; tdec_implicit_params=
         List.map ~f:(Untype_ast.type_expr ~loc) tdec_implicit_params
-    ; tdec_desc= TExtend (var_ident, decl, ctors)
+    ; tdec_desc= TExtend (Location.mkloc path var_ident.loc, decl, ctors)
     ; tdec_loc= loc }
   in
   let decl, env = Typet.TypeDecl.import decl env in

--- a/meja/src/typechecker.ml
+++ b/meja/src/typechecker.ml
@@ -417,7 +417,7 @@ let get_ctor (name : lid) env =
       in
       let args_typ = Envi.Type.copy ~loc args_typ bound_vars env in
       let typ = Envi.Type.copy ~loc typ bound_vars env in
-      (typ, args_typ)
+      (name, typ, args_typ)
   | _ ->
       raise (Error (loc, Unbound ("constructor", name)))
 
@@ -545,7 +545,8 @@ let rec check_pattern ~add env typ pat =
       ( {Typedast.pat_loc= loc; pat_type= typ; pat_desc= Tpat_record fields}
       , env )
   | Ppat_ctor (name, arg) ->
-      let typ', args_typ = get_ctor name env in
+      let name', typ', args_typ = get_ctor name env in
+      let name = Location.mkloc name' name.loc in
       check_type ~loc env typ typ' ;
       let arg, env =
         match arg with
@@ -923,7 +924,8 @@ let rec get_expression env expected exp =
             raise (Error (loc, Missing_fields names)) ) ;
       ({exp_loc= loc; exp_type= typ; exp_desc= Texp_record (fields, ext)}, !env)
   | Pexp_ctor (name, arg) ->
-      let typ, arg_typ = get_ctor name env in
+      let name', typ, arg_typ = get_ctor name env in
+      let name' = Location.mkloc name' name.loc in
       check_type ~loc env expected typ ;
       let arg, env =
         match arg with
@@ -936,7 +938,7 @@ let rec get_expression env expected exp =
               with _ -> raise (Error (loc, Argument_expected name.txt)) ) ;
             (None, env)
       in
-      ({exp_loc= loc; exp_type= typ; exp_desc= Texp_ctor (name, arg)}, env)
+      ({exp_loc= loc; exp_type= typ; exp_desc= Texp_ctor (name', arg)}, env)
   | Pexp_unifiable _ ->
       raise (Error (loc, Unifiable_expr))
   | Pexp_if (e1, e2, None) ->

--- a/meja/src/typechecker.ml
+++ b/meja/src/typechecker.ml
@@ -1159,7 +1159,7 @@ and check_module_sig env path msig =
       , Envi.Scope.Immediate m
       , env )
   | Pmty_name lid ->
-      let _path, m =
+      let path, m =
         match Envi.find_module_deferred ~loc lid env with
         | Some m ->
             m
@@ -1171,7 +1171,10 @@ and check_module_sig env path msig =
             ( Path.Pident (Ident.create "NOT_FOUND")
             , Envi.Scope.Deferred lid.txt )
       in
-      ({Typedast.msig_desc= Tmty_name lid; msig_loc= loc}, m, env)
+      ( { Typedast.msig_desc= Tmty_name (Location.mkloc path lid.loc)
+        ; msig_loc= loc }
+      , m
+      , env )
   | Pmty_abstract ->
       let env = Envi.open_absolute_module (Some path) env in
       let m, env = Envi.pop_module ~loc env in
@@ -1395,7 +1398,8 @@ and check_module_expr env m =
       let path = Envi.current_path env in
       (* Remove the module placed on the stack by the caller. *)
       let _, env = Envi.pop_module ~loc env in
-      let _path, m' = Envi.find_module ~loc name env in
+      let name', m' = Envi.find_module ~loc name env in
+      let name = Location.mkloc name' name.loc in
       let env = Envi.push_scope {m' with path} env in
       (env, {Typedast.mod_loc= loc; mod_desc= Tmod_name name})
   | Pmod_functor (f_name, f, m) ->

--- a/meja/src/typedast.ml
+++ b/meja/src/typedast.ml
@@ -3,6 +3,8 @@ open Parsetypes
 
 type ident = Ident.t Location.loc
 
+type path = Path.t Location.loc
+
 type literal = Int of int | Bool of bool | Field of string | String of string
 
 type pattern =
@@ -51,7 +53,7 @@ and signature_desc =
   | Tsig_type of type_decl
   | Tsig_module of ident * module_sig
   | Tsig_modtype of ident * module_sig
-  | Tsig_open of lid
+  | Tsig_open of path
   | Tsig_typeext of variant * ctor_decl list
   | Tsig_request of type_expr * ctor_decl
   | Tsig_multiple of signature
@@ -74,7 +76,7 @@ and statement_desc =
   | Tstmt_type of type_decl
   | Tstmt_module of ident * module_expr
   | Tstmt_modtype of ident * module_sig
-  | Tstmt_open of lid
+  | Tstmt_open of path
   | Tstmt_typeext of variant * ctor_decl list
   | Tstmt_request of
       type_expr * ctor_decl * (pattern option * expression) option

--- a/meja/src/typedast.ml
+++ b/meja/src/typedast.ml
@@ -17,7 +17,7 @@ and pattern_desc =
   | Tpat_tuple of pattern list
   | Tpat_or of pattern * pattern
   | Tpat_int of int
-  | Tpat_record of (lid * pattern) list
+  | Tpat_record of (path * pattern) list
   | Tpat_ctor of lid * pattern option
 
 type expression =
@@ -35,7 +35,7 @@ and expression_desc =
   | Texp_tuple of expression list
   | Texp_match of expression * (pattern * expression) list
   | Texp_field of expression * path
-  | Texp_record of (lid * expression) list * expression option
+  | Texp_record of (path * expression) list * expression option
   | Texp_ctor of lid * expression option
   | Texp_unifiable of
       { mutable expression: expression option

--- a/meja/src/typedast.ml
+++ b/meja/src/typedast.ml
@@ -18,7 +18,7 @@ and pattern_desc =
   | Tpat_or of pattern * pattern
   | Tpat_int of int
   | Tpat_record of (path * pattern) list
-  | Tpat_ctor of lid * pattern option
+  | Tpat_ctor of path * pattern option
 
 type expression =
   {exp_desc: expression_desc; exp_loc: Location.t; exp_type: Type0.type_expr}
@@ -36,7 +36,7 @@ and expression_desc =
   | Texp_match of expression * (pattern * expression) list
   | Texp_field of expression * path
   | Texp_record of (path * expression) list * expression option
-  | Texp_ctor of lid * expression option
+  | Texp_ctor of path * expression option
   | Texp_unifiable of
       { mutable expression: expression option
       ; name: ident

--- a/meja/src/typedast.ml
+++ b/meja/src/typedast.ml
@@ -1,6 +1,8 @@
 open Ast_types
 open Parsetypes
 
+type ident = Ident.t Location.loc
+
 type literal = Int of int | Bool of bool | Field of string | String of string
 
 type pattern =
@@ -47,8 +49,8 @@ and signature_desc =
   | Tsig_value of str * type_expr
   | Tsig_instance of str * type_expr
   | Tsig_type of type_decl
-  | Tsig_module of str * module_sig
-  | Tsig_modtype of str * module_sig
+  | Tsig_module of ident * module_sig
+  | Tsig_modtype of ident * module_sig
   | Tsig_open of lid
   | Tsig_typeext of variant * ctor_decl list
   | Tsig_request of type_expr * ctor_decl
@@ -70,8 +72,8 @@ and statement_desc =
   | Tstmt_value of pattern * expression
   | Tstmt_instance of str * expression
   | Tstmt_type of type_decl
-  | Tstmt_module of str * module_expr
-  | Tstmt_modtype of str * module_sig
+  | Tstmt_module of ident * module_expr
+  | Tstmt_modtype of ident * module_sig
   | Tstmt_open of lid
   | Tstmt_typeext of variant * ctor_decl list
   | Tstmt_request of

--- a/meja/src/typedast.ml
+++ b/meja/src/typedast.ml
@@ -12,7 +12,7 @@ type pattern =
 
 and pattern_desc =
   | Tpat_any
-  | Tpat_variable of str
+  | Tpat_variable of ident
   | Tpat_constraint of pattern * type_expr
   | Tpat_tuple of pattern list
   | Tpat_or of pattern * pattern
@@ -25,7 +25,7 @@ type expression =
 
 and expression_desc =
   | Texp_apply of expression * (Asttypes.arg_label * expression) list
-  | Texp_variable of lid
+  | Texp_variable of path
   | Texp_literal of literal
   | Texp_fun of Asttypes.arg_label * pattern * expression * explicitness
   | Texp_newtype of str * expression
@@ -39,7 +39,7 @@ and expression_desc =
   | Texp_ctor of lid * expression option
   | Texp_unifiable of
       { mutable expression: expression option
-      ; name: str
+      ; name: ident
       ; id: int }
   | Texp_if of expression * expression * expression option
 
@@ -48,8 +48,8 @@ type signature_item = {sig_desc: signature_desc; sig_loc: Location.t}
 and signature = signature_item list
 
 and signature_desc =
-  | Tsig_value of str * type_expr
-  | Tsig_instance of str * type_expr
+  | Tsig_value of ident * type_expr
+  | Tsig_instance of ident * type_expr
   | Tsig_type of type_decl
   | Tsig_module of ident * module_sig
   | Tsig_modtype of ident * module_sig
@@ -72,7 +72,7 @@ and statements = statement list
 
 and statement_desc =
   | Tstmt_value of pattern * expression
-  | Tstmt_instance of str * expression
+  | Tstmt_instance of ident * expression
   | Tstmt_type of type_decl
   | Tstmt_module of ident * module_expr
   | Tstmt_modtype of ident * module_sig

--- a/meja/src/typedast.ml
+++ b/meja/src/typedast.ml
@@ -28,7 +28,7 @@ and expression_desc =
   | Texp_variable of path
   | Texp_literal of literal
   | Texp_fun of Asttypes.arg_label * pattern * expression * explicitness
-  | Texp_newtype of str * expression
+  | Texp_newtype of ident * expression
   | Texp_seq of expression * expression
   | Texp_let of pattern * expression * expression
   | Texp_constraint of expression * type_expr

--- a/meja/src/typedast.ml
+++ b/meja/src/typedast.ml
@@ -62,7 +62,7 @@ and module_sig = {msig_desc: module_sig_desc; msig_loc: Location.t}
 
 and module_sig_desc =
   | Tmty_sig of signature
-  | Tmty_name of lid
+  | Tmty_name of path
   | Tmty_abstract
   | Tmty_functor of str * module_sig * module_sig
 
@@ -86,5 +86,5 @@ and module_expr = {mod_desc: module_desc; mod_loc: Location.t}
 
 and module_desc =
   | Tmod_struct of statements
-  | Tmod_name of lid
+  | Tmod_name of path
   | Tmod_functor of str * module_sig * module_expr

--- a/meja/src/typedast.ml
+++ b/meja/src/typedast.ml
@@ -34,7 +34,7 @@ and expression_desc =
   | Texp_constraint of expression * type_expr
   | Texp_tuple of expression list
   | Texp_match of expression * (pattern * expression) list
-  | Texp_field of expression * lid
+  | Texp_field of expression * path
   | Texp_record of (lid * expression) list * expression option
   | Texp_ctor of lid * expression option
   | Texp_unifiable of

--- a/meja/src/typedast_iter.ml
+++ b/meja/src/typedast_iter.ml
@@ -123,7 +123,7 @@ let pattern_desc iter = function
   | Tpat_any ->
       ()
   | Tpat_variable name ->
-      str iter name
+      ident iter name
   | Tpat_constraint (pat, typ) ->
       iter.type_expr iter typ ; iter.pattern iter pat
   | Tpat_tuple pats ->
@@ -149,7 +149,7 @@ let expression_desc iter = function
       iter.expression iter e ;
       List.iter args ~f:(fun (_label, e) -> iter.expression iter e)
   | Texp_variable name ->
-      lid iter name
+      path iter name
   | Texp_literal l ->
       iter.literal iter l
   | Texp_fun (_label, p, e, _explicit) ->
@@ -178,7 +178,7 @@ let expression_desc iter = function
       lid iter name ;
       Option.iter ~f:(iter.expression iter) arg
   | Texp_unifiable {expression; name; id= _} ->
-      str iter name ;
+      ident iter name ;
       Option.iter ~f:(iter.expression iter) expression
   | Texp_if (e1, e2, e3) ->
       iter.expression iter e1 ;
@@ -193,7 +193,7 @@ let signature_item iter {sig_desc; sig_loc} =
 
 let signature_desc iter = function
   | Tsig_value (name, typ) | Tsig_instance (name, typ) ->
-      str iter name ; iter.type_expr iter typ
+      ident iter name ; iter.type_expr iter typ
   | Tsig_type decl ->
       iter.type_decl iter decl
   | Tsig_module (name, msig) | Tsig_modtype (name, msig) ->
@@ -232,7 +232,7 @@ let statement_desc iter = function
   | Tstmt_value (p, e) ->
       iter.pattern iter p ; iter.expression iter e
   | Tstmt_instance (name, e) ->
-      str iter name ; iter.expression iter e
+      ident iter name ; iter.expression iter e
   | Tstmt_type decl ->
       iter.type_decl iter decl
   | Tstmt_module (name, me) ->

--- a/meja/src/typedast_iter.ml
+++ b/meja/src/typedast_iter.ml
@@ -136,7 +136,7 @@ let pattern_desc iter = function
       List.iter fields ~f:(fun (name, pat) ->
           path iter name ; iter.pattern iter pat )
   | Tpat_ctor (name, arg) ->
-      lid iter name ;
+      path iter name ;
       Option.iter ~f:(iter.pattern iter) arg
 
 let expression iter {exp_desc; exp_loc; exp_type} =
@@ -175,7 +175,7 @@ let expression_desc iter = function
       List.iter bindings ~f:(fun (name, e) ->
           path iter name ; iter.expression iter e )
   | Texp_ctor (name, arg) ->
-      lid iter name ;
+      path iter name ;
       Option.iter ~f:(iter.expression iter) arg
   | Texp_unifiable {expression; name; id= _} ->
       ident iter name ;

--- a/meja/src/typedast_iter.ml
+++ b/meja/src/typedast_iter.ml
@@ -106,7 +106,7 @@ let type_decl_desc iter = function
   | TOpen ->
       ()
   | TExtend (name, decl, ctors) ->
-      lid iter name ;
+      path iter name ;
       iter.type0_decl iter decl ;
       List.iter ~f:(iter.ctor_decl iter) ctors
   | TForward _ ->

--- a/meja/src/typedast_iter.ml
+++ b/meja/src/typedast_iter.ml
@@ -134,7 +134,7 @@ let pattern_desc iter = function
       ()
   | Tpat_record fields ->
       List.iter fields ~f:(fun (name, pat) ->
-          lid iter name ; iter.pattern iter pat )
+          path iter name ; iter.pattern iter pat )
   | Tpat_ctor (name, arg) ->
       lid iter name ;
       Option.iter ~f:(iter.pattern iter) arg
@@ -173,7 +173,7 @@ let expression_desc iter = function
   | Texp_record (bindings, default) ->
       Option.iter ~f:(iter.expression iter) default ;
       List.iter bindings ~f:(fun (name, e) ->
-          lid iter name ; iter.expression iter e )
+          path iter name ; iter.expression iter e )
   | Texp_ctor (name, arg) ->
       lid iter name ;
       Option.iter ~f:(iter.expression iter) arg

--- a/meja/src/typedast_iter.ml
+++ b/meja/src/typedast_iter.ml
@@ -155,7 +155,7 @@ let expression_desc iter = function
   | Texp_fun (_label, p, e, _explicit) ->
       iter.pattern iter p ; iter.expression iter e
   | Texp_newtype (name, e) ->
-      str iter name ; iter.expression iter e
+      ident iter name ; iter.expression iter e
   | Texp_seq (e1, e2) ->
       iter.expression iter e1 ; iter.expression iter e2
   | Texp_let (p, e1, e2) ->

--- a/meja/src/typedast_iter.ml
+++ b/meja/src/typedast_iter.ml
@@ -29,6 +29,7 @@ type iterator =
   ; location: iterator -> Location.t -> unit
   ; longident: iterator -> Longident.t -> unit
   ; ident: iterator -> Ident.t -> unit
+  ; path: iterator -> Path.t -> unit
   ; type0_expr: iterator -> Type0.type_expr -> unit
   ; type0_decl: iterator -> Type0.type_decl -> unit }
 
@@ -39,6 +40,9 @@ let str iter ({Location.txt= _; loc} : str) = iter.location iter loc
 
 let ident iter ({Location.txt; loc} : Ident.t Location.loc) =
   iter.ident iter txt ; iter.location iter loc
+
+let path iter ({Location.txt; loc} : Path.t Location.loc) =
+  iter.location iter loc ; iter.path iter txt
 
 let type_expr iter Parsetypes.{type_desc; type_loc} =
   iter.location iter type_loc ;
@@ -195,7 +199,7 @@ let signature_desc iter = function
   | Tsig_module (name, msig) | Tsig_modtype (name, msig) ->
       ident iter name ; iter.module_sig iter msig
   | Tsig_open name ->
-      lid iter name
+      path iter name
   | Tsig_typeext (typ, ctors) ->
       iter.variant iter typ ;
       List.iter ~f:(iter.ctor_decl iter) ctors
@@ -236,7 +240,7 @@ let statement_desc iter = function
   | Tstmt_modtype (name, mty) ->
       ident iter name ; iter.module_sig iter mty
   | Tstmt_open name ->
-      lid iter name
+      path iter name
   | Tstmt_typeext (typ, ctors) ->
       iter.variant iter typ ;
       List.iter ~f:(iter.ctor_decl iter) ctors
@@ -270,6 +274,14 @@ let longident iter = function
       iter.longident iter l
   | Lapply (l1, l2) ->
       iter.longident iter l1 ; iter.longident iter l2
+
+let path iter = function
+  | Path.Pident ident ->
+      iter.ident iter ident
+  | Path.Pdot (path, _) ->
+      iter.path iter path
+  | Path.Papply (path1, path2) ->
+      iter.path iter path1 ; iter.path iter path2
 
 let ident (_iter : iterator) (_ : Ident.t) = ()
 
@@ -308,5 +320,6 @@ let default_iterator =
   ; location
   ; longident
   ; ident
+  ; path
   ; type0_decl
   ; type0_expr }

--- a/meja/src/typedast_iter.ml
+++ b/meja/src/typedast_iter.ml
@@ -216,7 +216,7 @@ let module_sig_desc iter = function
   | Tmty_sig sigs ->
       iter.signature iter sigs
   | Tmty_name name ->
-      lid iter name
+      path iter name
   | Tmty_abstract ->
       ()
   | Tmty_functor (name, fsig, msig) ->
@@ -261,7 +261,7 @@ let module_desc iter = function
   | Tmod_struct stmts ->
       iter.statements iter stmts
   | Tmod_name name ->
-      lid iter name
+      path iter name
   | Tmod_functor (name, fsig, me) ->
       str iter name ; iter.module_sig iter fsig ; iter.module_expr iter me
 

--- a/meja/src/typedast_iter.ml
+++ b/meja/src/typedast_iter.ml
@@ -169,7 +169,7 @@ let expression_desc iter = function
       List.iter cases ~f:(fun (p, e) ->
           iter.pattern iter p ; iter.expression iter e )
   | Texp_field (e, name) ->
-      lid iter name ; iter.expression iter e
+      path iter name ; iter.expression iter e
   | Texp_record (bindings, default) ->
       Option.iter ~f:(iter.expression iter) default ;
       List.iter bindings ~f:(fun (name, e) ->

--- a/meja/src/typedast_map.ml
+++ b/meja/src/typedast_map.ml
@@ -118,7 +118,7 @@ let type_decl_desc mapper = function
       TOpen
   | TExtend (name, decl, ctors) ->
       TExtend
-        ( lid mapper name
+        ( path mapper name
         , mapper.type0_decl mapper decl
         , List.map ~f:(mapper.ctor_decl mapper) ctors )
   | TForward i ->

--- a/meja/src/typedast_map.ml
+++ b/meja/src/typedast_map.ml
@@ -188,7 +188,7 @@ let expression_desc mapper = function
         , List.map cases ~f:(fun (p, e) ->
               (mapper.pattern mapper p, mapper.expression mapper e) ) )
   | Texp_field (e, name) ->
-      Texp_field (mapper.expression mapper e, lid mapper name)
+      Texp_field (mapper.expression mapper e, path mapper name)
   | Texp_record (bindings, default) ->
       Texp_record
         ( List.map bindings ~f:(fun (name, e) ->

--- a/meja/src/typedast_map.ml
+++ b/meja/src/typedast_map.ml
@@ -29,6 +29,7 @@ type mapper =
   ; module_desc: mapper -> module_desc -> module_desc
   ; location: mapper -> Location.t -> Location.t
   ; longident: mapper -> Longident.t -> Longident.t
+  ; ident: mapper -> Ident.t -> Ident.t
   ; type0_decl: mapper -> Type0.type_decl -> Type0.type_decl
   ; type0_expr: mapper -> Type0.type_expr -> Type0.type_expr }
 
@@ -37,6 +38,9 @@ let lid mapper {Location.txt; loc} =
 
 let str mapper ({Location.txt; loc} : str) =
   {Location.txt; loc= mapper.location mapper loc}
+
+let ident mapper ({Location.txt; loc} : Ident.t Location.loc) =
+  {Location.txt= mapper.ident mapper txt; loc= mapper.location mapper loc}
 
 let type_expr mapper Parsetypes.{type_desc; type_loc} =
   let type_loc = mapper.location mapper type_loc in
@@ -213,9 +217,9 @@ let signature_desc mapper = function
   | Tsig_type decl ->
       Tsig_type (mapper.type_decl mapper decl)
   | Tsig_module (name, msig) ->
-      Tsig_module (str mapper name, mapper.module_sig mapper msig)
+      Tsig_module (ident mapper name, mapper.module_sig mapper msig)
   | Tsig_modtype (name, msig) ->
-      Tsig_modtype (str mapper name, mapper.module_sig mapper msig)
+      Tsig_modtype (ident mapper name, mapper.module_sig mapper msig)
   | Tsig_open name ->
       Tsig_open (lid mapper name)
   | Tsig_typeext (typ, ctors) ->
@@ -257,9 +261,9 @@ let statement_desc mapper = function
   | Tstmt_type decl ->
       Tstmt_type (mapper.type_decl mapper decl)
   | Tstmt_module (name, me) ->
-      Tstmt_module (str mapper name, mapper.module_expr mapper me)
+      Tstmt_module (ident mapper name, mapper.module_expr mapper me)
   | Tstmt_modtype (name, mty) ->
-      Tstmt_modtype (str mapper name, mapper.module_sig mapper mty)
+      Tstmt_modtype (ident mapper name, mapper.module_sig mapper mty)
   | Tstmt_open name ->
       Tstmt_open (lid mapper name)
   | Tstmt_typeext (typ, ctors) ->
@@ -290,7 +294,7 @@ let module_desc mapper = function
         , mapper.module_sig mapper fsig
         , mapper.module_expr mapper me )
 
-let location (_iter : mapper) (loc : Location.t) = loc
+let location (_mapper : mapper) (loc : Location.t) = loc
 
 let longident mapper = function
   | Longident.Lident str ->
@@ -299,6 +303,8 @@ let longident mapper = function
       Ldot (mapper.longident mapper l, str)
   | Lapply (l1, l2) ->
       Lapply (mapper.longident mapper l1, mapper.longident mapper l2)
+
+let ident (_mapper : mapper) (ident : Ident.t) = ident
 
 (** Stub. This isn't part of the parsetypes, so we don't do anything by
     default.
@@ -336,5 +342,6 @@ let default_iterator =
   ; module_desc
   ; location
   ; longident
+  ; ident
   ; type0_decl
   ; type0_expr }

--- a/meja/src/typedast_map.ml
+++ b/meja/src/typedast_map.ml
@@ -242,7 +242,7 @@ let module_sig_desc mapper = function
   | Tmty_sig sigs ->
       Tmty_sig (mapper.signature mapper sigs)
   | Tmty_name name ->
-      Tmty_name (lid mapper name)
+      Tmty_name (path mapper name)
   | Tmty_abstract ->
       Tmty_abstract
   | Tmty_functor (name, fsig, msig) ->
@@ -291,7 +291,7 @@ let module_desc mapper = function
   | Tmod_struct stmts ->
       Tmod_struct (mapper.statements mapper stmts)
   | Tmod_name name ->
-      Tmod_name (lid mapper name)
+      Tmod_name (path mapper name)
   | Tmod_functor (name, fsig, me) ->
       Tmod_functor
         ( str mapper name

--- a/meja/src/typedast_map.ml
+++ b/meja/src/typedast_map.ml
@@ -149,7 +149,7 @@ let pattern_desc mapper = function
         (List.map fields ~f:(fun (name, pat) ->
              (path mapper name, mapper.pattern mapper pat) ))
   | Tpat_ctor (name, arg) ->
-      Tpat_ctor (lid mapper name, Option.map ~f:(mapper.pattern mapper) arg)
+      Tpat_ctor (path mapper name, Option.map ~f:(mapper.pattern mapper) arg)
 
 let expression mapper {exp_desc; exp_loc; exp_type} =
   { exp_loc= mapper.location mapper exp_loc
@@ -195,7 +195,7 @@ let expression_desc mapper = function
               (path mapper name, mapper.expression mapper e) )
         , Option.map ~f:(mapper.expression mapper) default )
   | Texp_ctor (name, arg) ->
-      Texp_ctor (lid mapper name, Option.map ~f:(mapper.expression mapper) arg)
+      Texp_ctor (path mapper name, Option.map ~f:(mapper.expression mapper) arg)
   | Texp_unifiable {expression; name; id} ->
       Texp_unifiable
         { id

--- a/meja/src/typedast_map.ml
+++ b/meja/src/typedast_map.ml
@@ -170,7 +170,7 @@ let expression_desc mapper = function
       Texp_fun
         (label, mapper.pattern mapper p, mapper.expression mapper e, explicit)
   | Texp_newtype (name, e) ->
-      Texp_newtype (str mapper name, mapper.expression mapper e)
+      Texp_newtype (ident mapper name, mapper.expression mapper e)
   | Texp_seq (e1, e2) ->
       Texp_seq (mapper.expression mapper e1, mapper.expression mapper e2)
   | Texp_let (p, e1, e2) ->

--- a/meja/src/typedast_map.ml
+++ b/meja/src/typedast_map.ml
@@ -135,7 +135,7 @@ let pattern_desc mapper = function
   | Tpat_any ->
       Tpat_any
   | Tpat_variable name ->
-      Tpat_variable (str mapper name)
+      Tpat_variable (ident mapper name)
   | Tpat_constraint (pat, typ) ->
       Tpat_constraint (mapper.pattern mapper pat, mapper.type_expr mapper typ)
   | Tpat_tuple pats ->
@@ -163,7 +163,7 @@ let expression_desc mapper = function
         , List.map args ~f:(fun (label, e) ->
               (label, mapper.expression mapper e) ) )
   | Texp_variable name ->
-      Texp_variable (lid mapper name)
+      Texp_variable (path mapper name)
   | Texp_literal l ->
       Texp_literal (mapper.literal mapper l)
   | Texp_fun (label, p, e, explicit) ->
@@ -199,7 +199,7 @@ let expression_desc mapper = function
   | Texp_unifiable {expression; name; id} ->
       Texp_unifiable
         { id
-        ; name= str mapper name
+        ; name= ident mapper name
         ; expression= Option.map ~f:(mapper.expression mapper) expression }
   | Texp_if (e1, e2, e3) ->
       Texp_if
@@ -215,9 +215,9 @@ let signature_item mapper {sig_desc; sig_loc} =
 
 let signature_desc mapper = function
   | Tsig_value (name, typ) ->
-      Tsig_value (str mapper name, mapper.type_expr mapper typ)
+      Tsig_value (ident mapper name, mapper.type_expr mapper typ)
   | Tsig_instance (name, typ) ->
-      Tsig_instance (str mapper name, mapper.type_expr mapper typ)
+      Tsig_instance (ident mapper name, mapper.type_expr mapper typ)
   | Tsig_type decl ->
       Tsig_type (mapper.type_decl mapper decl)
   | Tsig_module (name, msig) ->
@@ -261,7 +261,7 @@ let statement_desc mapper = function
   | Tstmt_value (p, e) ->
       Tstmt_value (mapper.pattern mapper p, mapper.expression mapper e)
   | Tstmt_instance (name, e) ->
-      Tstmt_instance (str mapper name, mapper.expression mapper e)
+      Tstmt_instance (ident mapper name, mapper.expression mapper e)
   | Tstmt_type decl ->
       Tstmt_type (mapper.type_decl mapper decl)
   | Tstmt_module (name, me) ->

--- a/meja/src/typedast_map.ml
+++ b/meja/src/typedast_map.ml
@@ -147,7 +147,7 @@ let pattern_desc mapper = function
   | Tpat_record fields ->
       Tpat_record
         (List.map fields ~f:(fun (name, pat) ->
-             (lid mapper name, mapper.pattern mapper pat) ))
+             (path mapper name, mapper.pattern mapper pat) ))
   | Tpat_ctor (name, arg) ->
       Tpat_ctor (lid mapper name, Option.map ~f:(mapper.pattern mapper) arg)
 
@@ -192,7 +192,7 @@ let expression_desc mapper = function
   | Texp_record (bindings, default) ->
       Texp_record
         ( List.map bindings ~f:(fun (name, e) ->
-              (lid mapper name, mapper.expression mapper e) )
+              (path mapper name, mapper.expression mapper e) )
         , Option.map ~f:(mapper.expression mapper) default )
   | Texp_ctor (name, arg) ->
       Texp_ctor (lid mapper name, Option.map ~f:(mapper.expression mapper) arg)

--- a/meja/src/typeprint.ml
+++ b/meja/src/typeprint.ml
@@ -38,9 +38,9 @@ and type_expr_b fmt typ = type_desc ~bracket:true fmt typ.type_desc
 and variant fmt v =
   match v.var_params with
   | [] ->
-      Longident.pp fmt v.var_ident
+      Path.pp fmt v.var_ident
   | _ ->
-      fprintf fmt "@[<hv2>%a%a@]" Longident.pp v.var_ident tuple v.var_params
+      fprintf fmt "@[<hv2>%a%a@]" Path.pp v.var_ident tuple v.var_params
 
 let field_decl fmt decl =
   fprintf fmt "%a:@ @[<hv>%a@]" Ident.pprint decl.fld_ident type_expr

--- a/meja/src/typeprint.ml
+++ b/meja/src/typeprint.ml
@@ -43,7 +43,8 @@ and variant fmt v =
       fprintf fmt "@[<hv2>%a%a@]" Longident.pp v.var_ident tuple v.var_params
 
 let field_decl fmt decl =
-  fprintf fmt "%s:@ @[<hv>%a@]" decl.fld_ident type_expr decl.fld_type
+  fprintf fmt "%a:@ @[<hv>%a@]" Ident.pprint decl.fld_ident type_expr
+    decl.fld_type
 
 let ctor_args fmt = function
   | Ctor_tuple [] ->
@@ -58,7 +59,7 @@ let ctor_args fmt = function
       assert false
 
 let ctor_decl fmt decl =
-  fprintf fmt "%a%a" pp_name decl.ctor_ident ctor_args decl.ctor_args ;
+  fprintf fmt "%a%a" Ident.pprint decl.ctor_ident ctor_args decl.ctor_args ;
   match decl.ctor_ret with
   | Some typ ->
       fprintf fmt "@ :@ @[<hv>%a@]" type_expr typ
@@ -93,6 +94,6 @@ let type_decl_desc fmt = function
       fprintf fmt "@ /* forward declaration %a */" print_id !i
 
 let type_decl fmt decl =
-  fprintf fmt "type %s" decl.tdec_ident ;
+  fprintf fmt "type %a" Ident.pprint decl.tdec_ident ;
   (match decl.tdec_params with [] -> () | _ -> tuple fmt decl.tdec_params) ;
   type_decl_desc fmt decl.tdec_desc

--- a/meja/src/typeprint.ml
+++ b/meja/src/typeprint.ml
@@ -80,7 +80,7 @@ let type_decl_desc fmt = function
   | TOpen ->
       fprintf fmt "@ =@ .."
   | TExtend (name, _, ctors) ->
-      fprintf fmt "@ /*@[%a +=@ %a@]*/" Longident.pp name
+      fprintf fmt "@ /*@[%a +=@ %a@]*/" Path.pp name
         (pp_print_list ~pp_sep:bar_sep ctor_decl)
         ctors
   | TForward i ->

--- a/meja/src/typet.ml
+++ b/meja/src/typet.ml
@@ -7,7 +7,7 @@ open Longident
 
 type error =
   | Unbound_type_var of type_expr
-  | Wrong_number_args of Longident.t * int * int
+  | Wrong_number_args of Path.t * int * int
   | Wrong_number_implicit_args of Longident.t * int * int
   | Expected_type_var of type_expr
   | Constraints_not_satisfied of type_expr * type_decl
@@ -59,7 +59,7 @@ module Type = struct
         (mk (Tpoly (vars, typ)) env, env)
     | Ptyp_ctor variant -> (
         let {var_ident; var_params; var_implicit_params; _} = variant in
-        let decl = raw_find_type_declaration var_ident env in
+        let var_ident, decl = raw_find_type_declaration var_ident env in
         let import_implicits () =
           List.fold_map ~init:env decl.tdec_implicit_params
             ~f:(Envi.Type.refresh_var ~loc ?must_find)
@@ -107,18 +107,14 @@ module Type = struct
                 (Error
                    ( loc
                    , Wrong_number_args
-                       (var_ident.txt, given_args_length, expected_args_length)
-                   )) ;
+                       (var_ident, given_args_length, expected_args_length) )) ;
             let env, var_params =
               List.fold_map ~init:env var_params ~f:(fun env param ->
                   let param, env = import param env in
                   (env, param) )
             in
             let variant =
-              { Type0.var_params
-              ; var_ident= var_ident.txt
-              ; var_decl= decl
-              ; var_implicit_params }
+              {Type0.var_params; var_ident; var_decl= decl; var_implicit_params}
             in
             (mk (Tctor variant) env, env) )
     | Ptyp_tuple typs ->
@@ -196,9 +192,7 @@ module TypeDecl = struct
               if not (Int.equal given num_args) then
                 raise
                   (Error
-                     ( loc
-                     , Wrong_number_args
-                         (Lident tdec_ident.txt, given, num_args) ))
+                     (loc, Wrong_number_args (Pident ident, given, num_args)))
           | None ->
               () ) ;
           let {type_env; _} = env.resolve_env in
@@ -453,11 +447,11 @@ let pp_decl_typ ppf decl =
 let report_error ppf = function
   | Unbound_type_var var ->
       fprintf ppf "@[<hov>Unbound type parameter@ @[<h>%a@].@]" pp_typ var
-  | Wrong_number_args (lid, given, expected) ->
+  | Wrong_number_args (path, given, expected) ->
       fprintf ppf
         "@[The type constructor @[<h>%a@] expects %d argument(s)@ but is here \
          applied to %d argument(s).@]"
-        Longident.pp lid expected given
+        Path.pp path expected given
   | Wrong_number_implicit_args (lid, given, expected) ->
       fprintf ppf
         "@[The type constructor @[<h>%a@] expects %d implicit argument(s)@ \

--- a/meja/src/typet.ml
+++ b/meja/src/typet.ml
@@ -177,18 +177,19 @@ module TypeDecl = struct
 
   let import_field ?must_find env {fld_ident; fld_type; fld_loc= _} =
     let fld_type, env = Type.import ?must_find fld_type env in
-    (env, {Type0.fld_ident= fld_ident.txt; fld_type})
+    (env, {Type0.fld_ident= Ident.create fld_ident.txt; fld_type})
 
   let import decl' env =
     let {tdec_ident; tdec_params; tdec_implicit_params; tdec_desc; tdec_loc= _}
         =
       decl'
     in
-    let tdec_id =
+    let tdec_ident, tdec_id =
       match
-        Map.find env.resolve_env.type_env.predeclared_types tdec_ident.txt
+        IdTbl.find_name tdec_ident.txt
+          env.resolve_env.type_env.predeclared_types
       with
-      | Some (id, num_args, loc) ->
+      | Some (ident, (id, num_args, loc)) ->
           ( match !num_args with
           | Some num_args ->
               let given = List.length tdec_params in
@@ -203,11 +204,11 @@ module TypeDecl = struct
           let {type_env; _} = env.resolve_env in
           env.resolve_env.type_env
           <- { type_env with
-               predeclared_types=
-                 Map.remove type_env.predeclared_types tdec_ident.txt } ;
-          id
+               predeclared_types= IdTbl.remove ident type_env.predeclared_types
+             } ;
+          (Location.mkloc ident tdec_ident.loc, id)
       | None ->
-          next_id env
+          (map_loc ~f:Ident.create tdec_ident, next_id env)
     in
     let env = open_expr_scope env in
     let import_params env =
@@ -287,7 +288,7 @@ module TypeDecl = struct
                       let name =
                         match tdec_desc with
                         | TVariant _ ->
-                            Lident tdec_ident.txt
+                            Lident (Ident.name tdec_ident.txt)
                         | TExtend (lid, _, _) ->
                             lid.txt
                         | _ ->
@@ -332,15 +333,17 @@ module TypeDecl = struct
                         |> Set.to_list
                       in
                       let decl =
-                        mk ~name:ctor.ctor_ident.txt ~params (TRecord fields)
-                          env
+                        mk
+                          ~name:(Ident.create ctor.ctor_ident.txt)
+                          ~params (TRecord fields) env
                       in
                       (env, Type0.Ctor_record decl)
                 in
                 let env = push_scope scope (close_expr_scope env) in
                 ( env
-                , {Type0.ctor_ident= ctor.ctor_ident.txt; ctor_args; ctor_ret}
-                ) )
+                , { Type0.ctor_ident= Ident.create ctor.ctor_ident.txt
+                  ; ctor_args
+                  ; ctor_ret } ) )
           in
           let tdec_desc =
             match tdec_desc with

--- a/meja/src/typet.mli
+++ b/meja/src/typet.mli
@@ -1,6 +1,6 @@
 type error =
   | Unbound_type_var of Parsetypes.type_expr
-  | Wrong_number_args of Longident.t * int * int
+  | Wrong_number_args of Path.t * int * int
   | Wrong_number_implicit_args of Longident.t * int * int
   | Expected_type_var of Parsetypes.type_expr
   | Constraints_not_satisfied of Parsetypes.type_expr * Parsetypes.type_decl

--- a/meja/src/untype_ast.ml
+++ b/meja/src/untype_ast.ml
@@ -138,7 +138,7 @@ let rec expression_desc = function
         ( expression e
         , List.map cases ~f:(fun (p, e) -> (pattern p, expression e)) )
   | Texp_field (e, path) ->
-      Pexp_field (expression e, path)
+      Pexp_field (expression e, map_loc ~f:longident_of_path path)
   | Texp_record (fields, default) ->
       Pexp_record
         ( List.map fields ~f:(fun (label, e) -> (label, expression e))

--- a/meja/src/untype_ast.ml
+++ b/meja/src/untype_ast.ml
@@ -99,7 +99,7 @@ let rec pattern_desc = function
         (List.map fields ~f:(fun (label, p) ->
              (map_loc ~f:longident_of_path label, pattern p) ))
   | Tpat_ctor (name, arg) ->
-      Ppat_ctor (name, Option.map ~f:pattern arg)
+      Ppat_ctor (map_loc ~f:longident_of_path name, Option.map ~f:pattern arg)
 
 and pattern p =
   {Parsetypes.pat_desc= pattern_desc p.Typedast.pat_desc; pat_loc= p.pat_loc}
@@ -147,7 +147,8 @@ let rec expression_desc = function
               (map_loc ~f:longident_of_path label, expression e) )
         , Option.map ~f:expression default )
   | Texp_ctor (path, arg) ->
-      Pexp_ctor (path, Option.map ~f:expression arg)
+      Pexp_ctor
+        (map_loc ~f:longident_of_path path, Option.map ~f:expression arg)
   | Texp_unifiable {expression= e; name; id} ->
       Pexp_unifiable
         { expression= Option.map ~f:expression e

--- a/meja/src/untype_ast.ml
+++ b/meja/src/untype_ast.ml
@@ -28,7 +28,7 @@ let rec type_desc ?loc = function
       ; var_decl= _ } ->
       let params = List.map ~f:(type_expr ?loc) params in
       let implicits = List.map ~f:(type_expr ?loc) implicits in
-      Type.constr ?loc ~params ~implicits ident
+      Type.constr ?loc ~params ~implicits (longident_of_path ident)
   | Tpoly (vars, var) ->
       Type.poly ?loc (List.map ~f:(type_expr ?loc) vars) (type_expr ?loc var)
 

--- a/meja/src/untype_ast.ml
+++ b/meja/src/untype_ast.ml
@@ -1,4 +1,5 @@
 open Core_kernel
+open Ast_types
 open Type0
 open Ast_build
 
@@ -26,7 +27,8 @@ let rec type_desc ?loc = function
 and type_expr ?loc typ = type_desc ?loc typ.type_desc
 
 let field_decl ?loc fld =
-  Type_decl.Field.mk ?loc fld.fld_ident (type_expr ?loc fld.fld_type)
+  Type_decl.Field.mk ?loc (Ident.name fld.fld_ident)
+    (type_expr ?loc fld.fld_type)
 
 let ctor_args ?loc ?ret name = function
   | Ctor_tuple typs ->
@@ -39,7 +41,9 @@ let ctor_args ?loc ?ret name = function
       assert false
 
 let ctor_decl ?loc ctor =
-  ctor_args ?loc ctor.ctor_ident ctor.ctor_args
+  ctor_args ?loc
+    (Ident.name ctor.ctor_ident)
+    ctor.ctor_args
     ?ret:(Option.map ~f:(type_expr ?loc) ctor.ctor_ret)
 
 let rec type_decl_desc ?loc ?params ?implicits name = function
@@ -66,7 +70,8 @@ and type_decl ?loc decl =
   type_decl_desc ?loc
     ~params:(List.map ~f:type_expr decl.tdec_params)
     ~implicits:(List.map ~f:type_expr decl.tdec_implicit_params)
-    decl.tdec_ident decl.tdec_desc
+    (Ident.name decl.tdec_ident)
+    decl.tdec_desc
 
 let rec pattern_desc = function
   | Typedast.Tpat_any ->
@@ -148,9 +153,9 @@ let rec signature_desc = function
   | Tsig_type decl ->
       Psig_type decl
   | Tsig_module (name, msig) ->
-      Psig_module (name, module_sig msig)
+      Psig_module (map_loc ~f:Ident.name name, module_sig msig)
   | Tsig_modtype (name, msig) ->
-      Psig_modtype (name, module_sig msig)
+      Psig_modtype (map_loc ~f:Ident.name name, module_sig msig)
   | Tsig_open path ->
       Psig_open path
   | Tsig_typeext (typ, ctors) ->
@@ -185,9 +190,9 @@ let rec statement_desc = function
   | Tstmt_type decl ->
       Pstmt_type decl
   | Tstmt_module (name, m) ->
-      Pstmt_module (name, module_expr m)
+      Pstmt_module (map_loc ~f:Ident.name name, module_expr m)
   | Tstmt_modtype (name, msig) ->
-      Pstmt_modtype (name, module_sig msig)
+      Pstmt_modtype (map_loc ~f:Ident.name name, module_sig msig)
   | Tstmt_open path ->
       Pstmt_open path
   | Tstmt_typeext (typ, ctors) ->

--- a/meja/src/untype_ast.ml
+++ b/meja/src/untype_ast.ml
@@ -95,7 +95,9 @@ let rec pattern_desc = function
   | Tpat_int i ->
       Ppat_int i
   | Tpat_record fields ->
-      Ppat_record (List.map fields ~f:(fun (label, p) -> (label, pattern p)))
+      Ppat_record
+        (List.map fields ~f:(fun (label, p) ->
+             (map_loc ~f:longident_of_path label, pattern p) ))
   | Tpat_ctor (name, arg) ->
       Ppat_ctor (name, Option.map ~f:pattern arg)
 
@@ -141,7 +143,8 @@ let rec expression_desc = function
       Pexp_field (expression e, map_loc ~f:longident_of_path path)
   | Texp_record (fields, default) ->
       Pexp_record
-        ( List.map fields ~f:(fun (label, e) -> (label, expression e))
+        ( List.map fields ~f:(fun (label, e) ->
+              (map_loc ~f:longident_of_path label, expression e) )
         , Option.map ~f:expression default )
   | Texp_ctor (path, arg) ->
       Pexp_ctor (path, Option.map ~f:expression arg)

--- a/meja/src/untype_ast.ml
+++ b/meja/src/untype_ast.ml
@@ -124,7 +124,7 @@ let rec expression_desc = function
   | Texp_fun (label, p, e, explicit) ->
       Pexp_fun (label, pattern p, expression e, explicit)
   | Texp_newtype (name, e) ->
-      Pexp_newtype (name, expression e)
+      Pexp_newtype (map_loc ~f:Ident.name name, expression e)
   | Texp_seq (e1, e2) ->
       Pexp_seq (expression e1, expression e2)
   | Texp_let (p, e1, e2) ->

--- a/meja/src/untype_ast.ml
+++ b/meja/src/untype_ast.ml
@@ -183,7 +183,7 @@ and module_sig_desc = function
   | Typedast.Tmty_sig sigs ->
       Parsetypes.Pmty_sig (List.map ~f:signature_item sigs)
   | Tmty_name path ->
-      Pmty_name path
+      Pmty_name (map_loc ~f:longident_of_path path)
   | Tmty_abstract ->
       Pmty_abstract
   | Tmty_functor (name, fsig, msig) ->
@@ -226,7 +226,7 @@ and module_desc = function
   | Typedast.Tmod_struct stmts ->
       Parsetypes.Pmod_struct (List.map ~f:statement stmts)
   | Tmod_name path ->
-      Pmod_name path
+      Pmod_name (map_loc ~f:longident_of_path path)
   | Tmod_functor (name, fsig, m) ->
       Pmod_functor (name, module_sig fsig, module_expr m)
 

--- a/meja/src/untype_ast.ml
+++ b/meja/src/untype_ast.ml
@@ -85,7 +85,7 @@ let rec pattern_desc = function
   | Typedast.Tpat_any ->
       Parsetypes.Ppat_any
   | Tpat_variable str ->
-      Ppat_variable str
+      Ppat_variable (map_loc ~f:Ident.name str)
   | Tpat_constraint (p, typ) ->
       Ppat_constraint (pattern p, typ)
   | Tpat_tuple ps ->
@@ -118,7 +118,7 @@ let rec expression_desc = function
         ( expression e
         , List.map args ~f:(fun (label, e) -> (label, expression e)) )
   | Texp_variable name ->
-      Pexp_variable name
+      Pexp_variable (map_loc ~f:longident_of_path name)
   | Texp_literal i ->
       Pexp_literal (literal i)
   | Texp_fun (label, p, e, explicit) ->
@@ -146,7 +146,10 @@ let rec expression_desc = function
   | Texp_ctor (path, arg) ->
       Pexp_ctor (path, Option.map ~f:expression arg)
   | Texp_unifiable {expression= e; name; id} ->
-      Pexp_unifiable {expression= Option.map ~f:expression e; name; id}
+      Pexp_unifiable
+        { expression= Option.map ~f:expression e
+        ; name= map_loc ~f:Ident.name name
+        ; id }
   | Texp_if (e1, e2, e3) ->
       Pexp_if (expression e1, expression e2, Option.map ~f:expression e3)
 
@@ -155,9 +158,9 @@ and expression e =
 
 let rec signature_desc = function
   | Typedast.Tsig_value (name, typ) ->
-      Parsetypes.Psig_value (name, typ)
+      Parsetypes.Psig_value (map_loc ~f:Ident.name name, typ)
   | Tsig_instance (name, typ) ->
-      Psig_instance (name, typ)
+      Psig_instance (map_loc ~f:Ident.name name, typ)
   | Tsig_type decl ->
       Psig_type decl
   | Tsig_module (name, msig) ->
@@ -194,7 +197,7 @@ let rec statement_desc = function
   | Typedast.Tstmt_value (p, e) ->
       Parsetypes.Pstmt_value (pattern p, expression e)
   | Tstmt_instance (name, e) ->
-      Pstmt_instance (name, expression e)
+      Pstmt_instance (map_loc ~f:Ident.name name, expression e)
   | Tstmt_type decl ->
       Pstmt_type decl
   | Tstmt_module (name, m) ->

--- a/meja/src/untype_ast.ml
+++ b/meja/src/untype_ast.ml
@@ -165,7 +165,7 @@ let rec signature_desc = function
   | Tsig_modtype (name, msig) ->
       Psig_modtype (map_loc ~f:Ident.name name, module_sig msig)
   | Tsig_open path ->
-      Psig_open path
+      Psig_open (map_loc ~f:longident_of_path path)
   | Tsig_typeext (typ, ctors) ->
       Psig_typeext (typ, ctors)
   | Tsig_request (arg, ctor) ->
@@ -202,7 +202,7 @@ let rec statement_desc = function
   | Tstmt_modtype (name, msig) ->
       Pstmt_modtype (map_loc ~f:Ident.name name, module_sig msig)
   | Tstmt_open path ->
-      Pstmt_open path
+      Pstmt_open (map_loc ~f:longident_of_path path)
   | Tstmt_typeext (typ, ctors) ->
       Pstmt_typeext (typ, ctors)
   | Tstmt_request (arg, ctor, handler) ->

--- a/meja/src/untype_ast.ml
+++ b/meja/src/untype_ast.ml
@@ -3,6 +3,14 @@ open Ast_types
 open Type0
 open Ast_build
 
+let rec longident_of_path = function
+  | Path.Pident ident ->
+      Longident.Lident (Ident.name ident)
+  | Pdot (path, name) ->
+      Ldot (longident_of_path path, name)
+  | Papply (path1, path2) ->
+      Lapply (longident_of_path path1, longident_of_path path2)
+
 let rec type_desc ?loc = function
   | Tvar (None, explicit) ->
       Type.none ?loc ~explicit ()


### PR DESCRIPTION
This PR
* adds the `Path.t` type, describing a unique path to any object in the environment via `Ident.t`
* changes the environment search so that it constructs a `Path.t` as it locates a `Longident.t`
* migrates the majority of the constructors in `Typedast` from`Longident.t` to `Path.t`

This includes a couple of hacks:
* the `Path.t` that we should pass to a functor is converted to a `Longident.t`
  - we can implement functors much more cleanly using the typed AST mapper once #324 and #320 are in, so this will disappear along with all the other functor hacks soon anyway
* we bail out instead of attempting to map over a `TForward` in the parsetree
  - `TForward` should never appear in the user-generated parsetree
  - it's trivial to link it back in once #324 has landed

From here, we can re-introduce modes (`prover` vs `checked`), which will live in `Ident.t` and `Path.t`'s `Pdot` (for the string part to the right of the dot), that will let us bring back the 'split' environment without having to actually split the environment. I also plan to use this to simplify where we need to carry type declarations in the AST, which should fix some problems with loading ASTs from disk for multi-file compilation.

~~Note: record fields and constructors still use `Longident.t` in this PR.~~ Done. Everything that can use an `Ident.t` or `Path.t` in the typed AST now does.