### PR TITLE
[Meja] Prover blocks syntax

### DIFF
--- a/meja/ocaml/to_ocaml.ml
+++ b/meja/ocaml/to_ocaml.ml
@@ -143,6 +143,8 @@ let rec of_expression_desc ?loc = function
   | Pexp_if (e1, e2, e3) ->
       Exp.ifthenelse ?loc (of_expression e1) (of_expression e2)
         (Option.map ~f:of_expression e3)
+  | Pexp_prover e ->
+      of_expression e
 
 and of_handler ?(loc = Location.none) ?ctor_ident (args, body) =
   Parsetree.(
@@ -203,7 +205,7 @@ let rec of_signature_desc ?loc = function
           (Option.value ~default:Location.none loc)
       in
       Sig.type_extension ?loc (Te.mk ~params ident [of_ctor_decl_ext ctor])
-  | Psig_multiple sigs ->
+  | Psig_multiple sigs | Psig_prover sigs ->
       Sig.include_ ?loc
         { pincl_mod= Mty.signature ?loc (of_signature sigs)
         ; pincl_loc= Option.value ~default:Location.none loc
@@ -288,7 +290,7 @@ let rec of_statement_desc ?loc = function
         { pincl_mod= Mod.structure ?loc (typ_ext :: Option.to_list handler)
         ; pincl_loc= Option.value ~default:Location.none loc
         ; pincl_attributes= [] }
-  | Pstmt_multiple stmts ->
+  | Pstmt_multiple stmts | Pstmt_prover stmts ->
       Str.include_ ?loc
         { pincl_mod= Mod.structure ?loc (List.map ~f:of_statement stmts)
         ; pincl_loc= Option.value ~default:Location.none loc

--- a/meja/src/lexer_impl.mll
+++ b/meja/src/lexer_impl.mll
@@ -56,6 +56,7 @@ rule token = parse
     { BOOL true }
   | number as n 'f'
     { FIELD n }
+  | "Prover" { PROVER }
   | "fun" { FUN }
   | "let" { LET }
   | "instance" { INSTANCE }

--- a/meja/src/parser_impl.mly
+++ b/meja/src/parser_impl.mly
@@ -34,6 +34,7 @@ let consexp ~pos hd tl =
 %token <string> STRING
 %token <string> LIDENT
 %token <string> UIDENT
+%token PROVER
 %token FUN
 %token LET
 %token INSTANCE
@@ -161,6 +162,8 @@ structure_item:
         , ctors)) }
   | REQUEST LPAREN arg = type_expr RPAREN x = ctor_decl handler = maybe(default_request_handler)
     { mkstmt ~pos:$loc (Pstmt_request (arg, x, handler)) }
+  | PROVER LBRACE stmts = structure RBRACE
+    { mkstmt ~pos:$loc (Pstmt_prover stmts) }
 
 signature_item:
   | LET x = as_loc(val_ident) COLON typ = type_expr
@@ -191,6 +194,8 @@ signature_item:
         , ctors)) }
   | REQUEST LPAREN arg = type_expr RPAREN x = ctor_decl
     { mksig ~pos:$loc (Psig_request (arg, x)) }
+  | PROVER LBRACE sigs = signature RBRACE
+    { mksig ~pos:$loc (Psig_prover sigs) }
 
 default_request_handler:
   | WITH HANDLER p = pat_ctor_args EQUALGT LBRACE body = block RBRACE
@@ -340,6 +345,8 @@ simpl_expr:
     { mkexp ~pos:$loc (Pexp_field (e, field)) }
   | s = STRING
     { mkexp ~pos:$loc (Pexp_literal (String s)) }
+  | PROVER LBRACE e = block RBRACE
+    { mkexp ~pos:$loc (Pexp_prover e) }
 
 expr:
   | x = simpl_expr

--- a/meja/src/parsetypes.ml
+++ b/meja/src/parsetypes.ml
@@ -83,6 +83,7 @@ and expression_desc =
       ; name: str
       ; id: int }
   | Pexp_if of expression * expression * expression option
+  | Pexp_prover of expression
 
 type signature_item = {sig_desc: signature_desc; sig_loc: Location.t}
 
@@ -98,6 +99,7 @@ and signature_desc =
   | Psig_typeext of variant * ctor_decl list
   | Psig_request of type_expr * ctor_decl
   | Psig_multiple of signature
+  | Psig_prover of signature
 
 and module_sig = {msig_desc: module_sig_desc; msig_loc: Location.t}
 
@@ -122,6 +124,7 @@ and statement_desc =
   | Pstmt_request of
       type_expr * ctor_decl * (pattern option * expression) option
   | Pstmt_multiple of statements
+  | Pstmt_prover of statements
 
 and module_expr = {mod_desc: module_desc; mod_loc: Location.t}
 

--- a/meja/src/parsetypes_iter.ml
+++ b/meja/src/parsetypes_iter.ml
@@ -172,6 +172,8 @@ let expression_desc iter = function
       iter.expression iter e1 ;
       iter.expression iter e2 ;
       Option.iter ~f:(iter.expression iter) e3
+  | Pexp_prover e ->
+      iter.expression iter e
 
 let signature iter = List.iter ~f:(iter.signature_item iter)
 
@@ -194,6 +196,8 @@ let signature_desc iter = function
   | Psig_request (typ, ctor) ->
       iter.type_expr iter typ ; iter.ctor_decl iter ctor
   | Psig_multiple sigs ->
+      iter.signature iter sigs
+  | Psig_prover sigs ->
       iter.signature iter sigs
 
 let module_sig iter {msig_desc; msig_loc} =
@@ -239,6 +243,8 @@ let statement_desc iter = function
           Option.iter ~f:(iter.pattern iter) p ;
           iter.expression iter e )
   | Pstmt_multiple stmts ->
+      iter.statements iter stmts
+  | Pstmt_prover stmts ->
       iter.statements iter stmts
 
 let module_expr iter {mod_desc; mod_loc} =

--- a/meja/src/parsetypes_map.ml
+++ b/meja/src/parsetypes_map.ml
@@ -193,6 +193,8 @@ let expression_desc mapper = function
         ( mapper.expression mapper e1
         , mapper.expression mapper e2
         , Option.map ~f:(mapper.expression mapper) e3 )
+  | Pexp_prover e ->
+      Pexp_prover (mapper.expression mapper e)
 
 let signature mapper = List.map ~f:(mapper.signature_item mapper)
 
@@ -220,6 +222,8 @@ let signature_desc mapper = function
       Psig_request (mapper.type_expr mapper typ, mapper.ctor_decl mapper ctor)
   | Psig_multiple sigs ->
       Psig_multiple (mapper.signature mapper sigs)
+  | Psig_prover sigs ->
+      Psig_prover (mapper.signature mapper sigs)
 
 let module_sig mapper {msig_desc; msig_loc} =
   { msig_loc= mapper.location mapper msig_loc
@@ -269,6 +273,8 @@ let statement_desc mapper = function
               , mapper.expression mapper e ) ) )
   | Pstmt_multiple stmts ->
       Pstmt_multiple (mapper.statements mapper stmts)
+  | Pstmt_prover stmts ->
+      Pstmt_prover (mapper.statements mapper stmts)
 
 let module_expr mapper {mod_desc; mod_loc} =
   { mod_loc= mapper.location mapper mod_loc

--- a/meja/src/pprint.ml
+++ b/meja/src/pprint.ml
@@ -241,6 +241,8 @@ let rec expression_desc fmt = function
       fprintf fmt
         "if@ (@[<hv1>@,%a@,@]) {@[<hv2>@,%a@,@]}@ else@ {@[<hv2>@,%a@,@]}"
         expression e1 expression e2 expression e3
+  | Pexp_prover e ->
+      fprintf fmt "@[<hv2>Prover {@,%a@,}@]" expression e
 
 and expression_desc_bracket fmt exp =
   match exp with
@@ -298,6 +300,8 @@ let rec signature_desc fmt = function
         ctor_decl ctor
   | Psig_multiple sigs ->
       signature fmt sigs
+  | Psig_prover sigs ->
+      fprintf fmt "@[<2>Prover {@,%a@,}@]@;@;" signature sigs
 
 and signature_item fmt sigi = signature_desc fmt sigi.sig_desc
 

--- a/meja/src/typechecker.ml
+++ b/meja/src/typechecker.ml
@@ -940,6 +940,9 @@ let rec get_expression env expected exp =
       let e3, env = get_expression env expected e3 in
       ( {exp_loc= loc; exp_type= expected; exp_desc= Texp_if (e1, e2, Some e3)}
       , env )
+  | Pexp_prover e ->
+      let e, env = get_expression env expected e in
+      ({exp_loc= loc; exp_type= expected; exp_desc= Texp_prover e}, env)
 
 and check_binding ?(toplevel = false) (env : Envi.t) p e : 's =
   let loc = e.exp_loc in
@@ -1132,6 +1135,9 @@ let rec check_signature_item env item =
   | Psig_multiple sigs ->
       let env, sigs = check_signature env sigs in
       (env, {Typedast.sig_desc= Tsig_multiple sigs; sig_loc= loc})
+  | Psig_prover sigs ->
+      let env, sigs = check_signature env sigs in
+      (env, {Typedast.sig_desc= Tsig_prover sigs; sig_loc= loc})
 
 and check_signature env signature =
   List.fold_map ~init:env signature ~f:check_signature_item
@@ -1349,6 +1355,9 @@ let rec check_statement env stmt =
   | Pstmt_multiple stmts ->
       let env, stmts = List.fold_map ~init:env stmts ~f:check_statement in
       (env, {stmt_loc= loc; stmt_desc= Tstmt_multiple stmts})
+  | Pstmt_prover stmts ->
+      let env, stmts = List.fold_map ~init:env stmts ~f:check_statement in
+      (env, {stmt_loc= loc; stmt_desc= Tstmt_prover stmts})
 
 and check_module_expr env m =
   let loc = m.mod_loc in

--- a/meja/src/typedast.ml
+++ b/meja/src/typedast.ml
@@ -40,6 +40,7 @@ and expression_desc =
       ; name: str
       ; id: int }
   | Texp_if of expression * expression * expression option
+  | Texp_prover of expression
 
 type signature_item = {sig_desc: signature_desc; sig_loc: Location.t}
 
@@ -55,6 +56,7 @@ and signature_desc =
   | Tsig_typeext of variant * ctor_decl list
   | Tsig_request of type_expr * ctor_decl
   | Tsig_multiple of signature
+  | Tsig_prover of signature
 
 and module_sig = {msig_desc: module_sig_desc; msig_loc: Location.t}
 
@@ -79,6 +81,7 @@ and statement_desc =
   | Tstmt_request of
       type_expr * ctor_decl * (pattern option * expression) option
   | Tstmt_multiple of statements
+  | Tstmt_prover of statements
 
 and module_expr = {mod_desc: module_desc; mod_loc: Location.t}
 

--- a/meja/src/typedast_iter.ml
+++ b/meja/src/typedast_iter.ml
@@ -180,6 +180,8 @@ let expression_desc iter = function
       iter.expression iter e1 ;
       iter.expression iter e2 ;
       Option.iter ~f:(iter.expression iter) e3
+  | Texp_prover e ->
+      iter.expression iter e
 
 let signature iter = List.iter ~f:(iter.signature_item iter)
 
@@ -202,6 +204,8 @@ let signature_desc iter = function
   | Tsig_request (typ, ctor) ->
       iter.type_expr iter typ ; iter.ctor_decl iter ctor
   | Tsig_multiple sigs ->
+      iter.signature iter sigs
+  | Tsig_prover sigs ->
       iter.signature iter sigs
 
 let module_sig iter {msig_desc; msig_loc} =
@@ -247,6 +251,8 @@ let statement_desc iter = function
           Option.iter ~f:(iter.pattern iter) p ;
           iter.expression iter e )
   | Tstmt_multiple stmts ->
+      iter.statements iter stmts
+  | Tstmt_prover stmts ->
       iter.statements iter stmts
 
 let module_expr iter {mod_desc; mod_loc} =

--- a/meja/src/typedast_map.ml
+++ b/meja/src/typedast_map.ml
@@ -202,6 +202,8 @@ let expression_desc mapper = function
         ( mapper.expression mapper e1
         , mapper.expression mapper e2
         , Option.map ~f:(mapper.expression mapper) e3 )
+  | Texp_prover e ->
+      Texp_prover (mapper.expression mapper e)
 
 let signature mapper = List.map ~f:(mapper.signature_item mapper)
 
@@ -229,6 +231,8 @@ let signature_desc mapper = function
       Tsig_request (mapper.type_expr mapper typ, mapper.ctor_decl mapper ctor)
   | Tsig_multiple sigs ->
       Tsig_multiple (mapper.signature mapper sigs)
+  | Tsig_prover sigs ->
+      Tsig_prover (mapper.signature mapper sigs)
 
 let module_sig mapper {msig_desc; msig_loc} =
   { msig_loc= mapper.location mapper msig_loc
@@ -278,6 +282,8 @@ let statement_desc mapper = function
               , mapper.expression mapper e ) ) )
   | Tstmt_multiple stmts ->
       Tstmt_multiple (mapper.statements mapper stmts)
+  | Tstmt_prover stmts ->
+      Tstmt_prover (mapper.statements mapper stmts)
 
 let module_expr mapper {mod_desc; mod_loc} =
   { mod_loc= mapper.location mapper mod_loc

--- a/meja/src/untype_ast.ml
+++ b/meja/src/untype_ast.ml
@@ -141,6 +141,8 @@ let rec expression_desc = function
       Pexp_unifiable {expression= Option.map ~f:expression e; name; id}
   | Texp_if (e1, e2, e3) ->
       Pexp_if (expression e1, expression e2, Option.map ~f:expression e3)
+  | Texp_prover e ->
+      Pexp_prover (expression e)
 
 and expression e =
   {Parsetypes.exp_desc= expression_desc e.Typedast.exp_desc; exp_loc= e.exp_loc}
@@ -164,6 +166,8 @@ let rec signature_desc = function
       Psig_request (arg, ctor)
   | Tsig_multiple sigs ->
       Psig_multiple (List.map ~f:signature_item sigs)
+  | Tsig_prover sigs ->
+      Psig_prover (List.map ~f:signature_item sigs)
 
 and signature_item s =
   {Parsetypes.sig_desc= signature_desc s.Typedast.sig_desc; sig_loc= s.sig_loc}
@@ -206,6 +210,8 @@ let rec statement_desc = function
             handler )
   | Tstmt_multiple stmts ->
       Pstmt_multiple (List.map ~f:statement stmts)
+  | Tstmt_prover stmts ->
+      Pstmt_prover (List.map ~f:statement stmts)
 
 and statement s =
   { Parsetypes.stmt_desc= statement_desc s.Typedast.stmt_desc

--- a/meja/tests/prover-test.meja
+++ b/meja/tests/prover-test.meja
@@ -1,0 +1,36 @@
+module type P = {
+  Prover {
+    let x : int;
+
+    let f : bool -> bool;
+  };
+};
+
+module P = {
+  Prover {
+    let x = 15;
+    let f = fun (b) => { b; };
+  };
+};
+
+let f = Prover {
+  fun (x) => { x; };
+};
+
+Prover {
+  let g = fun (x) => { f(x); };
+};
+
+let h = fun (x) => { Prover { g(x); }; };
+
+let i = fun () => {
+  let f = Prover {
+    fun (x) => {
+      x;
+    };
+  };
+  let i = Prover {
+    f(15);
+  };
+  i;
+};

--- a/meja/tests/prover-test.ml
+++ b/meja/tests/prover-test.ml
@@ -1,0 +1,32 @@
+module Impl = Snarky.Snark.Make (Snarky.Backends.Mnt4.Default)
+open Impl
+
+module type P = sig
+  include
+    sig
+      val x : int
+
+      val f : bool -> bool
+  end
+end
+
+module P = struct
+  include struct
+    let x = 15
+
+    let f b = b
+  end
+end
+
+let f x = x
+
+include struct
+  let g x = f x
+end
+
+let h x = g x
+
+let i () =
+  let f x = x in
+  let i = f 15 in
+  i


### PR DESCRIPTION
This PR adds the syntax for prover blocks.

As well as the expression form from the conference, this also adds a structure and signature form, so toplevel names, type declarations, etc. can be defined to be prover-only.

Edit: This doesn't actually *do* anything yet, it needs #330, #334, and a follow-up to both that integrates `Path.t` with modes before we can start segmenting the namespace using this.