### PR TITLE
Add dummy proofs

### DIFF
--- a/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_curve.cpp.template
+++ b/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_curve.cpp.template
@@ -854,6 +854,10 @@ bool CURVE_PREFIX(proof_verify)(
   return r1cs_gg_ppzksnark_verifier_weak_IC(*key, *primary_input, *proof);
 }
 
+r1cs_gg_ppzksnark_proof<ppT>* CURVE_PREFIX(proof_dummy)() {
+  return new r1cs_gg_ppzksnark_proof<ppT>();
+}
+
 libff::G1<ppT>* CURVE_PREFIX(proof_a)(r1cs_gg_ppzksnark_proof<ppT>* proof) {
   return new libff::G1<ppT>(proof->g_A);
 }
@@ -1014,6 +1018,10 @@ bool CURVE_PREFIX(gm_proof_verify)(
   return r1cs_se_ppzksnark_verifier_weak_IC(*key, *primary_input, *proof);
 }
 
+r1cs_se_ppzksnark_proof<ppT>* CURVE_PREFIX(gm_proof_dummy)() {
+  return new r1cs_se_ppzksnark_proof<ppT>();
+}
+
 libff::G1<ppT>* CURVE_PREFIX(gm_proof_a)(r1cs_se_ppzksnark_proof<ppT>* proof) {
   return new libff::G1<ppT>(proof->A);
 }
@@ -1157,6 +1165,10 @@ bool CURVE_PREFIX(bg_proof_verify_components)(
 
 void CURVE_PREFIX(bg_proof_delete)(r1cs_bg_ppzksnark_proof<ppT>* proof) {
   delete proof;
+}
+
+r1cs_bg_ppzksnark_proof<ppT>* CURVE_PREFIX(bg_proof_dummy)() {
+  return new r1cs_bg_ppzksnark_proof<ppT>();
 }
 
 libff::G1<ppT>* CURVE_PREFIX(bg_proof_a)(r1cs_bg_ppzksnark_proof<ppT>* proof) {

--- a/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_curve.h.template
+++ b/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_curve.h.template
@@ -284,6 +284,8 @@ bool CURVE_PREFIX(proof_verify)(
     void* key,
     void* primary_input);
 
+void* CURVE_PREFIX(proof_dummy)();
+
 void* CURVE_PREFIX(proof_a)(void* proof);
 
 void* CURVE_PREFIX(proof_b)(void* proof);
@@ -372,6 +374,8 @@ bool CURVE_PREFIX(gm_proof_verify)(
     void* key,
     void* primary_input);
 
+void* CURVE_PREFIX(gm_proof_dummy)();
+
 void* CURVE_PREFIX(gm_proof_a)(void* proof);
 
 void* CURVE_PREFIX(gm_proof_b)(void* proof);
@@ -440,6 +444,8 @@ bool CURVE_PREFIX(bg_proof_verify_components)(
     void* primary_input);
 
 void CURVE_PREFIX(bg_proof_delete)(void* proof);
+
+void* CURVE_PREFIX(bg_proof_dummy)();
 
 void* CURVE_PREFIX(bg_proof_a)(void* proof);
 

--- a/src/camlsnark_c/libsnark-caml/libsnark/zk_proof_systems/ppzksnark/r1cs_se_ppzksnark/r1cs_se_ppzksnark.hpp
+++ b/src/camlsnark_c/libsnark-caml/libsnark/zk_proof_systems/ppzksnark/r1cs_se_ppzksnark/r1cs_se_ppzksnark.hpp
@@ -335,7 +335,12 @@ public:
     libff::G1<ppT> C;
 
     r1cs_se_ppzksnark_proof()
-    {}
+    {
+        // invalid proof with valid curve points
+        this->A = libff::G1<ppT>::one();
+        this->B = libff::G2<ppT>::one();
+        this->C = libff::G1<ppT>::one();
+    }
     r1cs_se_ppzksnark_proof(libff::G1<ppT> &&A,
         libff::G2<ppT> &&B,
         libff::G1<ppT> &&C) :

--- a/src/libsnark.ml
+++ b/src/libsnark.ml
@@ -1782,6 +1782,8 @@ struct
     val verify :
       ?message:message -> t -> Verification_key.t -> M.Field.Vector.t -> bool
 
+    val dummy : unit -> t
+
     include Binable.S with type t := t
   end = struct
     include Proof.Make
@@ -1834,6 +1836,8 @@ struct
           @-> returning bool )
       in
       fun ?message:_ t k primary -> stub t k primary
+
+    let dummy = foreign (func_name "dummy") (void @-> returning typ)
   end
 end
 
@@ -1990,6 +1994,8 @@ module Make_bowe_gabizon (M : sig
 
     module Vector : Deletable_intf
 
+    val one : t
+
     val scale_field : t -> Field.t -> t
   end
 
@@ -1997,6 +2003,8 @@ module Make_bowe_gabizon (M : sig
     include Deletable_intf
 
     include Binable.S with type t := t
+
+    val one : t
   end
 end) (H : sig
   open M
@@ -2067,6 +2075,8 @@ struct
         in
         let t = stub proving_key d primary auxiliary in
         Caml.Gc.finalise delete t ; t
+
+      let dummy = foreign (func_name "dummy") (void @-> returning typ)
     end
 
     type message = Fq.t array
@@ -2083,11 +2093,14 @@ struct
       let delta_prime = Pre.delta_prime pre in
       let y_s = H.hash ?message ~a ~b ~c ~delta_prime in
       let z = G1.scale_field y_s d in
-      {a= Pre.a pre; b= Pre.b pre; c= Pre.c pre; z; delta_prime}
+      {a; b; c; z; delta_prime}
 
     let verify ?message {a; b; c; z; delta_prime} vk input =
       let y_s = H.hash ?message ~a ~b ~c ~delta_prime in
       Pre.verify_components ~a ~b ~c ~delta_prime ~y_s ~z vk input
+
+    let dummy () =
+      {a= G1.one; b= G2.one; c= G1.one; z= G1.one; delta_prime= G2.one}
   end
 end
 
@@ -2854,3 +2867,36 @@ module type S = sig
     include Binable.S with type t := t
   end
 end
+
+let%test_module "dummy-proofs" =
+  ( module struct
+    module Hash = struct
+      let hash ?message:_ ~a:_ ~b:_ ~c:_ ~delta_prime:_ = assert false
+    end
+
+    module BG = struct
+      module Mnt4 = Make_bowe_gabizon (Mnt4) (Hash)
+      module Mnt6 = Make_bowe_gabizon (Mnt6) (Hash)
+      module Mnt4753 = Make_bowe_gabizon (Mnt4753) (Hash)
+      module Mnt6753 = Make_bowe_gabizon (Mnt6753) (Hash)
+    end
+
+    let _proofs =
+      ( Mnt4.Default.Proof.dummy ()
+      , Mnt4.GM.Proof.dummy ()
+      , Mnt6.Default.Proof.dummy ()
+      , Mnt6.GM.Proof.dummy ()
+      , Mnt4753.Default.Proof.dummy ()
+      , Mnt4753.GM.Proof.dummy ()
+      , Mnt6753.Default.Proof.dummy ()
+      , Mnt6753.GM.Proof.dummy ()
+      , Bn128.Default.Proof.dummy ()
+      , BG.Mnt4.Proof.Pre.dummy ()
+      , BG.Mnt6.Proof.Pre.dummy ()
+      , BG.Mnt4753.Proof.Pre.dummy ()
+      , BG.Mnt6753.Proof.Pre.dummy ()
+      , BG.Mnt4.Proof.dummy ()
+      , BG.Mnt6.Proof.dummy ()
+      , BG.Mnt4753.Proof.dummy ()
+      , BG.Mnt6753.Proof.dummy () )
+  end )

--- a/src/libsnark.ml
+++ b/src/libsnark.ml
@@ -1573,7 +1573,7 @@ module Make_proof_system_keys (M : Proof_system_inputs_intf) = struct
 
     val size_in_bits : t -> int
 
-    val dummy : input_size:int -> t
+    val get_dummy : input_size:int -> t
   end = struct
     include Verification_key.Make
               (Ctypes_foreign)
@@ -1581,7 +1581,7 @@ module Make_proof_system_keys (M : Proof_system_inputs_intf) = struct
                 let prefix = with_prefix M.prefix "verification_key"
               end)
 
-    let dummy ~input_size =
+    let get_dummy ~input_size =
       foreign (func_name "dummy") (int @-> returning typ) input_size
 
     let size_in_bits =
@@ -1782,7 +1782,7 @@ struct
     val verify :
       ?message:message -> t -> Verification_key.t -> M.Field.Vector.t -> bool
 
-    val dummy : unit -> t
+    val get_dummy : unit -> t
 
     include Binable.S with type t := t
   end = struct
@@ -1837,7 +1837,7 @@ struct
       in
       fun ?message:_ t k primary -> stub t k primary
 
-    let dummy = foreign (func_name "dummy") (void @-> returning typ)
+    let get_dummy = foreign (func_name "dummy") (void @-> returning typ)
   end
 end
 
@@ -2076,7 +2076,7 @@ struct
         let t = stub proving_key d primary auxiliary in
         Caml.Gc.finalise delete t ; t
 
-      let dummy = foreign (func_name "dummy") (void @-> returning typ)
+      let get_dummy = foreign (func_name "dummy") (void @-> returning typ)
     end
 
     type message = Fq.t array
@@ -2099,7 +2099,7 @@ struct
       let y_s = H.hash ?message ~a ~b ~c ~delta_prime in
       Pre.verify_components ~a ~b ~c ~delta_prime ~y_s ~z vk input
 
-    let dummy () =
+    let get_dummy () =
       {a= G1.one; b= G2.one; c= G1.one; z= G1.one; delta_prime= G2.one}
   end
 end
@@ -2882,21 +2882,21 @@ let%test_module "dummy-proofs" =
     end
 
     let _proofs =
-      ( Mnt4.Default.Proof.dummy ()
-      , Mnt4.GM.Proof.dummy ()
-      , Mnt6.Default.Proof.dummy ()
-      , Mnt6.GM.Proof.dummy ()
-      , Mnt4753.Default.Proof.dummy ()
-      , Mnt4753.GM.Proof.dummy ()
-      , Mnt6753.Default.Proof.dummy ()
-      , Mnt6753.GM.Proof.dummy ()
-      , Bn128.Default.Proof.dummy ()
-      , BG.Mnt4.Proof.Pre.dummy ()
-      , BG.Mnt6.Proof.Pre.dummy ()
-      , BG.Mnt4753.Proof.Pre.dummy ()
-      , BG.Mnt6753.Proof.Pre.dummy ()
-      , BG.Mnt4.Proof.dummy ()
-      , BG.Mnt6.Proof.dummy ()
-      , BG.Mnt4753.Proof.dummy ()
-      , BG.Mnt6753.Proof.dummy () )
+      ( Mnt4.Default.Proof.get_dummy ()
+      , Mnt4.GM.Proof.get_dummy ()
+      , Mnt6.Default.Proof.get_dummy ()
+      , Mnt6.GM.Proof.get_dummy ()
+      , Mnt4753.Default.Proof.get_dummy ()
+      , Mnt4753.GM.Proof.get_dummy ()
+      , Mnt6753.Default.Proof.get_dummy ()
+      , Mnt6753.GM.Proof.get_dummy ()
+      , Bn128.Default.Proof.get_dummy ()
+      , BG.Mnt4.Proof.Pre.get_dummy ()
+      , BG.Mnt6.Proof.Pre.get_dummy ()
+      , BG.Mnt4753.Proof.Pre.get_dummy ()
+      , BG.Mnt6753.Proof.Pre.get_dummy ()
+      , BG.Mnt4.Proof.get_dummy ()
+      , BG.Mnt6.Proof.get_dummy ()
+      , BG.Mnt4753.Proof.get_dummy ()
+      , BG.Mnt6753.Proof.get_dummy () )
   end )


### PR DESCRIPTION
This PR adds `Proof.dummy : unit -> Proof.t` for all proof systems. This gives us consistent values that we can use to test that serialisations of proofs are stable from Coda.

/cc @psteckler