### PR TITLE
[Meja] Seperate Mty_alias and Mty_ident

### DIFF
--- a/meja/ocaml/of_ocaml/of_ocaml_4.07.1.ml
+++ b/meja/ocaml/of_ocaml/of_ocaml_4.07.1.ml
@@ -136,8 +136,10 @@ and to_module_sig_desc ~loc decl =
   match decl with
   | None ->
       Pmty_abstract
-  | Some (Mty_ident path | Mty_alias (_, path)) ->
+  | Some (Mty_ident path) ->
       Pmty_name (mkloc (longident_of_path path) loc)
+  | Some (Mty_alias (_, path)) ->
+      Pmty_alias (mkloc (longident_of_path path) loc)
   | Some (Mty_signature signature) ->
       Pmty_sig (to_signature signature)
   | Some (Mty_functor (name, f, mty)) ->

--- a/meja/ocaml/of_ocaml/of_ocaml_4.08.0.ml
+++ b/meja/ocaml/of_ocaml/of_ocaml_4.08.0.ml
@@ -137,8 +137,10 @@ and to_module_sig_desc ~loc decl =
   match decl with
   | None ->
       Pmty_abstract
-  | Some (Mty_ident path | Mty_alias path) ->
+  | Some (Mty_ident path) ->
       Pmty_name (mkloc (longident_of_path path) loc)
+  | Some (Mty_alias (_, path)) ->
+      Pmty_alias (mkloc (longident_of_path path) loc)
   | Some (Mty_signature signature) ->
       Pmty_sig (to_signature signature)
   | Some (Mty_functor (name, f, mty)) ->

--- a/meja/ocaml/to_ocaml.ml
+++ b/meja/ocaml/to_ocaml.ml
@@ -215,6 +215,8 @@ and of_module_sig_desc ?loc = function
   | Pmty_sig signature ->
       Some (Mty.signature ?loc (of_signature signature))
   | Pmty_name name ->
+      Some (Mty.ident ?loc name)
+  | Pmty_alias name ->
       Some (Mty.alias ?loc name)
   | Pmty_abstract ->
       None

--- a/meja/src/parsetypes.ml
+++ b/meja/src/parsetypes.ml
@@ -102,6 +102,7 @@ and module_sig = {msig_desc: module_sig_desc; msig_loc: Location.t}
 and module_sig_desc =
   | Pmty_sig of signature
   | Pmty_name of lid
+  | Pmty_alias of lid
   | Pmty_abstract
   | Pmty_functor of str * module_sig * module_sig
 

--- a/meja/src/parsetypes_iter.ml
+++ b/meja/src/parsetypes_iter.ml
@@ -208,6 +208,8 @@ let module_sig_desc iter = function
       iter.signature iter sigs
   | Pmty_name name ->
       lid iter name
+  | Pmty_alias name ->
+      lid iter name
   | Pmty_abstract ->
       ()
   | Pmty_functor (name, fsig, msig) ->

--- a/meja/src/parsetypes_map.ml
+++ b/meja/src/parsetypes_map.ml
@@ -234,6 +234,8 @@ let module_sig_desc mapper = function
       Pmty_sig (mapper.signature mapper sigs)
   | Pmty_name name ->
       Pmty_name (lid mapper name)
+  | Pmty_alias name ->
+      Pmty_alias (lid mapper name)
   | Pmty_abstract ->
       Pmty_abstract
   | Pmty_functor (name, fsig, msig) ->

--- a/meja/src/pprint.ml
+++ b/meja/src/pprint.ml
@@ -304,6 +304,8 @@ and module_sig_desc ~prefix fmt = function
       fprintf fmt "{@[<hv1>@;%a@]}" signature msig
   | Pmty_name name ->
       prefix fmt ; Longident.pp fmt name.txt
+  | Pmty_alias name ->
+      fprintf fmt "=@ " ; Longident.pp fmt name.txt
   | Pmty_abstract ->
       ()
   | Pmty_functor (name, f, m) ->

--- a/meja/src/typechecker.ml
+++ b/meja/src/typechecker.ml
@@ -1229,18 +1229,25 @@ and check_module_sig env path msig =
       , env )
   | Pmty_name lid ->
       let path, m =
-        match Envi.find_module_deferred ~mode ~loc lid env with
+        match Envi.find_module_type ~mode lid env with
         | Some m ->
             m
         | None ->
-            (* TODO: This is a hack. We should set up the environment for
-               interface files before typechecking them, so that all of the
-               names are available and we can find those that aren't.
-            *)
-            ( Path.Pident (Ident.create ~mode:Checked "NOT_FOUND")
-            , Envi.Scope.Deferred lid.txt )
+            raise (Envi.Error (loc, Unbound ("module type", lid.txt)))
       in
       ( { Typedast.msig_desc= Tmty_name (Location.mkloc path lid.loc)
+        ; msig_loc= loc }
+      , m
+      , env )
+  | Pmty_alias lid ->
+      let path, m =
+        match Envi.find_module_deferred ~loc ~mode lid env with
+        | Some m ->
+            m
+        | None ->
+            raise (Envi.Error (loc, Unbound ("module", lid.txt)))
+      in
+      ( { Typedast.msig_desc= Tmty_alias (Location.mkloc path lid.loc)
         ; msig_loc= loc }
       , m
       , env )

--- a/meja/src/typedast.ml
+++ b/meja/src/typedast.ml
@@ -109,6 +109,7 @@ and module_sig = {msig_desc: module_sig_desc; msig_loc: Location.t}
 and module_sig_desc =
   | Tmty_sig of signature
   | Tmty_name of path
+  | Tmty_alias of path
   | Tmty_abstract
   | Tmty_functor of str * module_sig * module_sig
 

--- a/meja/src/typedast_iter.ml
+++ b/meja/src/typedast_iter.ml
@@ -244,6 +244,8 @@ let module_sig_desc iter = function
       iter.signature iter sigs
   | Tmty_name name ->
       path iter name
+  | Tmty_alias name ->
+      path iter name
   | Tmty_abstract ->
       ()
   | Tmty_functor (name, fsig, msig) ->

--- a/meja/src/typedast_map.ml
+++ b/meja/src/typedast_map.ml
@@ -277,6 +277,8 @@ let module_sig_desc mapper = function
       Tmty_sig (mapper.signature mapper sigs)
   | Tmty_name name ->
       Tmty_name (path mapper name)
+  | Tmty_alias name ->
+      Tmty_alias (path mapper name)
   | Tmty_abstract ->
       Tmty_abstract
   | Tmty_functor (name, fsig, msig) ->

--- a/meja/src/untype_ast.ml
+++ b/meja/src/untype_ast.ml
@@ -254,6 +254,8 @@ and module_sig_desc = function
       Parsetypes.Pmty_sig (List.map ~f:signature_item sigs)
   | Tmty_name path ->
       Pmty_name (map_loc ~f:longident_of_path path)
+  | Tmty_alias path ->
+      Pmty_alias (map_loc ~f:longident_of_path path)
   | Tmty_abstract ->
       Pmty_abstract
   | Tmty_functor (name, fsig, msig) ->


### PR DESCRIPTION
This fixes some weird errors that were showing up when loading some `.cmi` files, and removes a hack that was added to try and catch some of them.