### PR TITLE
Add a Field_unpacked module

### DIFF
--- a/src/snark_intf.ml
+++ b/src/snark_intf.ml
@@ -714,8 +714,8 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
 
       val unpack_full :
         Var.t -> (Boolean.var Bitstring_lib.Bitstring.Lsb_first.t, _) Checked.t
-      (** [unpack x ~length] returns a list of R1CS variables containing the
-          bits of [x].
+      (** [unpack_full x] returns a list of R1CS variables containing the bits
+          of [x], with the least significant bit of x first.
       *)
 
       val choose_preimage_var :
@@ -1420,6 +1420,8 @@ module type Run_basic = sig
     val to_bignum_bigint : t -> Bignum_bigint.t
   end
 
+  module Internal_Basic : Basic with type field = field
+
   (** Rank-1 constraints over {!type:Field.t}s. *)
   module rec Constraint : sig
     type t = Field.t Constraint0.t
@@ -1491,7 +1493,7 @@ module type Run_basic = sig
     end
 
     type ('var, 'value) t =
-      ('var, 'value, field, (unit, unit, field) Checked.t) Types.Typ.t
+      ('var, 'value, field, (unit, unit) Internal_Basic.Checked.t) Types.Typ.t
 
     (** Accessors for {!type:Types.Typ.t} fields: *)
 
@@ -1804,7 +1806,7 @@ module type Run_basic = sig
     module Ref : sig
       (** A mutable reference to an ['a] value, which may be used in checked
           computations. *)
-      type 'a t
+      type 'a t = 'a Internal_Basic.As_prover.Ref.t
 
       val create : (unit -> 'a) as_prover -> 'a t
 
@@ -2028,11 +2030,6 @@ module type Run_basic = sig
   val set_constraint_logger : (Constraint.t -> unit) -> unit
 
   val clear_constraint_logger : unit -> unit
-
-  module Internal_Basic :
-    Basic
-    with type field = field
-     and type 'a As_prover.Ref.t = 'a As_prover.Ref.t
 
   val run_checked : ('a, prover_state) Internal_Basic.Checked.t -> 'a
 end

--- a/src/unpacked_field.ml
+++ b/src/unpacked_field.ml
@@ -84,14 +84,18 @@ module Make (Snark : Snark_intf.Basic) :
 
   let constant x = List.map ~f:Boolean.var_of_value (Field.unpack x)
 
+  let rec pad n x = if n > 0 then pad (n - 1) (Boolean.false_ :: x) else x
+
   module Unsafe = struct
     let of_bits l =
-      assert (List.length l <= Field.size_in_bits) ;
-      List.map ~f:Boolean.var_of_value l
+      let pad_size = Field.size_in_bits - List.length l in
+      assert (pad_size >= 0) ;
+      pad pad_size (List.map ~f:Boolean.var_of_value l)
 
     let of_bitstring l =
-      assert (List.length l <= Field.size_in_bits) ;
-      l
+      let pad_size = Field.size_in_bits - List.length l in
+      assert (pad_size >= 0) ;
+      pad pad_size l
   end
 
   let to_bitstring l =

--- a/src/unpacked_field.ml
+++ b/src/unpacked_field.ml
@@ -99,7 +99,6 @@ module Make (Snark : Snark_intf.Basic) :
   end
 
   let to_bitstring l =
-    assert (List.length l <= Field.size_in_bits) ;
     l
 
   let unpack f =

--- a/src/unpacked_field.ml
+++ b/src/unpacked_field.ml
@@ -98,8 +98,7 @@ module Make (Snark : Snark_intf.Basic) :
       pad pad_size l
   end
 
-  let to_bitstring l =
-    l
+  let to_bitstring l = l
 
   let unpack f =
     let open Checked in

--- a/src/unpacked_field.ml
+++ b/src/unpacked_field.ml
@@ -1,0 +1,175 @@
+module type S = sig
+  type (_, _) checked
+
+  type (_, _) typ
+
+  type field
+
+  type field_var
+
+  type bool_var
+
+  type bitstring
+
+  (** The type of unpacked field variables.
+
+      The field variable is represented internally in the R1CS as a sequence of
+      bit variables, so that it can be converted to either a bitstring or a
+      field variable multiple times with no extra cost.
+  *)
+  type t
+
+  val typ : (t, field) typ
+  (** Convert between field element values and R1CS unpacked field variables.
+
+      Storing a field element requires 1 constraint for each bit in the field size.
+  *)
+
+  val constant : field -> t
+  (** The unpacked field representing the given field element. *)
+
+  (** Caution: Passing the bit representation of a number larger than the
+      maximum field element to any of these functions will result in a field
+      element distinct from the number represented.
+  *)
+  module Unsafe : sig
+    val of_bits : bool list -> t
+    (** The unpacked field element representing the given bits.
+        Raises [AssertionError] if the number of bits is greater than the
+        number of bits in the field.
+    *)
+
+    val of_bitstring : bitstring -> t
+    (** The unpacked field representing the given bitstring.
+        Raises [AssertionError] if the number of bits is greater than the
+        number of bits in the field.
+    *)
+  end
+
+  val to_bitstring : t -> bitstring
+  (** Convert an unpacked field to a bitstring. *)
+
+  val unpack : field_var -> (t, _) checked
+  (** Convert a field variable into an unpacked field variable.
+      Requires 1 constraint for each bit in the field size.
+  *)
+
+  val pack : t -> field_var
+  (** Convert an unpacked field variable into a field variable. *)
+end
+
+open Core_kernel
+
+module Make (Snark : Snark_intf.Basic) :
+  S
+  with type ('a, 's) checked := ('a, 's) Snark.Checked.t
+   and type ('var, 'value) typ := ('var, 'value) Snark.Typ.t
+   and type field := Snark.Field.t
+   and type field_var := Snark.Field.Var.t
+   and type bool_var := Snark.Boolean.var
+   and type bitstring := Snark.Bitstring_checked.t = struct
+  open Snark
+
+  type t = Bitstring_checked.t
+
+  let typ : (t, Field.t) Typ.t =
+    Typ.transport
+      (Typ.list ~length:Field.size_in_bits Boolean.typ)
+      ~there:Field.unpack ~back:Field.project
+
+  let constant x = List.map ~f:Boolean.var_of_value (Field.unpack x)
+
+  module Unsafe = struct
+    let of_bits l =
+      assert (List.length l <= Field.size_in_bits) ;
+      List.map ~f:Boolean.var_of_value l
+
+    let of_bitstring l =
+      assert (List.length l <= Field.size_in_bits) ;
+      l
+  end
+
+  let to_bitstring l =
+    assert (List.length l <= Field.size_in_bits) ;
+    l
+
+  let unpack f =
+    let open Checked in
+    let%map x = Field.Checked.unpack_full f in
+    (Bitstring_lib.Bitstring.Msb_first.of_lsb_first x :> Bitstring_checked.t)
+
+  let pack x = Field.Var.project x
+end
+
+module Run = struct
+  module type S = sig
+    type (_, _) typ
+
+    type field
+
+    type field_var
+
+    type bool_var
+
+    type bitstring
+
+    (** The type of unpacked field variables.
+
+      The field variable is represented internally in the R1CS as a sequence of
+      bit variables, so that it can be converted to either a bitstring or a
+      field variable multiple times with no extra cost.
+  *)
+    type t
+
+    val typ : (t, field) typ
+    (** Convert between field element values and R1CS unpacked field variables.
+
+        Storing a field element requires 1 constraint for each bit in the field
+        size.
+    *)
+
+    val constant : field -> t
+    (** The unpacked field representing the given field element. *)
+
+    (** Caution: Passing the bit representation of a number larger than the
+        maximum field element to any of these functions will result in a field
+        element distinct from the number represented.
+    *)
+    module Unsafe : sig
+      val of_bits : bool list -> t
+      (** The unpacked field element representing the given bits.
+          Raises [AssertionError] if the number of bits is greater than the
+          number of bits in the field.
+      *)
+
+      val of_bitstring : bitstring -> t
+      (** The unpacked field representing the given bitstring.
+          Raises [AssertionError] if the number of bits is greater than the
+          number of bits in the field.
+      *)
+    end
+
+    val to_bitstring : t -> bitstring
+    (** Convert an unpacked field to a bitstring. *)
+
+    val unpack : field_var -> t
+    (** Convert a field variable into an unpacked field variable.
+        Requires 1 constraint for each bit in the field size.
+    *)
+
+    val pack : t -> field_var
+    (** Convert an unpacked field variable into a field variable. *)
+  end
+
+  module Make (Snark : Snark_intf.Run_basic) :
+    S
+    with type ('var, 'value) typ := ('var, 'value) Snark.Typ.t
+     and type field := Snark.field
+     and type field_var := Snark.Field.t
+     and type bool_var := Snark.Boolean.var
+     and type bitstring := Snark.Bitstring_checked.t = struct
+    include Make (Snark.Internal_Basic)
+
+    let unpack f = Snark.run_checked (unpack f)
+  end
+end


### PR DESCRIPTION
This PR adds the `Field_unpacked` module.

The idea is that
* the underlying representation is just a bitstring in the R1CS
* it is always 'free' in the R1CS to get from a `Field_unpacked.t` to a `Field.t` **and** to convert to a `Bitstring_checked.t`/`Boolean.t list`
  - most importantly, it makes it easier to avoid unpacking the same field element twice
* we avoid the nuances of the `Number` implementation, where multiple calls to `to_bits` are free in some cases and expensive in others, depending on what operations have been done to it

This fixes #332.