### PR TITLE
[Meja] Use mutability for unification

### DIFF
--- a/meja/src/envi.ml
+++ b/meja/src/envi.ml
@@ -1,10 +1,10 @@
 open Compiler_internals
 open Core_kernel
 open Ast_types
+open Longident
 open Type0
 open Type1
 open Ast_build.Loc
-open Longident
 module IdTbl = Ident.Table
 
 type error =
@@ -34,7 +34,6 @@ module TypeEnvi = struct
   type t =
     { type_decl_id: int
     ; instance_id: int
-    ; variable_instances: type_expr Int.Map.t
     ; implicit_vars: Typedast.expression list
     ; implicit_id: int
     ; instances: (int * type_expr) list
@@ -44,19 +43,10 @@ module TypeEnvi = struct
   let empty =
     { type_decl_id= 1
     ; instance_id= 1
-    ; variable_instances= Int.Map.empty
     ; implicit_id= 1
     ; implicit_vars= []
     ; instances= []
     ; predeclared_types= IdTbl.empty }
-
-  let instance env (typ : type_expr) =
-    Map.find env.variable_instances typ.type_id
-
-  let add_instance (typ : type_expr) typ' env =
-    { env with
-      variable_instances=
-        Map.set env.variable_instances ~key:typ.type_id ~data:typ' }
 
   let next_type_id env = (env.type_id, {env with type_id= env.type_id + 1})
 
@@ -869,11 +859,7 @@ module Type = struct
 
   let mkvar name env = Type1.mkvar env.depth name
 
-  let instance env typ = TypeEnvi.instance env.resolve_env.type_env typ
-
   let map_env ~f env = env.resolve_env.type_env <- f env.resolve_env.type_env
-
-  let add_instance typ typ' = map_env ~f:(TypeEnvi.add_instance typ typ')
 
   let refresh_var ~loc ?must_find env typ =
     match typ.type_desc with
@@ -967,36 +953,7 @@ module Type = struct
 
   let rec update_depths env typ =
     Type1.update_depth env.depth typ ;
-    match typ.type_desc with
-    | Tvar _ ->
-        Option.iter ~f:(update_depths env) (instance env typ)
-    | _ ->
-        Type1.iter ~f:(update_depths env) typ
-
-  let flatten typ env =
-    let rec flatten typ =
-      let typ = repr typ in
-      match typ.type_desc with
-      | Tvar _ -> (
-        match instance env typ with
-        | Some typ' ->
-            (* Replace variables with their instances. *)
-            let typ' = repr typ' in
-            set_repr typ typ' ; flatten typ'
-        | None ->
-            (* Don't copy variables! *)
-            typ )
-      | Tpoly _ ->
-          (* Tpoly should only ever appear at the top level of a type. *)
-          assert false
-      | _ ->
-          Type1.mk typ.type_depth (copy_desc ~f:flatten typ.type_desc)
-    in
-    let snap = Snapshot.create () in
-    let typ = repr typ in
-    let typ = flatten typ in
-    (* Restore variables back without their instances. *)
-    backtrack snap ; typ
+    Type1.iter ~f:(update_depths env) typ
 
   let or_compare cmp ~f = if Int.equal cmp 0 then f () else cmp
 
@@ -1096,15 +1053,17 @@ module Type = struct
       ~f:(fun (id, instance_typ) ->
         let instance_typ = copy instance_typ env in
         let snapshot = Snapshot.create () in
-        let {TypeEnvi.variable_instances; _} = env.resolve_env.type_env in
         if unifies env typ instance_typ then
           if
-            Set.exists typ_vars ~f:(fun var ->
-                Option.is_some (instance env var) )
+            Set.exists typ_vars ~f:(fun var -> not (phys_equal var (repr var)))
           then (
+            (* There is at least one variable that hasn't been instantiated.
+               In particular, this must mean that it was less general than the
+               variable that it unified with, or that a parent type expression
+               instantiated a type variable in the target type, and so this
+               instance isn't general enough to satisfy the target type.
+            *)
             backtrack snapshot ;
-            env.resolve_env.type_env
-            <- {env.resolve_env.type_env with variable_instances} ;
             None )
           else
             List.find_map env.scope_stack ~f:(fun {instances; _} ->
@@ -1132,7 +1091,7 @@ module Type = struct
     let implicit_vars =
       List.filter implicit_vars
         ~f:(fun ({Typedast.exp_loc; exp_type; _} as exp) ->
-          let exp_type = flatten exp_type env in
+          let exp_type = flatten exp_type in
           let typ_vars = type_vars exp_type in
           match implicit_instances ~unifies exp_type typ_vars env with
           | [(name, instance_typ)] ->
@@ -1169,7 +1128,7 @@ module Type = struct
     let {TypeEnvi.implicit_vars; _} = env.resolve_env.type_env in
     let implicit_vars =
       List.map implicit_vars ~f:(fun exp ->
-          {exp with exp_type= flatten exp.exp_type env} )
+          {exp with exp_type= flatten exp.exp_type} )
     in
     let implicit_vars =
       instantiate_implicits ~loc ~unifies implicit_vars env

--- a/meja/src/envi.ml
+++ b/meja/src/envi.ml
@@ -908,19 +908,14 @@ module Type = struct
   (** Replace the representatives of each of list of variables with a fresh
       variable.
 
-      Once the representatives have been used, the variables must be restored
-      to their previous representatives using [List.iter ~f:restore_desc] on
-      the return value.
+      The old values can be restored by taking a snapshot before calling this
+      and backtracking to it once the new values have been used.
   *)
   let refresh_vars vars env =
-    List.map vars ~f:(fun var ->
-        let {type_desc; _} = var in
+    List.iter vars ~f:(fun var ->
         (* Sanity check. *)
-        (match (repr var).type_desc with Tvar _ -> () | _ -> assert false) ;
-        var.type_desc <- Tref (mkvar None env) ;
-        (var, type_desc) )
-
-  let restore_desc (typ, desc) = typ.type_desc <- desc
+        (match var.type_desc with Tvar _ -> () | _ -> assert false) ;
+        set_repr var (mkvar None env) )
 
   let copy typ env =
     let rec copy typ =
@@ -935,36 +930,32 @@ module Type = struct
       | _ ->
           mk (copy_desc ~f:copy typ.type_desc) env
     in
+    let snap = Snapshot.create () in
     let typ = repr typ in
-    let restores, typ =
+    let typ =
       match typ.type_desc with
       | Tpoly (vars, typ) ->
           (* Make fresh variables to instantiate [Tpoly]s. *)
-          (refresh_vars vars env, typ)
+          refresh_vars vars env ; copy typ
       | _ ->
-          ([], typ)
+          copy typ
     in
-    let typ = copy typ in
-    (* Restore the original variables back into the [Tpoly]s. *)
-    List.iter ~f:restore_desc restores ;
-    typ
+    (* Restore the values of 'refreshed' variables. *)
+    backtrack snap ; typ
 
   (** [instantiate params typs typ env] creates a new type by replacing the
       each of the type variables in [params] with the corresponding instance
       from [typs] in [typ].
   *)
   let instantiate params typs typ env =
-    let restores =
-      List.map2_exn params typs ~f:(fun param typ ->
-          let {type_desc; _} = param in
-          (* Sanity check. *)
-          (match (repr param).type_desc with Tvar _ -> () | _ -> assert false) ;
-          param.type_desc <- Tref typ ;
-          (param, type_desc) )
-    in
+    let snap = Snapshot.create () in
+    List.iter2_exn params typs ~f:(fun param typ ->
+        (* Sanity check. *)
+        (match param.type_desc with Tvar _ -> () | _ -> assert false) ;
+        set_repr param typ ) ;
     let typ = copy typ env in
-    List.iter restores ~f:restore_desc ;
-    typ
+    (* Restore the original values of the parameters. *)
+    backtrack snap ; typ
 
   module T = struct
     type t = type_expr
@@ -983,7 +974,6 @@ module Type = struct
         Type1.iter ~f:(update_depths env) typ
 
   let flatten typ env =
-    let restores = ref [] in
     let rec flatten typ =
       let typ = repr typ in
       match typ.type_desc with
@@ -992,9 +982,7 @@ module Type = struct
         | Some typ' ->
             (* Replace variables with their instances. *)
             let typ' = repr typ' in
-            restores := (typ, typ.type_desc) :: !restores ;
-            typ.type_desc <- Tref typ' ;
-            flatten typ'
+            set_repr typ typ' ; flatten typ'
         | None ->
             (* Don't copy variables! *)
             typ )
@@ -1004,29 +992,11 @@ module Type = struct
       | _ ->
           Type1.mk typ.type_depth (copy_desc ~f:flatten typ.type_desc)
     in
+    let snap = Snapshot.create () in
     let typ = repr typ in
-    let assert_is_var typ =
-      match typ.type_desc with Tvar _ -> () | _ -> assert false
-    in
-    let typ =
-      match typ.type_desc with
-      | Tpoly (vars, typ') ->
-          (* Handle [Tpoly] specially, since it should only appear at the top
-             level of a type.
-          *)
-          (* Sanity check: variables should not have instances. *)
-          List.iter ~f:assert_is_var vars ;
-          let typ' = flatten typ' in
-          (* Sanity check: should not have found instances for these variables.
-          *)
-          List.iter ~f:assert_is_var vars ;
-          Type1.mk typ.type_depth (Tpoly (vars, typ'))
-      | _ ->
-          flatten typ
-    in
+    let typ = flatten typ in
     (* Restore variables back without their instances. *)
-    List.iter !restores ~f:restore_desc ;
-    typ
+    backtrack snap ; typ
 
   let or_compare cmp ~f = if Int.equal cmp 0 then f () else cmp
 

--- a/meja/src/type1.ml
+++ b/meja/src/type1.ml
@@ -229,6 +229,21 @@ let set_desc typ desc =
 
 let set_repr typ typ' = set_desc typ (Tref typ')
 
+let add_instance = set_repr
+
+let flatten typ =
+  let rec flatten typ =
+    let typ = repr typ in
+    match typ.type_desc with
+    | Tvar _ ->
+        (* Don't copy variables! *)
+        typ
+    | _ ->
+        mk typ.type_depth (copy_desc ~f:flatten typ.type_desc)
+  in
+  let typ = flatten typ in
+  typ
+
 let type_vars ?depth typ =
   let deep_enough =
     match depth with

--- a/meja/src/type1.ml
+++ b/meja/src/type1.ml
@@ -227,10 +227,31 @@ let set_desc typ desc =
   Snapshot.add_to_history (Desc (typ, typ.type_desc)) ;
   typ.type_desc <- desc
 
+(** [set_repr typ typ'] sets the representative of [typ] to be [typ']. *)
 let set_repr typ typ' = set_desc typ (Tref typ')
 
-let add_instance = set_repr
+(** [add_instance var typ'] changes the representative of the type variable
+    [var] to [typ']. If [typ'] is also a type variable, then the user-provided
+    of [var] is added to [typ'], unless [typ'] already has a user-provided name
+    of its own.
 
+    Raises [AssertionError] if [var] is not a type variable.
+*)
+let add_instance typ typ' =
+  ( match (typ.type_desc, typ'.type_desc) with
+  | Tvar (Some name), Tvar None ->
+      (* We would lose the user-provided name associated with [typ], so promote
+         it to be the name of [typ'].
+      *)
+      set_desc typ' (Tvar (Some name))
+  | Tvar _, _ ->
+      ()
+  | _ ->
+      (* Sanity check: we should be adding an instance to a type variable. *)
+      assert false ) ;
+  set_repr typ typ'
+
+(** Create an equivalent type by unfolding all of the type representatives. *)
 let flatten typ =
   let rec flatten typ =
     let typ = repr typ in

--- a/meja/src/typechecker.ml
+++ b/meja/src/typechecker.ml
@@ -65,13 +65,9 @@ let rec check_type_aux ~loc typ ctyp env =
   if Type1.contains typ ~in_:ctyp || Type1.contains ctyp ~in_:typ then
     raise (Error (loc, Recursive_variable typ)) ;
   let check_type_aux = check_type_aux ~loc in
-  let without_instance ~f (typ : type_expr) env =
-    match Envi.Type.instance env typ with
-    | Some typ ->
-        Some (f typ env)
-    | None ->
-        None
-  in
+  Type1.unify_depths typ ctyp ;
+  let typ = repr typ in
+  let ctyp = repr ctyp in
   Type1.unify_depths typ ctyp ;
   match (typ.type_desc, ctyp.type_desc) with
   | Tref _, _ | _, Tref _ ->
@@ -86,26 +82,15 @@ let rec check_type_aux ~loc typ ctyp env =
       *)
       assert false
   | Tvar _, Tvar _ ->
-      map_none
-        (without_instance typ env ~f:(fun typ -> check_type_aux typ ctyp))
-        (fun () ->
-          map_none
-            (without_instance ctyp env ~f:(fun ctyp -> check_type_aux typ ctyp))
-            (fun () ->
-              (* Add the outermost (in terms of lexical scope) of the variables as
+      (* Add the outermost (in terms of lexical scope) of the variables as
                  the instance for the other. We do this by chosing the type of
                  lowest ID, to ensure strict ordering and thus no cycles. *)
-              if ctyp.type_id < typ.type_id then
-                Envi.Type.add_instance typ ctyp env
-              else Envi.Type.add_instance ctyp typ env ) )
+      if ctyp.type_id < typ.type_id then Type1.add_instance typ ctyp
+      else Type1.add_instance ctyp typ
   | Tvar _, _ ->
-      map_none
-        (without_instance typ env ~f:(fun typ -> check_type_aux typ ctyp))
-        (fun () -> Envi.Type.add_instance typ ctyp env)
+      Type1.add_instance typ ctyp
   | _, Tvar _ ->
-      map_none
-        (without_instance ctyp env ~f:(fun ctyp -> check_type_aux typ ctyp))
-        (fun () -> Envi.Type.add_instance ctyp typ env)
+      Type1.add_instance ctyp typ
   | Ttuple typs, Ttuple ctyps -> (
     match
       List.iter2 typs ctyps ~f:(fun typ ctyp -> check_type_aux typ ctyp env)
@@ -178,23 +163,19 @@ let rec check_type_aux ~loc typ ctyp env =
 let check_type ~loc env typ constr_typ =
   match check_type_aux ~loc typ constr_typ env with
   | exception Error (_, err) ->
-      let typ = Envi.Type.flatten typ env in
-      let constr_typ = Envi.Type.flatten constr_typ env in
+      let typ = Type1.flatten typ in
+      let constr_typ = Type1.flatten constr_typ in
       raise (Error (loc, Check_failed (typ, constr_typ, err)))
   | () ->
       ()
 
 let unifies env typ constr_typ =
   let snapshot = Snapshot.create () in
-  let {Envi.TypeEnvi.variable_instances; _} = env.Envi.resolve_env.type_env in
   match check_type ~loc:Location.none env typ constr_typ with
   | () ->
       true
   | exception Error _ ->
-      env.resolve_env.type_env
-      <- {env.resolve_env.type_env with variable_instances} ;
-      backtrack snapshot ;
-      false
+      backtrack snapshot ; false
 
 let rec add_implicits ~loc implicits typ env =
   match implicits with
@@ -229,7 +210,7 @@ let polymorphise typ env =
       Envi.Type.mk (Tpoly (typ_vars, typ)) env
 
 let add_polymorphised name typ env =
-  let typ = Envi.Type.flatten typ env in
+  let typ = Type1.flatten typ in
   let typ = polymorphise typ env in
   Envi.add_name name typ env
 
@@ -516,9 +497,9 @@ let rec get_expression env expected exp =
                   e_typ
             in
             let e, env = get_expression env e_typ e in
-            ((Envi.Type.flatten res_typ env, env), (label, e)) )
+            ((Type1.flatten res_typ, env), (label, e)) )
       in
-      let typ = Type1.discard_optional_labels @@ Envi.Type.flatten typ env in
+      let typ = Type1.discard_optional_labels @@ Type1.flatten typ in
       (* Squash nested applies from implicit arguments. *)
       let f, es =
         match f.exp_desc with
@@ -624,7 +605,7 @@ let rec get_expression env expected exp =
                 | _ ->
                     Type0_map.default_mapper.type_expr mapper typ ) }
         in
-        mapper.type_expr mapper (Envi.Type.flatten res env)
+        mapper.type_expr mapper (Type1.flatten res)
       in
       check_type ~loc env expected res ;
       Envi.Type.update_depths env res ;
@@ -801,7 +782,7 @@ let rec get_expression env expected exp =
         | None ->
             (expected, None, env)
       in
-      let typ = Envi.Type.flatten typ env in
+      let typ = Type1.flatten typ in
       let typ, field_decls, type_vars, bound_vars =
         match Envi.TypeDecl.find_unaliased_of_type ~loc typ env with
         | Some
@@ -909,12 +890,12 @@ and check_binding ?(toplevel = false) (env : Envi.t) p e : 's =
   let loc = e.exp_loc in
   let typ = Envi.Type.mkvar None env in
   let p, pattern_variables, env = check_pattern env typ p in
-  let typ = Envi.Type.flatten typ env in
+  let typ = Type1.flatten typ in
   let env = Envi.open_expr_scope env in
   let e, env = get_expression env typ e in
   let env = Envi.close_expr_scope env in
   Envi.Type.update_depths env e.exp_type ;
-  let exp_type = Envi.Type.flatten e.exp_type env in
+  let exp_type = Type1.flatten e.exp_type in
   let e = {e with exp_type} in
   let typ_vars = free_type_vars ~depth:env.Envi.depth exp_type in
   let implicit_vars =
@@ -931,7 +912,7 @@ and check_binding ?(toplevel = false) (env : Envi.t) p e : 's =
       let name, typ =
         match pattern_variables with
         | [(name, typ)] ->
-            (name, Envi.Type.flatten typ env)
+            (name, Type1.flatten typ)
         | _ ->
             raise (Error (loc, No_instance implicit.exp_type))
       in

--- a/meja/src/typechecker.ml
+++ b/meja/src/typechecker.ml
@@ -241,7 +241,8 @@ let get_field (field : lid) env =
       ( ident
       , ( ({tdec_desc= TRecord field_decls; tdec_ident; tdec_params; _} as decl)
         , i ) ) ->
-      let bound_vars = Envi.Type.refresh_vars tdec_params env in
+      let snap = Snapshot.create () in
+      Envi.Type.refresh_vars tdec_params env ;
       let name =
         match ident with
         | Path.Pdot (m, _, _) ->
@@ -255,7 +256,7 @@ let get_field (field : lid) env =
       let {fld_type; _} = List.nth_exn field_decls i in
       let rcd_type = Envi.Type.copy rcd_type env in
       let fld_type = Envi.Type.copy fld_type env in
-      List.iter ~f:Envi.Type.restore_desc bound_vars ;
+      backtrack snap ;
       (ident, i, fld_type, rcd_type)
   | _ ->
       raise (Error (loc, Unbound ("record field", field)))
@@ -334,11 +335,11 @@ let get_ctor (name : lid) env =
   let bound_vars =
     Set.to_list (Set.union (Type1.type_vars typ) (Type1.type_vars args_typ))
   in
-  let bound_vars = Envi.Type.refresh_vars bound_vars env in
+  let snap = Snapshot.create () in
+  Envi.Type.refresh_vars bound_vars env ;
   let args_typ = Envi.Type.copy args_typ env in
   let typ = Envi.Type.copy typ env in
-  List.iter ~f:Envi.Type.restore_desc bound_vars ;
-  (name, typ, args_typ)
+  backtrack snap ; (name, typ, args_typ)
 
 let rec check_pattern env typ pat =
   let mode = Envi.current_mode env in


### PR DESCRIPTION
This PR replaces the existing variable instance set-up (a map from type ID to the instance) with the new `Tref` constructor. This
* makes finding type instances 'free', which speeds up the typechecker
* simplifies the implementation of `flatten` and stops it from depending on the environment
* makes type unification actually `backtrack`able without using the `variable_instances` overwrite hack
* adds some more sanity checks to make sure that we're not adding instances to non-type-variables
* preserves the user-provided names of types whenever possible
* removes some of the complications with variable instances from type stitching