### PR TITLE
Lazy values

### DIFF
--- a/src/checked_intf.ml
+++ b/src/checked_intf.ml
@@ -12,6 +12,8 @@ module type Basic = sig
   val as_prover :
     (unit, 'f field, 's) Types.As_prover.t -> (unit, 's, 'f field) t
 
+  val mk_lazy : ('a, unit, 'f) t -> ('a Lazy.t, 's, 'f) t
+
   val with_label : string -> ('a, 's, 'f field) t -> ('a, 's, 'f field) t
 
   val with_state :
@@ -50,6 +52,8 @@ module type S = sig
 
   val as_prover :
     (unit, 'f field, 's) Types.As_prover.t -> (unit, 's, 'f field) t
+
+  val mk_lazy : ('a, unit, 'f) t -> ('a Lazy.t, 's, 'f) t
 
   val request_witness :
        ('var, 'value, 'f field) Types.Typ.t

--- a/src/checked_runner.ml
+++ b/src/checked_runner.ml
@@ -117,18 +117,19 @@ struct
           let {stack; prover_state; _} = s in
           let prover_state = Option.map prover_state ~f:ignore in
           let s = Run_state.set_prover_state prover_state s in
-          (* Add a label to indicate that the new stack is the point at which this
-         was forced. When printed for errors, this will split the stack into
+          (* Add a label to indicate that the new stack is the point at which
+             this was forced. When printed for errors, this will split the
+             stack into
 
-         ...
-         stack to lazy
-         ...
+             ...
+             stack to lazy
+             ...
 
-         Lazy value forced at:
-         ...
-         stack to lazy forcing point
-         ...
-      *)
+             Lazy value forced at:
+             ...
+             stack to lazy forcing point
+             ...
+          *)
           let label = "\nLazy value forced at:" in
           let _s', y = x {s with stack= old_stack @ (label :: stack)} in
           y ) )

--- a/src/snark_intf.ml
+++ b/src/snark_intf.ml
@@ -1207,6 +1207,13 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
   val as_prover : (unit, 's) As_prover.t -> (unit, 's) Checked.t
   (** Run an {!module:As_prover} block. *)
 
+  val mk_lazy : ('a, unit) Checked.t -> ('a Lazy.t, 's) Checked.t
+  (** Lazily evaluate a checked computation.
+
+      Any constraints within the checked computation are not added to the
+      constraint system unless the lazy value is forced.
+  *)
+
   val with_state :
        ?and_then:('s1 -> (unit, 's) As_prover.t)
     -> ('s1, 's) As_prover.t

--- a/src/types.ml
+++ b/src/types.ml
@@ -79,6 +79,7 @@ module Checked = struct
         'f Cvar.t Constraint.t * ('a, 's, 'f) t
         -> ('a, 's, 'f) t
     | As_prover : (unit, 'f, 's) As_prover.t * ('a, 's, 'f) t -> ('a, 's, 'f) t
+    | Lazy : ('a, unit, 'f) t * ('a Lazy.t -> ('b, 's, 'f) t) -> ('b, 's, 'f) t
     | With_label :
         string * ('a, 's, 'f) t * ('a -> ('b, 's, 'f) t)
         -> ('b, 's, 'f) t


### PR DESCRIPTION
This PR adds the `Lazy` constructor to `Checked.t`.

This gives us a straightforward way of caching without needing to jerry-rig it each time, like we've been trying to do with bit unpacking. The obvious use cases are:
* `choose_preimage_*`/`unpack`
* possibly `Field.Checked.compare` (where we don't necessarily always need the constraints for the 'less-than' condition)

For exceptions raised when a lazy value is forced during normal evaluation, the error message will look like this:
```
Uncaught exception:

  Snarky.Checked_runner.Runtime_error(_, _, _, _)

Encountered an error while evaluating the checked computation:
  (Your error here)

Label stack trace:
labels
to
the
error

Lazy value forced at:
labels
to
the
lazy
value
forcing

Raised at file "blah.ml", line blah, characters blah
Called from file "blah.ml", line blah, characters blah
...
Called from file "blah.ml", line blah, characters blah
Called from file "src/checked_runner.ml", line blah, characters blah


Raised at file "src/checked_runner.ml", line 329, characters 8-55
Called from file "src/snark0.ml", line blah, characters blah
Called from file "src/snark0.ml" (inlined), line blah, characters blah
Called from file "src/snark0.ml", line blah, characters blah
Called from file "blah.ml", line blah, characters blah
```

If we are multiple layers deep for lazy value forcing, there will be a `Lazy value forced at:` section for each forcing in order from innermost to outermost.

For values forced during a reduced evaluation, we don't get the forcing labels stack, but the label `Lazy value forced (reduced):` is added, to make it clear that we're not able to show the full label stack.