### PR TITLE
[Meja] Remove Tvar explicitness parameter

### DIFF
--- a/meja/ocaml/of_ocaml/of_ocaml_4.07.1.ml
+++ b/meja/ocaml/of_ocaml/of_ocaml_4.07.1.ml
@@ -27,7 +27,7 @@ let rec to_type_desc ~loc desc =
   let to_type_expr = to_type_expr ~loc in
   match desc with
   | Tvar x | Tunivar x ->
-      Ptyp_var (Option.map ~f:(fun x -> mkloc x loc) x, Explicit)
+      Ptyp_var (Option.map ~f:(fun x -> mkloc x loc) x)
   | Tarrow (label, typ1, typ2, _) ->
       Ptyp_arrow (to_type_expr typ1, to_type_expr typ2, Explicit, label)
   | Ttuple typs ->
@@ -54,7 +54,7 @@ let rec to_type_desc ~loc desc =
   | Tobject _ | Tfield _ | Tnil | Tvariant _ ->
       (* This type isn't supported here. For now, just replace it with a
          variable, so we can still manipulate values including it. *)
-      Ptyp_var (None, Explicit)
+      Ptyp_var None
 
 and to_type_expr ~loc typ =
   {type_desc= to_type_desc ~loc typ.desc; type_loc= loc}

--- a/meja/ocaml/of_ocaml/of_ocaml_4.08.0.ml
+++ b/meja/ocaml/of_ocaml/of_ocaml_4.08.0.ml
@@ -27,7 +27,7 @@ let rec to_type_desc ~loc desc =
   let to_type_expr = to_type_expr ~loc in
   match desc with
   | Tvar x | Tunivar x ->
-      Ptyp_var (Option.map ~f:(fun x -> mkloc x loc) x, Explicit)
+      Ptyp_var (Option.map ~f:(fun x -> mkloc x loc) x)
   | Tarrow (label, typ1, typ2, _) ->
       Ptyp_arrow (to_type_expr typ1, to_type_expr typ2, Explicit, label)
   | Ttuple typs ->
@@ -54,7 +54,7 @@ let rec to_type_desc ~loc desc =
   | Tobject _ | Tfield _ | Tnil | Tvariant _ ->
       (* This type isn't supported here. For now, just replace it with a
          variable, so we can still manipulate values including it. *)
-      Ptyp_var (None, Explicit)
+      Ptyp_var None
 
 and to_type_expr ~loc typ =
   {type_desc= to_type_desc ~loc typ.desc; type_loc= loc}

--- a/meja/ocaml/to_ocaml.ml
+++ b/meja/ocaml/to_ocaml.ml
@@ -6,9 +6,9 @@ open Meja_lib.Parsetypes
 
 let rec of_type_desc ?loc typ =
   match typ with
-  | Ptyp_var (None, _) ->
+  | Ptyp_var None ->
       Typ.any ?loc ()
-  | Ptyp_var (Some name, _) ->
+  | Ptyp_var (Some name) ->
       Typ.var ?loc name.txt
   | Ptyp_poly (_, typ) ->
       of_type_expr typ

--- a/meja/src/ast_build.ml
+++ b/meja/src/ast_build.ml
@@ -49,10 +49,9 @@ module Type = struct
     ; var_params= params
     ; var_implicit_params= implicits }
 
-  let none ?loc ?(explicit = Explicit) () = mk ?loc (Ptyp_var (None, explicit))
+  let none ?loc () = mk ?loc (Ptyp_var None)
 
-  let var ?loc ?(explicit = Explicit) name =
-    mk ?loc (Ptyp_var (Some (Loc.mk ?loc name), explicit))
+  let var ?loc name = mk ?loc (Ptyp_var (Some (Loc.mk ?loc name)))
 
   let constr ?loc ?params ?implicits ident =
     mk ?loc (Ptyp_ctor (variant ?loc ?params ?implicits ident))

--- a/meja/src/codegen.ml
+++ b/meja/src/codegen.ml
@@ -171,7 +171,7 @@ let typ_of_decl ~loc (decl : type_decl) =
                 fresh_names
                   (List.map decl.tdec_params ~f:(fun param ->
                        match param.type_desc with
-                       | Ptyp_var (Some name, _) ->
+                       | Ptyp_var (Some name) ->
                            name.txt
                        | _ ->
                            "a" ))

--- a/meja/src/envi.ml
+++ b/meja/src/envi.ml
@@ -727,7 +727,7 @@ module Type = struct
 
   let mk type_desc env = Type1.mk env.depth type_desc
 
-  let mkvar ?explicitness name env = Type1.mkvar ?explicitness env.depth name
+  let mkvar name env = Type1.mkvar env.depth name
 
   let instance env typ = TypeEnvi.instance env.resolve_env.type_env typ
 
@@ -737,18 +737,18 @@ module Type = struct
 
   let refresh_var ~loc ?must_find env typ =
     match typ.type_desc with
-    | Tvar (None, explicitness) -> (
-      match (must_find, explicitness) with
-      | Some true, Explicit ->
+    | Tvar None -> (
+      match must_find with
+      | Some true ->
           raise (Error (loc, Unbound_type_var typ))
       | _ ->
-          (env, mkvar ~explicitness None env) )
-    | Tvar ((Some x as name), explicitness) -> (
+          (env, mkvar None env) )
+    | Tvar (Some x as name) -> (
         let var =
           match must_find with
           | Some true ->
               let var = find_type_variable x env in
-              if (not (Option.is_some var)) && explicitness = Explicit then
+              if Option.is_none var then
                 raise (Error (loc, Unbound_type_var typ)) ;
               var
           | Some false ->
@@ -760,7 +760,7 @@ module Type = struct
         | Some var ->
             (env, var)
         | None ->
-            let var = mkvar ~explicitness name env in
+            let var = mkvar name env in
             (add_type_variable x var env, var) )
     | _ ->
         raise (Error (loc, Expected_type_var typ))

--- a/meja/src/parser_impl.mly
+++ b/meja/src/parser_impl.mly
@@ -568,9 +568,9 @@ pat_or_bare_tuple:
 
 simple_type_expr:
   | UNDERSCORE
-    { mktyp ~pos:$loc (Ptyp_var (None, Explicit)) }
+    { mktyp ~pos:$loc (Ptyp_var None) }
   | QUOT x = as_loc(lident)
-    { mktyp ~pos:$loc (Ptyp_var (Some x, Explicit)) }
+    { mktyp ~pos:$loc (Ptyp_var (Some x)) }
   | t = decl_type_expr
     { t }
   | LPAREN x = type_expr RPAREN

--- a/meja/src/parsetypes.ml
+++ b/meja/src/parsetypes.ml
@@ -4,7 +4,7 @@ type type_expr = {type_desc: type_desc; type_loc: Location.t}
 
 and type_desc =
   (* A type variable. Name is None when not yet chosen. *)
-  | Ptyp_var of str option * explicitness
+  | Ptyp_var of str option
   | Ptyp_tuple of type_expr list
   | Ptyp_arrow of type_expr * type_expr * explicitness * Asttypes.arg_label
   (* A type name. *)

--- a/meja/src/parsetypes_iter.ml
+++ b/meja/src/parsetypes_iter.ml
@@ -40,7 +40,7 @@ let type_expr iter {type_desc; type_loc} =
   iter.type_desc iter type_desc
 
 let type_desc iter = function
-  | Ptyp_var (name, _) ->
+  | Ptyp_var name ->
       Option.iter ~f:(str iter) name
   | Ptyp_tuple typs ->
       List.iter ~f:(iter.type_expr iter) typs

--- a/meja/src/parsetypes_map.ml
+++ b/meja/src/parsetypes_map.ml
@@ -47,8 +47,8 @@ let type_expr mapper {type_desc; type_loc} =
 
 let type_desc mapper typ =
   match typ with
-  | Ptyp_var (name, explicit) ->
-      Ptyp_var (Option.map ~f:(str mapper) name, explicit)
+  | Ptyp_var name ->
+      Ptyp_var (Option.map ~f:(str mapper) name)
   | Ptyp_tuple typs ->
       Ptyp_tuple (List.map ~f:(mapper.type_expr mapper) typs)
   | Ptyp_arrow (typ1, typ2, explicit, label) ->

--- a/meja/src/pprint.ml
+++ b/meja/src/pprint.ml
@@ -4,9 +4,9 @@ open Format
 open Ast_print
 
 let rec type_desc ?(bracket = false) fmt = function
-  | Ptyp_var (None, _) ->
+  | Ptyp_var None ->
       fprintf fmt "_"
-  | Ptyp_var (Some name, _) ->
+  | Ptyp_var (Some name) ->
       fprintf fmt "'%s" name.txt
   | Ptyp_tuple typs ->
       fprintf fmt "@[<1>%a@]" tuple typs

--- a/meja/src/type0.ml
+++ b/meja/src/type0.ml
@@ -7,7 +7,7 @@ type type_expr =
 
 and type_desc =
   (* A type variable. Name is None when not yet chosen. *)
-  | Tvar of string option * explicitness
+  | Tvar of string option
   | Ttuple of type_expr list
   | Tarrow of type_expr * type_expr * explicitness * Ast_types.arg_label
   (* A type name. *)

--- a/meja/src/type1.ml
+++ b/meja/src/type1.ml
@@ -162,8 +162,6 @@ let bubble_label label typ =
   | None, typ ->
       typ
 
-let implicit_params _typ = Typeset.empty
-
 let rec constr_map ~f typ =
   let {type_depth; _} = typ in
   match typ.type_desc with

--- a/meja/src/type1.ml
+++ b/meja/src/type1.ml
@@ -8,8 +8,7 @@ let mk depth type_desc =
   incr type_id ;
   {type_desc; type_id= !type_id; type_depth= depth}
 
-let mkvar ?(explicitness = Explicit) depth name =
-  mk depth (Tvar (name, explicitness))
+let mkvar depth name = mk depth (Tvar name)
 
 let rec typ_debug_print fmt typ =
   let open Format in
@@ -26,14 +25,10 @@ let rec typ_debug_print fmt typ =
   in
   print "(%i:" typ.type_id ;
   ( match typ.type_desc with
-  | Tvar (None, Explicit) ->
+  | Tvar None ->
       print "var _"
-  | Tvar (Some name, Explicit) ->
+  | Tvar (Some name) ->
       print "var %s@" name
-  | Tvar (None, Implicit) ->
-      print "implicit_var _"
-  | Tvar (Some name, Implicit) ->
-      print "implicit_var %s" name
   | Tpoly (typs, typ) ->
       print "poly [%a] %a"
         (print_list typ_debug_print)
@@ -167,17 +162,7 @@ let bubble_label label typ =
   | None, typ ->
       typ
 
-let implicit_params typ =
-  let rec implicit_params set typ =
-    match typ.type_desc with
-    | Tvar (_, Implicit) ->
-        Set.add set typ
-    | Tpoly (_, typ) ->
-        implicit_params set typ
-    | _ ->
-        fold ~init:set typ ~f:implicit_params
-  in
-  implicit_params Typeset.empty typ
+let implicit_params _typ = Typeset.empty
 
 let rec constr_map ~f typ =
   let {type_depth; _} = typ in

--- a/meja/src/typedast.ml
+++ b/meja/src/typedast.ml
@@ -9,7 +9,7 @@ type type_expr =
 
 and type_desc =
   (* A type variable. Name is None when not yet chosen. *)
-  | Ttyp_var of str option * explicitness
+  | Ttyp_var of str option
   | Ttyp_tuple of type_expr list
   | Ttyp_arrow of type_expr * type_expr * explicitness * Asttypes.arg_label
   (* A type name. *)

--- a/meja/src/typedast_iter.ml
+++ b/meja/src/typedast_iter.ml
@@ -53,7 +53,7 @@ let type_expr iter {type_desc; type_loc; type_type} =
   iter.type_desc iter type_desc
 
 let type_desc iter = function
-  | Ttyp_var (name, _) ->
+  | Ttyp_var name ->
       Option.iter ~f:(str iter) name
   | Ttyp_tuple typs ->
       List.iter ~f:(iter.type_expr iter) typs
@@ -75,7 +75,7 @@ let ptype_expr iter Parsetypes.{type_desc; type_loc} =
   iter.ptype_desc iter type_desc
 
 let ptype_desc iter = function
-  | Parsetypes.Ptyp_var (name, _) ->
+  | Parsetypes.Ptyp_var name ->
       Option.iter ~f:(fun name -> iter.location iter name.Location.loc) name
   | Ptyp_tuple typs ->
       List.iter ~f:(iter.ptype_expr iter) typs

--- a/meja/src/typedast_map.ml
+++ b/meja/src/typedast_map.ml
@@ -56,8 +56,8 @@ let type_expr mapper {type_desc; type_loc; type_type} =
 
 let type_desc mapper typ =
   match typ with
-  | Ttyp_var (name, explicit) ->
-      Ttyp_var (Option.map ~f:(str mapper) name, explicit)
+  | Ttyp_var name ->
+      Ttyp_var (Option.map ~f:(str mapper) name)
   | Ttyp_tuple typs ->
       Ttyp_tuple (List.map ~f:(mapper.type_expr mapper) typs)
   | Ttyp_arrow (typ1, typ2, explicit, label) ->
@@ -86,8 +86,8 @@ let ptype_expr mapper Parsetypes.{type_desc; type_loc} =
 
 let ptype_desc mapper typ =
   match typ with
-  | Parsetypes.Ptyp_var (name, explicit) ->
-      Parsetypes.Ptyp_var (Option.map ~f:(str mapper) name, explicit)
+  | Parsetypes.Ptyp_var name ->
+      Parsetypes.Ptyp_var (Option.map ~f:(str mapper) name)
   | Ptyp_tuple typs ->
       Ptyp_tuple (List.map ~f:(mapper.ptype_expr mapper) typs)
   | Ptyp_arrow (typ1, typ2, explicit, label) ->

--- a/meja/src/typeprint.ml
+++ b/meja/src/typeprint.ml
@@ -4,9 +4,9 @@ open Format
 open Ast_print
 
 let rec type_desc ?(bracket = false) fmt = function
-  | Tvar (None, _) ->
+  | Tvar None ->
       fprintf fmt "_"
-  | Tvar (Some name, _) ->
+  | Tvar (Some name) ->
       fprintf fmt "'%s" name
   | Ttuple typs ->
       fprintf fmt "@[<1>%a@]" tuple typs

--- a/meja/src/typet.ml
+++ b/meja/src/typet.ml
@@ -24,21 +24,19 @@ module Type = struct
     let import = import ?must_find in
     let loc = typ.type_loc in
     match typ.type_desc with
-    | Ptyp_var (None, explicitness) -> (
-      match (must_find, explicitness) with
-      | Some true, Explicit ->
+    | Ptyp_var None -> (
+      match must_find with
+      | Some true ->
           raise (Error (loc, Unbound_type_var typ))
       | _ ->
-          ( { type_desc= Ttyp_var (None, explicitness)
-            ; type_loc= loc
-            ; type_type= mkvar ~explicitness None env }
+          ( {type_desc= Ttyp_var None; type_loc= loc; type_type= mkvar None env}
           , env ) )
-    | Ptyp_var ((Some {txt= x; _} as name), explicitness) ->
+    | Ptyp_var (Some {txt= x; _} as name) ->
         let var =
           match must_find with
           | Some true ->
               let var = find_type_variable x env in
-              if (not (Option.is_some var)) && explicitness = Explicit then
+              if Option.is_none var then
                 raise (Error (loc, Unbound_type_var typ)) ;
               var
           | Some false ->
@@ -51,11 +49,10 @@ module Type = struct
           | Some var ->
               (var, env)
           | None ->
-              let var = mkvar ~explicitness (Some x) env in
+              let var = mkvar (Some x) env in
               (var, add_type_variable x var env)
         in
-        ( {type_desc= Ttyp_var (name, explicitness); type_loc= loc; type_type}
-        , env )
+        ({type_desc= Ttyp_var name; type_loc= loc; type_type}, env)
     | Ptyp_poly (vars, typ) ->
         let env = open_expr_scope env in
         let env, vars =

--- a/meja/src/untype_ast.ml
+++ b/meja/src/untype_ast.ml
@@ -14,10 +14,10 @@ module Type0 = struct
   open Type0
 
   let rec type_desc ?loc = function
-    | Tvar (None, explicit) ->
-        Type.none ?loc ~explicit ()
-    | Tvar (Some name, explicit) ->
-        Type.var ?loc ~explicit name
+    | Tvar None ->
+        Type.none ?loc ()
+    | Tvar (Some name) ->
+        Type.var ?loc name
     | Ttuple typs ->
         Type.tuple ?loc (List.map ~f:(type_expr ?loc) typs)
     | Tarrow (typ1, typ2, explicit, label) ->
@@ -83,8 +83,8 @@ module Type0 = struct
 end
 
 let rec type_desc = function
-  | Typedast.Ttyp_var (name, explicit) ->
-      Parsetypes.Ptyp_var (name, explicit)
+  | Typedast.Ttyp_var name ->
+      Parsetypes.Ptyp_var name
   | Ttyp_tuple typs ->
       Ptyp_tuple (List.map ~f:type_expr typs)
   | Ttyp_arrow (typ1, typ2, explicit, label) ->


### PR DESCRIPTION
The parameter is never anything but `Explicit` any more, so there is no need to keep it. This PR also removes some code in `Typet` that wasn't being executed because of this.

Implicit parameters to types will be removed as part of PR #366; those changes are not included here to avoid redundancy.