### PR TITLE
Tweak the dummy verification key function

### DIFF
--- a/src/camlsnark_c/libsnark-caml/depends/libff/libff/algebra/fields/fp4.hpp
+++ b/src/camlsnark_c/libsnark-caml/depends/libff/libff/algebra/fields/fp4.hpp
@@ -67,6 +67,7 @@ public:
     Fp4_model cyclotomic_squared() const;
 
     std::vector<my_Fp> all_base_field_elements() { return { c0.c0, c0.c1, c1.c0, c1.c1 }; }
+    Fp4_model(const std::vector<my_Fp>& v) : c0(my_Fp2(v[0], v[1])), c1(my_Fp2(v[2], v[3])) {};
 
     static my_Fp2 mul_by_non_residue(const my_Fp2 &elt);
 

--- a/src/camlsnark_c/libsnark-caml/depends/libff/libff/algebra/fields/fp4.hpp
+++ b/src/camlsnark_c/libsnark-caml/depends/libff/libff/algebra/fields/fp4.hpp
@@ -43,6 +43,7 @@ public:
     my_Fp2 c0, c1;
     Fp4_model() {};
     Fp4_model(const my_Fp2& c0, const my_Fp2& c1) : c0(c0), c1(c1) {};
+    Fp4_model(const std::vector<my_Fp>& v) : c0(my_Fp2(v[0], v[1])), c1(my_Fp2(v[2], v[3])) {};
 
     void print() const { printf("c0/c1:\n"); c0.print(); c1.print(); }
     void clear() { c0.clear(); c1.clear(); }
@@ -67,7 +68,6 @@ public:
     Fp4_model cyclotomic_squared() const;
 
     std::vector<my_Fp> all_base_field_elements() { return { c0.c0, c0.c1, c1.c0, c1.c1 }; }
-    Fp4_model(const std::vector<my_Fp>& v) : c0(my_Fp2(v[0], v[1])), c1(my_Fp2(v[2], v[3])) {};
 
     static my_Fp2 mul_by_non_residue(const my_Fp2 &elt);
 

--- a/src/camlsnark_c/libsnark-caml/depends/libff/libff/algebra/fields/fp6_2over3.hpp
+++ b/src/camlsnark_c/libsnark-caml/depends/libff/libff/algebra/fields/fp6_2over3.hpp
@@ -46,6 +46,7 @@ public:
     my_Fp3 c0, c1;
     Fp6_2over3_model() {};
     Fp6_2over3_model(const my_Fp3& c0, const my_Fp3& c1) : c0(c0), c1(c1) {};
+    Fp6_2over3_model(const std::vector<my_Fp>& v) : c0(my_Fp3(v[0], v[1], v[2])), c1(my_Fp3(v[3], v[4], v[5])) {};
 
     void print() const { printf("c0/c1:\n"); c0.print(); c1.print(); }
     void clear() { c0.clear(); c1.clear(); }

--- a/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_curve.cpp.template
+++ b/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_curve.cpp.template
@@ -700,14 +700,6 @@ CURVE_PREFIX(verification_key_alpha_beta)(r1cs_gg_ppzksnark_verification_key<ppT
   return new libff::Fqk<ppT>(vk->alpha_g1_beta_g2);
 }
 
-r1cs_gg_ppzksnark_verification_key<ppT>* CURVE_PREFIX(verification_key_dummy)(int input_size) {
-  return new r1cs_gg_ppzksnark_verification_key<ppT>(
-    libff::Fqk<ppT>::one(),
-    libff::G2<ppT>::one(),
-    accumulation_vector<libff::G1<ppT>>(libff::G1<ppT>::one(), libff::G1_vector<ppT>(input_size, libff::G1<ppT>::one()))
-  );
-}
-
 r1cs_gg_ppzksnark_proving_key<ppT>* CURVE_PREFIX(keypair_pk)(r1cs_gg_ppzksnark_keypair<ppT>* keypair) {
   return new r1cs_gg_ppzksnark_proving_key<ppT>(keypair->pk);
 }
@@ -868,16 +860,6 @@ r1cs_se_ppzksnark_verification_key<ppT>* CURVE_PREFIX(gm_verification_key_of_str
   return vk;
 }
 
-r1cs_se_ppzksnark_verification_key<ppT>* CURVE_PREFIX(gm_verification_key_dummy)(int input_size) {
-  return new r1cs_se_ppzksnark_verification_key<ppT>(
-      libff::G2<ppT>::one(),
-      libff::G1<ppT>::one(),
-      libff::G2<ppT>::one(),
-      libff::G1<ppT>::one(),
-      libff::G2<ppT>::one(),
-      std::vector<libff::G1<ppT>>(input_size + 1, libff::G1<ppT>::one()));
-}
-
 r1cs_se_ppzksnark_proving_key<ppT>* CURVE_PREFIX(gm_keypair_pk)(r1cs_se_ppzksnark_keypair<ppT>* keypair) {
   return new r1cs_se_ppzksnark_proving_key<ppT>(keypair->pk);
 }
@@ -1008,14 +990,6 @@ CURVE_PREFIX(bg_verification_key_delta)(r1cs_bg_ppzksnark_verification_key<ppT>*
 libff::Fqk<ppT>*
 CURVE_PREFIX(bg_verification_key_alpha_beta)(r1cs_bg_ppzksnark_verification_key<ppT>* vk) {
   return new libff::Fqk<ppT>(vk->alpha_g1_beta_g2);
-}
-
-r1cs_bg_ppzksnark_verification_key<ppT>* CURVE_PREFIX(bg_verification_key_dummy)(int input_size) {
-  return new r1cs_bg_ppzksnark_verification_key<ppT>(
-    libff::Fqk<ppT>::one(),
-    libff::G2<ppT>::one(),
-    accumulation_vector<libff::G1<ppT>>(libff::G1<ppT>::one(), libff::G1_vector<ppT>(input_size, libff::G1<ppT>::one()))
-  );
 }
 
 r1cs_bg_ppzksnark_proving_key<ppT>* CURVE_PREFIX(bg_keypair_pk)(r1cs_bg_ppzksnark_keypair<ppT>* keypair) {

--- a/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_mnt.cpp.template
+++ b/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_mnt.cpp.template
@@ -78,4 +78,36 @@ libff::G2<ppT>* CURVE_PREFIX(g2_of_coords)(
   return new libff::G2<ppT>(*x, *y, libff::Fqe<ppT>::one());
 }
 
+r1cs_gg_ppzksnark_verification_key<ppT>* CURVE_PREFIX(verification_key_dummy)(int input_size) {
+  return new r1cs_gg_ppzksnark_verification_key<ppT>(
+    libff::Fqk<ppT>(
+      std::vector<libff::Fq<ppT>>(
+      libff::Fqk<ppT>::extension_degree(),
+      libff::Fq<ppT>::one())),
+    libff::G2<ppT>::one(),
+    accumulation_vector<libff::G1<ppT>>(libff::G1<ppT>::one(), libff::G1_vector<ppT>(input_size, libff::G1<ppT>::one()))
+  );
+}
+
+r1cs_se_ppzksnark_verification_key<ppT>* CURVE_PREFIX(gm_verification_key_dummy)(int input_size) {
+  return new r1cs_se_ppzksnark_verification_key<ppT>(
+      libff::G2<ppT>::one(),
+      libff::G1<ppT>::one(),
+      libff::G2<ppT>::one(),
+      libff::G1<ppT>::one(),
+      libff::G2<ppT>::one(),
+      std::vector<libff::G1<ppT>>(input_size + 1, libff::G1<ppT>::one()));
+}
+
+r1cs_bg_ppzksnark_verification_key<ppT>* CURVE_PREFIX(bg_verification_key_dummy)(int input_size) {
+  return new r1cs_bg_ppzksnark_verification_key<ppT>(
+    libff::Fqk<ppT>(
+      std::vector<libff::Fq<ppT>>(
+      libff::Fqk<ppT>::extension_degree(),
+      libff::Fq<ppT>::one())),
+    libff::G2<ppT>::one(),
+    accumulation_vector<libff::G1<ppT>>(libff::G1<ppT>::one(), libff::G1_vector<ppT>(input_size, libff::G1<ppT>::one()))
+  );
+}
+
 }

--- a/src/libsnark.ml
+++ b/src/libsnark.ml
@@ -1569,9 +1569,8 @@ module Make_proof_system_keys (M : Proof_system_inputs_intf) = struct
                 let prefix = with_prefix M.prefix "verification_key"
               end)
 
-    let dummy =
-      let stub = foreign (func_name "dummy") (int @-> returning typ) in
-      fun ~input_size -> stub input_size
+    let dummy ~input_size =
+      foreign (func_name "dummy") (int @-> returning typ) input_size
 
     let size_in_bits =
       foreign (func_name "size_in_bits") (typ @-> returning int)


### PR DESCRIPTION
This PR tweaks the dummy verification  key backend function to have any `Fqk` elements be "all ones" so to speak. The reason is the following:

When hashing a verification key, we want to compress it down to as much data as possible.
Say Fqk is F_{(p^e)^2} = F_{p^e}[X] / (..).

An element `a + b X` of Fqk is called unitary if `a^2 + b^2 = 1`. Fqk elements in the verification key are unitary, which means the `b` coordinate can be deduced from the `a` coordinate up to a sign. So, we can compress `a + b X` down to `a` plus a bit. The bit that we use (because extracting it is convenient in the circuit) is the parity of the "real part" of `b`. But this bit is only enough information to figure out the sign if `b` has non-zero real-part. So, the real part of `b` should be nonzero and we have an assertion enforcing this.

A simple way of accomplishing this is making everything all ones, which is what I did here.