### PR TITLE
[Meja] Implement backtracking

### DIFF
--- a/meja/src/type1.ml
+++ b/meja/src/type1.ml
@@ -92,9 +92,7 @@ end
 
 let backtrack snap =
   let changes = Snapshot.backtrack snap in
-  List.iter changes ~f:(function
-    | Depth (typ, depth) ->
-        typ.type_depth <- depth)
+  List.iter changes ~f:(function Depth (typ, depth) -> typ.type_depth <- depth )
 
 let rec typ_debug_print fmt typ =
   let open Format in

--- a/meja/src/type1.ml
+++ b/meja/src/type1.ml
@@ -11,6 +11,91 @@ let mk depth type_desc =
 let mkvar ?(explicitness = Explicit) depth name =
   mk depth (Tvar (name, explicitness))
 
+type change = Depth of (type_expr * int)
+
+(** Implements a weak, mutable linked-list containing the history of changes.
+
+    Every change is added to the same list, and the snapshots correspond to
+    cuts of this list.
+    We gain several advantages from using a weak, mutable linked-list:
+    * if there are no active snapshots, the whole list will be GC'd and any
+      changes don't need to be stored at all
+    * if there are active snapshots, OCaml will GC the history of changes up to
+      the first active snapshot
+    * all simultaneously active snapshots point to a part of the same physical
+      list
+    * the snapshots can be erased during backtracking, so that different
+      snapshots can't be used out of order to 'restore' a state that didn't
+      exist previously
+*)
+module Snapshot : sig
+  type t
+
+  val create : unit -> t
+  (** Get a new snapshot. *)
+
+  val add_to_history : change -> unit
+  (** Add a change to the history of all active snapshots. *)
+
+  val backtrack : t -> change list
+  (** Erase the history back to the snapshot, and return the list of changes
+      that occurred since, ordered from newest to oldest.
+  *)
+end = struct
+  type node = Some of (change * t) | None
+
+  and t = node ref
+
+  (* Points to the end of the current history list.
+
+     If multiple snapshots are captured before the next change, they will all
+     point to the value held here.
+
+     If there are no snapshots active, OCaml is free to GC the value held here.
+  *)
+  let current = Weak.create 1
+
+  (* Update the value held by [current] to represent the given change, and set
+     current to be a new empty value.
+  *)
+  let add_to_history change =
+    match Weak.get current 0 with
+    | Some ptr ->
+        let new_ptr = ref None in
+        ptr := Some (change, new_ptr) ;
+        Weak.set current 0 (Some new_ptr)
+    | None ->
+        (* No snapshots active, no list to add to. *)
+        ()
+
+  let create () =
+    match Weak.get current 0 with
+    | Some ptr ->
+        ptr
+    | None ->
+        let new_ptr = ref None in
+        Weak.set current 0 (Some new_ptr) ;
+        new_ptr
+
+  let backtrack snap =
+    let rec backtrack changes ptr =
+      match !ptr with
+      | Some (change, ptr) ->
+          (* Clear this snapshot so that it can't be re-used. *)
+          snap := None ;
+          backtrack (change :: changes) ptr
+      | None ->
+          changes
+    in
+    backtrack [] snap
+end
+
+let backtrack snap =
+  let changes = Snapshot.backtrack snap in
+  List.iter changes ~f:(function
+    | Depth (typ, depth) ->
+        typ.type_depth <- depth)
+
 let rec typ_debug_print fmt typ =
   let open Format in
   let print i = fprintf fmt i in
@@ -104,8 +189,9 @@ let rec equal_at_depth ~depth typ1 typ2 =
     | _, _ ->
         false
 
-(* TODO: integrate with a backtrack mechanism for unification errors. *)
-let set_depth depth typ = typ.type_depth <- depth
+let set_depth depth typ =
+  Snapshot.add_to_history (Depth (typ, typ.type_depth)) ;
+  typ.type_depth <- depth
 
 let update_depth depth typ = if typ.type_depth > depth then set_depth depth typ
 

--- a/meja/src/typechecker.ml
+++ b/meja/src/typechecker.ml
@@ -168,109 +168,17 @@ let check_type ~loc env typ constr_typ =
   | () ->
       ()
 
-(** [is_subtype ~loc env typ ~of_:ctyp] returns whether [typ] is a subtype of
-    [ctyp], instantiating any variables in [ctyp] to those they match with in
-    [typ].
-
-    If this function returns [false], the [ctyp] value *must not* be used,
-    since its variables may have been instantiated incorrectly. A type
-    containing only fresh variables should be used.
-
-    The type variables within [typ] will remain unchanged.
-    *)
-let rec is_subtype ~loc env typ ~of_:ctyp =
-  let is_subtype = is_subtype ~loc env in
-  let without_instance ~f (typ : type_expr) =
-    match Envi.Type.instance env typ with
-    | Some typ' ->
-        Some (f typ')
-    | None ->
-        None
-  in
-  if Int.equal typ.type_id ctyp.type_id then true
-  else if Type1.contains typ ~in_:ctyp || Type1.contains ctyp ~in_:typ then
-    (* Unifying the type will create a recursive type, which isn't ever what we
-       want. Bail out here.
-    *)
-    false
-  else
-    match (typ.type_desc, ctyp.type_desc) with
-    | Tpoly (_, typ), _ ->
-        is_subtype typ ~of_:ctyp
-    | _, Tpoly (_, ctyp) ->
-        is_subtype typ ~of_:ctyp
-    | Tvar _, Tvar _ ->
-        bind_none
-          (without_instance typ ~f:(fun typ -> is_subtype typ ~of_:ctyp))
-          (fun () ->
-            bind_none
-              (without_instance ctyp ~f:(fun ctyp -> is_subtype typ ~of_:ctyp))
-              (fun () ->
-                Envi.Type.add_instance ctyp typ env ;
-                true ) )
-    | Tvar _, _ ->
-        (* [typ] is more general than [ctyp] *)
-        bind_none
-          (without_instance typ ~f:(fun typ -> is_subtype typ ~of_:ctyp))
-          (fun () -> false)
-    | _, Tvar _ ->
-        (* [ctyp] is more general than [typ] *)
-        bind_none
-          (without_instance ctyp ~f:(fun ctyp -> is_subtype typ ~of_:ctyp))
-          (fun () ->
-            Envi.Type.add_instance ctyp typ env ;
-            true )
-    | Ttuple typs, Ttuple ctyps -> (
-      match
-        List.for_all2 typs ctyps ~f:(fun typ ctyp -> is_subtype typ ~of_:ctyp)
-      with
-      | Ok x ->
-          x
-      | Unequal_lengths ->
-          false )
-    | ( Tarrow (typ1, typ2, Explicit, label1)
-      , Tarrow (ctyp1, ctyp2, Explicit, label2) )
-    | ( Tarrow (typ1, typ2, Implicit, label1)
-      , Tarrow (ctyp1, ctyp2, Implicit, label2) ) ->
-        ( match (label1, label2) with
-        | Nolabel, Nolabel ->
-            true
-        | Labelled x, Labelled y when String.equal x y ->
-            true
-        | Optional x, Optional y when String.equal x y ->
-            true
-        | _ ->
-            false )
-        && is_subtype typ1 ~of_:ctyp1 && is_subtype typ2 ~of_:ctyp2
-    | Tctor variant, Tctor constr_variant -> (
-      (* Always try to unfold first, so that type aliases with phantom
-         parameters can unify, as in OCaml.
-      *)
-      match unpack_decls ~loc typ ctyp env with
-      | Some (typ, ctyp) ->
-          is_subtype typ ~of_:ctyp
-      | None ->
-          if Int.equal variant.var_decl.tdec_id constr_variant.var_decl.tdec_id
-          then
-            match
-              List.for_all2 variant.var_params constr_variant.var_params
-                ~f:(fun param constr_param ->
-                  is_subtype param ~of_:constr_param )
-            with
-            | Ok x ->
-                x
-            | Unequal_lengths ->
-                false
-          else false )
-    | Tctor _, _ | _, Tctor _ -> (
-      (* Unfold an alias and compare again *)
-      match unpack_decls ~loc typ ctyp env with
-      | Some (typ, ctyp) ->
-          is_subtype typ ~of_:ctyp
-      | None ->
-          false )
-    | _, _ ->
-        false
+let unifies env typ constr_typ =
+  let snapshot = Snapshot.create () in
+  let {Envi.TypeEnvi.variable_instances; _} = env.Envi.resolve_env.type_env in
+  match check_type ~loc:Location.none env typ constr_typ with
+  | () ->
+      true
+  | exception Error _ ->
+      env.resolve_env.type_env
+      <- {env.resolve_env.type_env with variable_instances} ;
+      backtrack snapshot ;
+      false
 
 let rec add_implicits ~loc implicits typ env =
   match implicits with
@@ -1012,9 +920,7 @@ and check_binding ?(toplevel = false) (env : Envi.t) p e : 's =
   let e = {e with exp_type} in
   let typ_vars = free_type_vars ~depth:env.Envi.depth exp_type in
   let implicit_vars =
-    Envi.Type.flattened_implicit_vars ~loc ~toplevel
-      ~is_subtype:(is_subtype ~loc:e.exp_loc)
-      typ_vars env
+    Envi.Type.flattened_implicit_vars ~loc ~toplevel ~unifies typ_vars env
   in
   match implicit_vars with
   | [] ->


### PR DESCRIPTION
This PR
* implements backtracking
* uses backtracking to implement `unifies`
* uses the new `unifies` function (and an extra check) to implement implicit instance searches
  - this also lets us remove `is_subtype`