### PR TITLE
Add a generic if_ function

### DIFF
--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -1,6 +1,7 @@
 module Cvar0 = Cvar
 module Bignum_bigint = Bigint
 module Checked_ast = Checked
+module Typ_monads0 = Typ_monads
 open Core_kernel
 
 let () = Camlsnark_c.linkme
@@ -323,6 +324,16 @@ struct
       let open Let_syntax in
       let%map _ = inv v in
       ()
+
+    (** Read the [Cvar.t]s that represent the value [x].
+
+        WARNING: This assumes that reading zero will not cause an error within
+        the [read] function.
+    *)
+    let unsafe_read_cvars {Typ.read; _} x =
+      Typ_monads0.Read.run
+        (Typ_monads0.Read.make_cvars (read x))
+        (fun _ -> Field.zero)
 
     module Boolean = struct
       open Boolean.Unsafe
@@ -1304,6 +1315,28 @@ struct
 
   include Checked
 
+  let%snarkydef_ if_ (b : Boolean.var) ~(typ : ('var, _) Typ.t) ~(then_ : 'var)
+      ~(else_ : 'var) =
+    let then_ = unsafe_read_cvars typ then_ in
+    let else_ = unsafe_read_cvars typ else_ in
+    let%map res =
+      all
+        (Core_kernel.List.map2_exn then_ else_ ~f:(fun then_ else_ ->
+             if_ b ~then_ ~else_ ))
+    in
+    let res = ref res in
+    let ret =
+      Typ_monads0.Alloc.run typ.alloc (fun () ->
+          match !res with
+          | hd :: tl ->
+              res := tl ;
+              hd
+          | _ ->
+              assert false )
+    in
+    assert (!res = []) ;
+    ret
+
   module Proof_system = struct
     open Run.Proof_system
 
@@ -1990,6 +2023,8 @@ module Run = struct
     let handle_as_prover x h =
       let h = h () in
       handle x h
+
+    let if_ b ~typ ~then_ ~else_ = run (if_ b ~typ ~then_ ~else_)
 
     let with_label lbl x =
       let {stack; _} = !state in

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -1326,6 +1326,9 @@ struct
     in
     let res = ref res in
     let ret =
+      (* Run the typ's allocator, providing the values from the Cvar.t list
+         [res].
+      *)
       Typ_monads0.Alloc.run typ.alloc (fun () ->
           match !res with
           | hd :: tl ->

--- a/src/snark_intf.ml
+++ b/src/snark_intf.ml
@@ -1224,6 +1224,19 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
       {!val:exists} calls in the wrapped checked computation.
   *)
 
+  val if_ :
+       Boolean.var
+    -> typ:('var, _) Typ.t
+    -> then_:'var
+    -> else_:'var
+    -> ('var, _) Checked.t
+  (** [if_ b ~then_ ~else_] returns [then_] if [b] is true, or [else_]
+      otherwise.
+
+      WARNING: The [Typ.t]'s [read] field must be able to construct values from
+      a series of field zeros.
+  *)
+
   val with_label : string -> ('a, 's) Checked.t -> ('a, 's) Checked.t
   (** Add a label to all of the constraints added in the checked computation.
       If a constraint is checked and isn't satisfied, this label will be shown
@@ -2001,6 +2014,15 @@ module type Run_basic = sig
   val handle : (unit -> 'a) -> Handler.t -> 'a
 
   val handle_as_prover : (unit -> 'a) -> (unit -> Handler.t As_prover.t) -> 'a
+
+  val if_ :
+    Boolean.var -> typ:('var, _) Typ.t -> then_:'var -> else_:'var -> 'var
+  (** [if_ b ~then_ ~else_] returns [then_] if [b] is true, or [else_]
+      otherwise.
+
+      WARNING: The [Typ.t]'s [read] field must be able to construct values from
+      a series of field zeros.
+  *)
 
   val with_label : string -> (unit -> 'a) -> 'a
 

--- a/src/typ_monads.ml
+++ b/src/typ_monads.ml
@@ -26,6 +26,17 @@ module Read = struct
 
   let rec run t f =
     match t with Pure x -> x | Free (T.Read (x, k)) -> run (k (f x)) f
+
+  (** Aggregate [Cvar.t]s used in the underlying monad. *)
+  let make_cvars t =
+    let rec make_cvars acc t =
+      match t with
+      | Pure _ ->
+          Pure (List.rev acc)
+      | Free (T.Read (x, k)) ->
+          Free (T.Read (x, fun y -> make_cvars (x :: acc) (k y)))
+    in
+    make_cvars [] t
 end
 
 module Alloc = struct


### PR DESCRIPTION
This PR
* adds a helper function to `Typ_monads.Read` to convert a normal read value into one that returns the underlying `Cvar.t`s
* uses it to implement `unsafe_read_cvars`, which evaluates the read on a series of field zeros and dumps the `Cvar.t`s
* implements a generic `if_` with a `Typ.t` argument

This is safe to use as long as
* the `Typ.t` is consistent between its `alloc` and `read` fields
  - we have a variety of other problems if this doesn't hold
* the `read` field of the `Typ.t` will accept a value comprised of only field zeros
  - this is true for all of our built-ins, including `Enumerable.Make`
  - there's a warning mentioning in the function's doc-comment