### PR TITLE
Add padding functions to bitstring lib

### DIFF
--- a/bitstring_lib/bitstring.ml
+++ b/bitstring_lib/bitstring.ml
@@ -10,24 +10,32 @@ module type S = sig
   val init : int -> f:(int -> 'a) -> 'a t
 
   val map : 'a t -> f:('a -> 'b) -> 'b t
+
+  val pad : padding_length:int -> zero:'a -> 'a t -> 'a t
 end
 
 module T = struct
   include List
 
-  let of_list bs = bs
+  let of_list = Fn.id
 end
 
 module Msb_first = struct
   include T
 
   let of_lsb_first = List.rev
+
+  let pad ~padding_length ~zero xs =
+    List.init padding_length ~f:(fun _ -> zero) @ xs
 end
 
 module Lsb_first = struct
   include T
 
   let of_msb_first = List.rev
+
+  let pad ~padding_length ~zero xs =
+    xs @ List.init padding_length ~f:(fun _ -> zero)
 end
 
 let pad_to_triple_list ~default xs =

--- a/bitstring_lib/bitstring.mli
+++ b/bitstring_lib/bitstring.mli
@@ -11,6 +11,8 @@ module type S = sig
   val init : int -> f:(int -> 'a) -> 'a t
 
   val map : 'a t -> f:('a -> 'b) -> 'b t
+
+  val pad : padding_length:int -> zero:'a -> 'a t -> 'a t
 end
 
 module rec Msb_first : sig


### PR DESCRIPTION
Adds a simple function for padding a bitstring with zeroes. If it's LSB first we pad at the end and if it's MSB first we pad at the beginning.