### PR TITLE
[Meja] Enable stitching in type declarations

### DIFF
--- a/meja/src/type0.ml
+++ b/meja/src/type0.ml
@@ -37,7 +37,8 @@ and type_decl =
   { tdec_ident: Ident.t
   ; tdec_params: type_expr list
   ; tdec_desc: type_decl_desc
-  ; tdec_id: int }
+  ; tdec_id: int
+  ; tdec_ret: type_expr }
 [@@deriving sexp]
 
 and type_decl_desc =

--- a/meja/src/type0.ml
+++ b/meja/src/type0.ml
@@ -34,8 +34,7 @@ and ctor_decl =
 [@@deriving sexp]
 
 and type_decl =
-  { tdec_ident: Ident.t
-  ; tdec_params: type_expr list
+  { tdec_params: type_expr list
   ; tdec_desc: type_decl_desc
   ; tdec_id: int
   ; tdec_ret: type_expr }

--- a/meja/src/type0_map.ml
+++ b/meja/src/type0_map.ml
@@ -130,22 +130,13 @@ let ctor_decl mapper ({ctor_ident; ctor_args= args; ctor_ret} as decl) =
       else {ctor_ident; ctor_args; ctor_ret= Some ctor_ret}
 
 let type_decl mapper
-    ( { tdec_ident= ident
-      ; tdec_params= params
-      ; tdec_desc= desc
-      ; tdec_id
-      ; tdec_ret= ret } as decl ) =
+    ({tdec_params= params; tdec_desc= desc; tdec_id; tdec_ret= ret} as decl) =
   let same = ref true in
   let tdec_params = map_list params ~same ~f:(mapper.type_expr mapper) in
   let tdec_desc = mapper.type_decl_desc mapper desc in
-  let tdec_ident = mapper.ident mapper ident in
   let tdec_ret = mapper.type_expr mapper ret in
-  if
-    !same && phys_equal tdec_desc desc
-    && phys_equal tdec_ident ident
-    && phys_equal tdec_ret ret
-  then decl
-  else {tdec_ident; tdec_params; tdec_desc; tdec_id; tdec_ret}
+  if !same && phys_equal tdec_desc desc && phys_equal tdec_ret ret then decl
+  else {tdec_params; tdec_desc; tdec_id; tdec_ret}
 
 let type_decl_desc mapper desc =
   match desc with

--- a/meja/src/type0_map.ml
+++ b/meja/src/type0_map.ml
@@ -130,15 +130,22 @@ let ctor_decl mapper ({ctor_ident; ctor_args= args; ctor_ret} as decl) =
       else {ctor_ident; ctor_args; ctor_ret= Some ctor_ret}
 
 let type_decl mapper
-    ({tdec_ident= ident; tdec_params= params; tdec_desc= desc; tdec_id} as decl)
-    =
+    ( { tdec_ident= ident
+      ; tdec_params= params
+      ; tdec_desc= desc
+      ; tdec_id
+      ; tdec_ret= ret } as decl ) =
   let same = ref true in
   let tdec_params = map_list params ~same ~f:(mapper.type_expr mapper) in
   let tdec_desc = mapper.type_decl_desc mapper desc in
   let tdec_ident = mapper.ident mapper ident in
-  if !same && phys_equal tdec_desc desc && phys_equal tdec_ident ident then
-    decl
-  else {tdec_ident; tdec_params; tdec_desc; tdec_id}
+  let tdec_ret = mapper.type_expr mapper ret in
+  if
+    !same && phys_equal tdec_desc desc
+    && phys_equal tdec_ident ident
+    && phys_equal tdec_ret ret
+  then decl
+  else {tdec_ident; tdec_params; tdec_desc; tdec_id; tdec_ret}
 
 let type_decl_desc mapper desc =
   match desc with

--- a/meja/src/type1.ml
+++ b/meja/src/type1.ml
@@ -602,9 +602,5 @@ module Decl = struct
     let tdec_ret =
       Mk.ctor ~mode:(Ident.mode name) 10000 (Path.Pident name) params
     in
-    { tdec_ident= name
-    ; tdec_params= params
-    ; tdec_desc= desc
-    ; tdec_id= !decl_id
-    ; tdec_ret }
+    {tdec_params= params; tdec_desc= desc; tdec_id= !decl_id; tdec_ret}
 end

--- a/meja/src/type1.ml
+++ b/meja/src/type1.ml
@@ -599,9 +599,12 @@ module Decl = struct
 
   let mk ~name ~params desc =
     incr decl_id ;
-    {tdec_ident= name; tdec_params= params; tdec_desc= desc; tdec_id= !decl_id}
-
-  let mk_typ ~mode ~params ?ident depth decl =
-    let ident = Option.value ident ~default:(Path.Pident decl.tdec_ident) in
-    Mk.ctor ~mode depth ident params
+    let tdec_ret =
+      Mk.ctor ~mode:(Ident.mode name) 10000 (Path.Pident name) params
+    in
+    { tdec_ident= name
+    ; tdec_params= params
+    ; tdec_desc= desc
+    ; tdec_id= !decl_id
+    ; tdec_ret }
 end

--- a/meja/src/typechecker.ml
+++ b/meja/src/typechecker.ml
@@ -1434,9 +1434,9 @@ let rec report_error ppf = function
         pp_typ constr_typ
   | Recursive_variable typ ->
       fprintf ppf
-        "@[<hov>The variable@ @[<h>%a@](%d) would have an instance that \
-         contains itself.@]"
-        pp_typ typ typ.type_id
+        "@[<hov>The variable@ @[<h>%a@] would have an instance that contains \
+         itself.@]"
+        pp_typ typ
   | Unbound (kind, value) ->
       fprintf ppf "@[<hov>Unbound %s@ %a.@]" kind Longident.pp value.txt
   | Unbound_value value ->

--- a/meja/src/typechecker.ml
+++ b/meja/src/typechecker.ml
@@ -46,10 +46,12 @@ let unpack_decls ~loc typ ctyp env =
     match (typ.type_desc, ctyp.type_desc) with
     | Tctor variant, Tctor cvariant ->
         let decl_id =
-          (Envi.raw_get_type_declaration ~loc variant.var_ident env).tdec_id
+          (snd (Envi.raw_get_type_declaration ~loc variant.var_ident env))
+            .tdec_id
         in
         let cdecl_id =
-          (Envi.raw_get_type_declaration ~loc cvariant.var_ident env).tdec_id
+          (snd (Envi.raw_get_type_declaration ~loc cvariant.var_ident env))
+            .tdec_id
         in
         (* Try to unfold the oldest type definition first. *)
         if decl_id < cdecl_id then bind_none (unfold_ctyp ()) unfold_typ
@@ -132,10 +134,12 @@ let rec check_type_aux ~loc typ ctyp env =
         check_type_aux typ ctyp env
     | None ->
         let decl_id =
-          (Envi.raw_get_type_declaration ~loc variant.var_ident env).tdec_id
+          (snd (Envi.raw_get_type_declaration ~loc variant.var_ident env))
+            .tdec_id
         in
         let cdecl_id =
-          (Envi.raw_get_type_declaration ~loc constr_variant.var_ident env)
+          (snd
+             (Envi.raw_get_type_declaration ~loc constr_variant.var_ident env))
             .tdec_id
         in
         if Int.equal decl_id cdecl_id then
@@ -222,23 +226,12 @@ let get_field (field : lid) env =
   let loc = field.loc in
   match Envi.TypeDecl.find_of_field ~mode field env with
   | Some
-      ( ident
-      , ( ({tdec_desc= TRecord field_decls; tdec_ident; tdec_params; _} as decl)
-        , i ) ) ->
+      (ident, ({tdec_desc= TRecord field_decls; tdec_ret; tdec_params; _}, i))
+    ->
       let snap = Snapshot.create () in
       Envi.Type.refresh_vars tdec_params env ;
-      let name =
-        match ident with
-        | Path.Pdot (m, _, _) ->
-            Path.dot m tdec_ident
-        | _ ->
-            Path.Pident tdec_ident
-      in
-      let rcd_type =
-        Envi.TypeDecl.mk_typ ~mode ~params:tdec_params ~ident:name decl env
-      in
       let {fld_type; _} = List.nth_exn field_decls i in
-      let rcd_type = Envi.Type.copy rcd_type env in
+      let rcd_type = Envi.Type.copy tdec_ret env in
       let fld_type = Type1.get_mode mode fld_type in
       let fld_type = Envi.Type.copy fld_type env in
       backtrack snap ;
@@ -290,22 +283,8 @@ let get_ctor (name : lid) env =
     | _ ->
         Path.Pident tdec_ident
   in
-  let typ =
-    match ctor.ctor_ret with
-    | Some typ ->
-        typ
-    | _ ->
-        let ident, decl =
-          match decl.tdec_desc with
-          | TVariant _ ->
-              (make_name name decl.tdec_ident, decl)
-          | TExtend (name, decl, _) ->
-              (make_name name decl.tdec_ident, decl)
-          | _ ->
-              assert false
-        in
-        Envi.TypeDecl.mk_typ ~mode ~params:decl.tdec_params ~ident decl env
-  in
+  let typ = match ctor.ctor_ret with Some typ -> typ | _ -> decl.tdec_ret in
+  let typ = get_mode mode typ in
   let args_typ =
     match ctor.ctor_args with
     | Ctor_record decl ->
@@ -313,7 +292,7 @@ let get_ctor (name : lid) env =
           (make_name name ctor.ctor_ident)
           decl.tdec_params env
     | Ctor_tuple [typ] ->
-        typ
+        get_mode mode typ
     | Ctor_tuple typs ->
         Envi.Type.Mk.tuple ~mode typs env
   in
@@ -394,26 +373,16 @@ let rec check_pattern env typ pat =
         | _ -> (
           match Envi.TypeDecl.find_of_field ~mode field env with
           | Some
-              ( ident
-              , (({tdec_desc= TRecord field_decls; tdec_params; _} as decl), _)
+              ( _fld_ident
+              , ({tdec_desc= TRecord field_decls; tdec_params; tdec_ret; _}, _)
               ) ->
               let vars =
                 List.map
                   ~f:(fun _ -> Envi.Type.mkvar ~mode None env)
                   tdec_params
               in
-              let ident =
-                Path.(
-                  match ident with
-                  | Pident _ ->
-                      Pident decl.tdec_ident
-                  | Pdot (path, _, _) ->
-                      dot path decl.tdec_ident
-                  | _ ->
-                      failwith "Unhandled Papply in field name")
-              in
               let decl_type =
-                Envi.TypeDecl.mk_typ ~mode ~params:vars ~ident decl env
+                Envi.Type.instantiate tdec_params vars tdec_ret env
               in
               check_type ~loc env typ decl_type ;
               (decl_type, field_decls, tdec_params, vars)
@@ -684,22 +653,15 @@ let rec get_expression env expected exp =
           match Envi.TypeDecl.find_of_field ~mode field env with
           | Some
               ( fld_ident
-              , (({tdec_desc= TRecord field_decls; tdec_params; _} as decl), i)
+              , ({tdec_desc= TRecord field_decls; tdec_params; tdec_ret; _}, i)
               ) ->
               let vars =
                 List.map
                   ~f:(fun _ -> Envi.Type.mkvar ~mode None env)
                   tdec_params
               in
-              let ident =
-                match fld_ident with
-                | Pdot (path, _, _) ->
-                    Path.dot path decl.tdec_ident
-                | _ ->
-                    Path.Pident decl.tdec_ident
-              in
               let decl_type =
-                Envi.TypeDecl.mk_typ ~mode ~params:vars ~ident decl env
+                Envi.Type.instantiate tdec_params vars tdec_ret env
               in
               let {fld_type; _} = List.nth_exn field_decls i in
               let fld_type =
@@ -750,25 +712,15 @@ let rec get_expression env expected exp =
             match Envi.TypeDecl.find_of_field ~mode field env with
             | Some
                 ( fld_ident
-                , ( ({tdec_desc= TRecord field_decls; tdec_params; _} as decl)
+                , ( {tdec_desc= TRecord field_decls; tdec_params; tdec_ret; _}
                   , i ) ) ->
                 let vars =
                   List.map
                     ~f:(fun _ -> Envi.Type.mkvar ~mode None env)
                     tdec_params
                 in
-                let ident =
-                  Path.(
-                    match fld_ident with
-                    | Pident _ ->
-                        Pident decl.tdec_ident
-                    | Pdot (path, _, _) ->
-                        dot path decl.tdec_ident
-                    | _ ->
-                        failwith "Unhandled Papply in field name")
-                in
                 let e_typ =
-                  Envi.TypeDecl.mk_typ ~mode ~params:vars ~ident decl env
+                  Envi.Type.instantiate tdec_params vars tdec_ret env
                 in
                 check_type ~loc env e.exp_type e_typ ;
                 let {fld_type; _} = List.nth_exn field_decls i in
@@ -804,26 +756,16 @@ let rec get_expression env expected exp =
         | _ -> (
           match Envi.TypeDecl.find_of_field ~mode field env with
           | Some
-              ( ident
-              , (({tdec_desc= TRecord field_decls; tdec_params; _} as decl), _)
+              ( _fld_ident
+              , ({tdec_desc= TRecord field_decls; tdec_params; tdec_ret; _}, _)
               ) ->
               let vars =
                 List.map
                   ~f:(fun _ -> Envi.Type.mkvar ~mode None env)
                   tdec_params
               in
-              let ident =
-                Path.(
-                  match ident with
-                  | Pident _ ->
-                      Pident decl.tdec_ident
-                  | Pdot (path, _, _) ->
-                      dot path decl.tdec_ident
-                  | _ ->
-                      failwith "Unhandled Papply in field name")
-              in
               let decl_type =
-                Envi.TypeDecl.mk_typ ~mode ~params:vars ~ident decl env
+                Envi.Type.instantiate tdec_params vars tdec_ret env
               in
               check_type ~loc env typ decl_type ;
               (decl_type, field_decls, tdec_params, vars)
@@ -984,7 +926,7 @@ and check_binding ?(toplevel = false) (env : Envi.t) p e : 's =
 let type_extension ~loc variant ctors env =
   let mode = Envi.current_mode env in
   let {Parsetypes.var_ident; var_params} = variant in
-  let path, ({tdec_ident; tdec_params; tdec_desc; _} as decl) =
+  let path, ({tdec_params; tdec_desc; _} as decl) =
     match Envi.raw_find_type_declaration ~mode var_ident env with
     | open_decl ->
         open_decl
@@ -1001,8 +943,17 @@ let type_extension ~loc variant ctors env =
       ()
   | Unequal_lengths ->
       raise (Error (loc, Extension_different_arity var_ident.txt)) ) ;
+  let tdec_ident =
+    match path with
+    | Pident name ->
+        Ident.name name
+    | Pdot (_, _, name) ->
+        name
+    | _ ->
+        assert false
+  in
   let decl =
-    { Parsetypes.tdec_ident= Location.mkloc (Ident.name tdec_ident) loc
+    { Parsetypes.tdec_ident= Location.mkloc tdec_ident loc
     ; tdec_params= var_params
     ; tdec_desc= Pdec_extend (Location.mkloc path var_ident.loc, decl, ctors)
     ; tdec_loc= loc }

--- a/meja/src/typeprint.ml
+++ b/meja/src/typeprint.ml
@@ -98,7 +98,7 @@ let type_decl_desc fmt = function
       in
       fprintf fmt "@ /* forward declaration %a */" print_id !i
 
-let type_decl fmt decl =
-  fprintf fmt "type %a" Ident.pprint decl.tdec_ident ;
+let type_decl ident fmt decl =
+  fprintf fmt "type %a" Ident.pprint ident ;
   (match decl.tdec_params with [] -> () | _ -> tuple fmt decl.tdec_params) ;
   type_decl_desc fmt decl.tdec_desc

--- a/meja/src/typet.mli
+++ b/meja/src/typet.mli
@@ -30,5 +30,15 @@ module TypeDecl : sig
   val generalise :
     Parsetypes.type_decl -> Parsetypes.type_decl * Parsetypes.type_decl
 
-  val import : Parsetypes.type_decl -> Envi.t -> Typedast.type_decl * Envi.t
+  val import :
+       ?other_name:Path.t
+    -> Parsetypes.type_decl
+    -> Envi.t
+    -> Typedast.type_decl * Envi.t
+  (** Import a type declaration.
+
+      If [other_name] is specified, then the type declaration will be stitched
+      to the type with that name; otherwise, the type is stitched to a type of
+      its own name in the other mode.
+  *)
 end

--- a/meja/src/untype_ast.ml
+++ b/meja/src/untype_ast.ml
@@ -71,11 +71,10 @@ module Type0 = struct
     | TForward _ ->
         failwith "Cannot convert TForward to a parsetree equivalent"
 
-  and type_decl ?loc decl =
+  and type_decl ?loc name decl =
     type_decl_desc ?loc
       ~params:(List.map ~f:type_expr decl.tdec_params)
-      (Ident.name decl.tdec_ident)
-      decl.tdec_desc
+      name decl.tdec_desc
 end
 
 let rec type_desc = function

--- a/meja/tests/recursive-type.stderr
+++ b/meja/tests/recursive-type.stderr
@@ -1,3 +1,3 @@
 File "tests/recursive-type.meja", line 11, characters 10-11:
 Error: Incompatible types (_, _) and (_, (_, _)):
-       The variable _(24719) would have an instance that contains itself.
+       The variable _ would have an instance that contains itself.


### PR DESCRIPTION
Note: this PR includes #389.

This PR
* adds a `tdec_ret` field to type declarations, which specifies the (stitched) type that instances of the type declaration should be instantiated with
* adds an optional parameter to `Typet.TypeDecl.import` to specify which type the imported declaration's type should be stitched to

I have been working on a different strategy for conversions (ie. `Typ.t` generation) using a dedicated AST and a new type `Tconv`. This will let us drop the `Codegen` and actually call `Typet.TypeDecl.import` with this new parameter, as well as properly generating `Typ.t`s for tuples, etc. That PR will depend on this, but this is broken out because that work already has a particularly large diff footprint, and is still incomplete.