### PR TITLE
[Meja] Use modes in Ident.Table.t

### DIFF
--- a/meja/meja.ml
+++ b/meja/meja.ml
@@ -167,7 +167,7 @@ let main =
               let env = Envi.open_absolute_module None env in
               let _path, m =
                 try
-                  Envi.find_module ~loc
+                  Envi.find_module ~mode:Checked ~loc
                     (mkloc (Longident.Lident "Snarky__Request"))
                     env
                 with _ ->

--- a/meja/src/ast_types.ml
+++ b/meja/src/ast_types.ml
@@ -109,3 +109,9 @@ type mode = Checked | Prover [@@deriving sexp]
 let string_of_mode = function Checked -> "Checked" | Prover -> "Prover"
 
 let pp_mode ppf mode = Format.pp_print_string ppf (string_of_mode mode)
+
+let modes_of_mode = function
+  | Checked -> (
+      function Checked -> true | Prover -> false )
+  | Prover -> (
+      function Checked -> true | Prover -> true )

--- a/meja/src/envi.ml
+++ b/meja/src/envi.ml
@@ -136,7 +136,8 @@ module Scope = struct
 
   let get_name name {names; _} = IdTbl.find name names
 
-  let find_name name {names; _} = IdTbl.find_name name names
+  let find_name ~mode name {names; _} =
+    IdTbl.find_name ~modes:(modes_of_mode mode) name names
 
   let add_type_variable key typ scope =
     {scope with type_variables= Map.set scope.type_variables ~key ~data:typ}
@@ -150,7 +151,8 @@ module Scope = struct
 
   let get_field ident scope = IdTbl.find ident scope.fields
 
-  let find_field name scope = IdTbl.find_name name scope.fields
+  let find_field ~mode name scope =
+    IdTbl.find_name ~modes:(modes_of_mode mode) name scope.fields
 
   let add_ctor decl index scope ctor_decl =
     { scope with
@@ -159,7 +161,8 @@ module Scope = struct
 
   let get_ctor name scope = IdTbl.find name scope.ctors
 
-  let find_ctor name scope = IdTbl.find_name name scope.ctors
+  let find_ctor ~mode name scope =
+    IdTbl.find_name ~modes:(modes_of_mode mode) name scope.ctors
 
   let add_preferred_type_name path decl_id {type_paths} =
     {type_paths= Map.set type_paths ~key:decl_id ~data:path}
@@ -176,7 +179,8 @@ module Scope = struct
 
   let get_type_declaration name scope = IdTbl.find name scope.type_decls
 
-  let find_type_declaration name scope = IdTbl.find_name name scope.type_decls
+  let find_type_declaration ~mode name scope =
+    IdTbl.find_name ~modes:(modes_of_mode mode) name scope.type_decls
 
   let register_type_declaration decl scope =
     let scope' = scope in
@@ -311,7 +315,8 @@ module Scope = struct
   let add_module_type name m scope =
     {scope with module_types= IdTbl.add scope.module_types ~key:name ~data:m}
 
-  let get_module_type name scope = IdTbl.find_name name scope.module_types
+  let get_module_type ~mode name scope =
+    IdTbl.find_name ~modes:(modes_of_mode mode) name scope.module_types
 
   let rec outer_mod_name ~loc lid =
     let outer_mod_name = outer_mod_name ~loc in
@@ -332,21 +337,27 @@ module Scope = struct
           (* You can't apply a toplevel module, so we just error out instead. *)
           raise (Error (loc, Unbound_module lid)) )
 
-  let rec find_module_ ~loc ~scopes resolve_env lid scope =
+  let rec find_module_ ~mode ~loc ~scopes resolve_env lid scope =
     let open Option.Let_syntax in
     match lid with
     | Lident name ->
-        let%map ident, m = get_module ~loc ~scopes resolve_env name scope in
+        let%map ident, m =
+          get_module ~mode ~loc ~scopes resolve_env name scope
+        in
         (Path.Pident ident, m)
     | Ldot (path, name) ->
-        let%bind path, m = find_module_ ~loc ~scopes resolve_env path scope in
-        let%map ident, m = get_module ~loc ~scopes resolve_env name m in
+        let%bind path, m =
+          find_module_ ~mode ~loc ~scopes resolve_env path scope
+        in
+        let%map ident, m = get_module ~mode ~loc ~scopes resolve_env name m in
         (Path.Pdot (path, Ident.name ident), m)
     | Lapply (fpath, path) ->
-        let%map fpath, m = find_module_ ~loc ~scopes resolve_env fpath scope in
-        apply_functor ~loc ~scopes resolve_env fpath path m
+        let%map fpath, m =
+          find_module_ ~mode ~loc ~scopes resolve_env fpath scope
+        in
+        apply_functor ~mode ~loc ~scopes resolve_env fpath path m
 
-  and apply_functor ~loc ~scopes resolve_env fpath lid scope =
+  and apply_functor ~mode ~loc ~scopes resolve_env fpath lid scope =
     let f =
       match scope.kind with
       | Functor f ->
@@ -354,25 +365,28 @@ module Scope = struct
       | _ ->
           raise (Error (loc, Not_a_functor))
     in
-    let path, m = find_module ~loc lid resolve_env scopes in
+    let path, m = find_module ~mode ~loc lid resolve_env scopes in
     (* HACK *)
     let flid = Untype_ast.longident_of_path fpath in
     (Path.Papply (fpath, path), f flid (Immediate m))
 
-  and get_module ~loc ~scopes resolve_env name scope =
-    match IdTbl.find_name name scope.modules with
+  and get_module ~mode ~loc ~scopes resolve_env name scope =
+    match IdTbl.find_name ~modes:(modes_of_mode mode) name scope.modules with
     | Some (ident, Immediate m) ->
         Some (ident, m)
     | Some (ident, Deferred lid) ->
-        Option.map (get_global_module ~loc ~scopes resolve_env lid)
+        Option.map (get_global_module ~mode ~loc ~scopes resolve_env lid)
           ~f:(fun (_ident, m) -> (ident, m))
     | None ->
         None
 
-  and get_global_module ~loc ~scopes resolve_env lid =
+  and get_global_module ~mode ~loc ~scopes resolve_env lid =
     let name, lid = outer_mod_name ~loc lid in
     let m =
-      match IdTbl.find_name name resolve_env.external_modules with
+      match
+        IdTbl.find_name ~modes:(modes_of_mode mode) name
+          resolve_env.external_modules
+      with
       | Some (name, Immediate m) ->
           Some (name, m)
       | Some (name, Deferred filename) ->
@@ -393,36 +407,37 @@ module Scope = struct
     in
     match (m, lid) with
     | Some (ident, m), Some lid ->
-        Option.map (find_module_ ~loc ~scopes resolve_env lid m)
+        Option.map (find_module_ ~mode ~loc ~scopes resolve_env lid m)
           ~f:(fun (path, m) -> (Path.add_outer_module ident path, m))
     | Some (ident, m), None ->
         Some (Pident ident, m)
     | None, _ ->
         None
 
-  and find_module ~loc lid resolve_env scopes =
+  and find_module ~mode ~loc lid resolve_env scopes =
     match
-      List.find_map ~f:(find_module_ ~loc ~scopes resolve_env lid) scopes
+      List.find_map ~f:(find_module_ ~mode ~loc ~scopes resolve_env lid) scopes
     with
     | Some m ->
         m
     | None -> (
-      match get_global_module ~loc ~scopes resolve_env lid with
+      match get_global_module ~mode ~loc ~scopes resolve_env lid with
       | Some m ->
           m
       | None ->
           raise (Error (loc, Unbound_module lid)) )
 
-  let rec find_module_deferred ~loc ~scopes resolve_env lid scope =
+  let rec find_module_deferred ~mode ~loc ~scopes resolve_env lid scope =
     let open Option.Let_syntax in
+    let modes = modes_of_mode mode in
     match lid with
     | Lident name ->
-        let%map ident, m = IdTbl.find_name name scope.modules in
+        let%map ident, m = IdTbl.find_name ~modes name scope.modules in
         (Path.Pident ident, m)
     | Ldot (lid, name) -> (
-      match find_module_deferred ~loc ~scopes resolve_env lid scope with
+      match find_module_deferred ~mode ~loc ~scopes resolve_env lid scope with
       | Some (path, Immediate m) ->
-          let%map ident, m = IdTbl.find_name name m.modules in
+          let%map ident, m = IdTbl.find_name ~modes name m.modules in
           (Path.Pdot (path, Ident.name ident), m)
       | Some (path, Deferred lid) ->
           Some (Path.Pdot (path, name), Deferred (Ldot (lid, name)))
@@ -430,9 +445,11 @@ module Scope = struct
           None )
     | Lapply (lid1, lid2) ->
         (* Don't defer functor applications *)
-        let fpath, m_functor = find_module ~loc lid1 resolve_env scopes in
+        let fpath, m_functor =
+          find_module ~mode ~loc lid1 resolve_env scopes
+        in
         let path, m =
-          apply_functor ~loc ~scopes resolve_env fpath lid2 m_functor
+          apply_functor ~mode ~loc ~scopes resolve_env fpath lid2 m_functor
         in
         Some (path, Immediate m)
 
@@ -593,11 +610,11 @@ let register_external_module name x env =
 let find_module ~loc (lid : lid) env =
   Scope.find_module ~loc lid.txt env.resolve_env env.scope_stack
 
-let find_module_deferred ~loc (lid : lid) env =
+let find_module_deferred ~mode ~loc (lid : lid) env =
   List.find_map
     ~f:
-      (Scope.find_module_deferred ~loc ~scopes:env.scope_stack env.resolve_env
-         lid.txt)
+      (Scope.find_module_deferred ~mode ~loc ~scopes:env.scope_stack
+         env.resolve_env lid.txt)
     env.scope_stack
 
 let add_implicit_instance name typ env =
@@ -610,22 +627,22 @@ let add_implicit_instance name typ env =
   env.resolve_env.type_env <- TypeEnvi.add_implicit_instance id typ type_env ;
   env
 
-let find_of_lident ~kind ~get_name (lid : lid) env =
+let find_of_lident ~mode ~kind ~get_name (lid : lid) env =
   let open Option.Let_syntax in
   let loc = lid.loc in
   let full_get_name =
     match lid.txt with
     | Lident name ->
         fun scope ->
-          let%map ident, data = get_name name scope in
+          let%map ident, data = get_name ~mode name scope in
           (Path.Pident ident, data)
     | Ldot (path, name) ->
         fun scope ->
           let%bind path, m =
-            Scope.find_module_ ~loc ~scopes:env.scope_stack env.resolve_env
-              path scope
+            Scope.find_module_ ~mode ~loc ~scopes:env.scope_stack
+              env.resolve_env path scope
           in
-          let%map ident, data = get_name name m in
+          let%map ident, data = get_name ~mode name m in
           (Path.Pdot (path, Ident.name ident), data)
     | Lapply _ ->
         raise (Error (loc, Lident_unhandled (kind, lid.txt)))
@@ -637,10 +654,10 @@ let find_of_lident ~kind ~get_name (lid : lid) env =
     match lid.txt with
     | Ldot (path, name) ->
         let%bind path, m =
-          Scope.get_global_module ~loc ~scopes:env.scope_stack env.resolve_env
-            path
+          Scope.get_global_module ~mode ~loc ~scopes:env.scope_stack
+            env.resolve_env path
         in
-        let%map ident, data = get_name name m in
+        let%map ident, data = get_name ~mode name m in
         (Path.Pdot (path, Ident.name ident), data)
     | _ ->
         None )
@@ -649,8 +666,10 @@ let join_expr_scope env expr_scope =
   map_current_scope ~f:(Scope.join_expr_scope expr_scope) env
 
 let raw_find_type_declaration ~mode (lid : lid) env =
+  let modes = modes_of_mode mode in
   match
-    find_of_lident ~kind:"type" ~get_name:Scope.find_type_declaration lid env
+    find_of_lident ~mode ~kind:"type" ~get_name:Scope.find_type_declaration lid
+      env
   with
   | Some v ->
       v
@@ -659,7 +678,7 @@ let raw_find_type_declaration ~mode (lid : lid) env =
     | Lident name when env.resolve_env.predeclare_types ->
         let {type_env; _} = env.resolve_env in
         let ident, id, num_args =
-          match IdTbl.find_name name type_env.predeclared_types with
+          match IdTbl.find_name ~modes name type_env.predeclared_types with
           | Some (ident, (id, num_args, _loc)) ->
               (ident, id, num_args)
           | None ->
@@ -1288,16 +1307,18 @@ end
 
 let add_name name typ = map_current_scope ~f:(Scope.add_name name typ)
 
-let get_name (name : str) env =
+let get_name ~mode (name : str) env =
   let loc = name.loc in
-  match List.find_map ~f:(Scope.find_name name.txt) env.scope_stack with
+  match List.find_map ~f:(Scope.find_name ~mode name.txt) env.scope_stack with
   | Some (ident, typ) ->
       (ident, Type.copy typ Int.Map.empty env)
   | None ->
       raise (Error (loc, Unbound_value (Lident name.txt)))
 
-let find_name ~loc (lid : lid) env =
-  match find_of_lident ~kind:"name" ~get_name:Scope.find_name lid env with
+let find_name ~mode ~loc (lid : lid) env =
+  match
+    find_of_lident ~mode ~kind:"name" ~get_name:Scope.find_name lid env
+  with
   | Some (ident, typ) ->
       (ident, Type.copy ~loc typ Int.Map.empty env)
   | None ->

--- a/meja/src/ident.ml
+++ b/meja/src/ident.ml
@@ -56,7 +56,10 @@ module Table = struct
     | None ->
         None
 
-  let find_name name tbl = Option.bind ~f:List.hd (Map.find tbl name)
+  let find_name name ~modes tbl =
+    Option.bind
+      ~f:(List.find ~f:(fun (ident, _) -> modes (mode ident)))
+      (Map.find tbl name)
 
   let first_exn tbl = List.hd_exn (snd (Map.min_elt_exn tbl))
 

--- a/meja/src/ident.mli
+++ b/meja/src/ident.mli
@@ -50,9 +50,11 @@ module Table : sig
       [None] otherwise.
   *)
 
-  val find_name : string -> 'a t -> (ident * 'a) option
-  (** [find_name name tbl] returns the most recently bound [ident] and its
-      associated value if it exists, or [None] otherwise.
+  val find_name :
+    string -> modes:(Ast_types.mode -> bool) -> 'a t -> (ident * 'a) option
+  (** [find_name name ~modes tbl] returns the most recently bound [ident] and its
+      associated value if it exists, or [None] otherwise. Any [ident]
+      satisfying [modes (Ident.mode ident)] will be skipped.
   *)
 
   val first_exn : 'a t -> ident * 'a

--- a/meja/src/typechecker.ml
+++ b/meja/src/typechecker.ml
@@ -315,8 +315,9 @@ let add_polymorphised name typ env =
   Envi.add_name name typ env
 
 let get_field (field : lid) env =
+  let mode = Envi.current_mode env in
   let loc = field.loc in
-  match Envi.TypeDecl.find_of_field field env with
+  match Envi.TypeDecl.find_of_field ~mode field env with
   | Some
       ( ident
       , ( ({tdec_desc= TRecord field_decls; tdec_ident; tdec_params; _} as decl)
@@ -357,8 +358,9 @@ let get_field_of_decl typ bound_vars field_decls (field : lid) env =
       get_field field env
 
 let get_ctor (name : lid) env =
+  let mode = Envi.current_mode env in
   let loc = name.loc in
-  match (Envi.TypeDecl.find_of_constructor name env, name.txt) with
+  match (Envi.TypeDecl.find_of_constructor ~mode name env, name.txt) with
   | ( Some
         ( name
         , ( ( { tdec_desc= TVariant ctors
@@ -516,7 +518,7 @@ let rec check_pattern ~add env typ pat =
         | Some ({tdec_desc= TRecord field_decls; _}, bound_vars, env) ->
             (typ, field_decls, bound_vars, env)
         | _ -> (
-          match Envi.TypeDecl.find_of_field field env with
+          match Envi.TypeDecl.find_of_field ~mode field env with
           | Some
               ( ident
               , (({tdec_desc= TRecord field_decls; tdec_params; _} as decl), _)
@@ -589,6 +591,7 @@ and check_patterns ~add env typs pats =
   (List.rev rev_pats, env)
 
 let rec get_expression env expected exp =
+  let mode = Envi.current_mode env in
   let loc = exp.exp_loc in
   match exp.exp_desc with
   | Pexp_apply (f, es) ->
@@ -635,7 +638,7 @@ let rec get_expression env expected exp =
       check_type ~loc env expected typ ;
       ({exp_loc= loc; exp_type= typ; exp_desc= Texp_apply (f, es)}, env)
   | Pexp_variable name ->
-      let path, typ = Envi.find_name ~loc name env in
+      let path, typ = Envi.find_name ~mode ~loc name env in
       let path = Location.mkloc path name.loc in
       let implicits, result_typ = Envi.Type.get_implicits [] typ in
       check_type ~loc env expected result_typ ;
@@ -779,7 +782,7 @@ let rec get_expression env expected exp =
         | Lident _ ->
             None
         | Ldot _ -> (
-          match Envi.TypeDecl.find_of_field field env with
+          match Envi.TypeDecl.find_of_field ~mode field env with
           | Some
               ( fld_ident
               , (({tdec_desc= TRecord field_decls; tdec_params; _} as decl), i)
@@ -838,7 +841,7 @@ let rec get_expression env expected exp =
                 raise (Error (loc, Wrong_record_field (field.txt, e.exp_type)))
             )
           | _ -> (
-            match Envi.TypeDecl.find_of_field field env with
+            match Envi.TypeDecl.find_of_field ~mode field env with
             | Some
                 ( fld_ident
                 , ( ({tdec_desc= TRecord field_decls; tdec_params; _} as decl)
@@ -887,7 +890,7 @@ let rec get_expression env expected exp =
         | Some ({tdec_desc= TRecord field_decls; _}, bound_vars, env) ->
             (typ, field_decls, bound_vars, env)
         | _ -> (
-          match Envi.TypeDecl.find_of_field field env with
+          match Envi.TypeDecl.find_of_field ~mode field env with
           | Some
               ( ident
               , (({tdec_desc= TRecord field_decls; tdec_params; _} as decl), _)
@@ -1161,7 +1164,7 @@ let rec check_signature_item env item =
       let env = Envi.add_module_type name.txt m_env env in
       (env, {Typedast.sig_desc= Tsig_modtype (name, signature); sig_loc= loc})
   | Psig_open name ->
-      let path, m = Envi.find_module ~loc name env in
+      let path, m = Envi.find_module ~mode ~loc name env in
       let env = Envi.open_namespace_scope m env in
       ( env
       , { Typedast.sig_desc= Tsig_open (Location.mkloc path name.loc)
@@ -1203,7 +1206,7 @@ and check_module_sig env path msig =
       , env )
   | Pmty_name lid ->
       let path, m =
-        match Envi.find_module_deferred ~loc lid env with
+        match Envi.find_module_deferred ~mode ~loc lid env with
         | Some m ->
             m
         | None ->
@@ -1248,7 +1251,8 @@ and check_module_sig env path msig =
         | Envi.Scope.Immediate m ->
             (m, msig)
         | Envi.Scope.Deferred path ->
-            (snd (Envi.find_module ~loc (Location.mkloc path loc) env), msig)
+            ( snd (Envi.find_module ~mode ~loc (Location.mkloc path loc) env)
+            , msig )
       in
       (* Check that f_mty builds the functor as expected. *)
       let _, msig = ftor (Lapply (path, Lident f_name.txt)) f_mty in
@@ -1333,7 +1337,7 @@ let rec check_statement env stmt =
       ( env
       , {Typedast.stmt_loc= loc; stmt_desc= Tstmt_modtype (name, signature)} )
   | Pstmt_open name ->
-      let path, m = Envi.find_module ~loc name env in
+      let path, m = Envi.find_module ~mode ~loc name env in
       ( Envi.open_namespace_scope m env
       , { Typedast.stmt_loc= loc
         ; stmt_desc= Tstmt_open (Location.mkloc path name.loc) } )
@@ -1443,7 +1447,7 @@ and check_module_expr env m =
       let path = Envi.current_path env in
       (* Remove the module placed on the stack by the caller. *)
       let _, env = Envi.pop_module ~loc env in
-      let name', m' = Envi.find_module ~loc name env in
+      let name', m' = Envi.find_module ~mode ~loc name env in
       let name = Location.mkloc name' name.loc in
       let env = Envi.push_scope {m' with path} env in
       (env, {Typedast.mod_loc= loc; mod_desc= Tmod_name name})

--- a/meja/src/typet.ml
+++ b/meja/src/typet.ml
@@ -270,7 +270,7 @@ module TypeDecl = struct
     in
     let tdec_ident, tdec_id =
       match
-        IdTbl.find_name tdec_ident.txt
+        IdTbl.find_name ~modes:(modes_of_mode mode) tdec_ident.txt
           env.resolve_env.type_env.predeclared_types
       with
       | Some (ident, (id, num_args, loc)) ->


### PR DESCRIPTION
This PR
* integrates mode filtering with `Ident.Table.t`
* uses the mode filtering to fetch names according to which mode the current scope is for