### PR TITLE
Add support for prover state to js_snarky

### DIFF
--- a/examples/sfbw/ex00_preimage/ex00_preimage.ml.ignore
+++ b/examples/sfbw/ex00_preimage/ex00_preimage.ml.ignore
@@ -1,12 +1,23 @@
-module Universe = (val Snarky_universe.default ())
+module rec Universe :
+  (Snarky_universe.Intf.S with type Impl.prover_state = Prover_state.t) =
+  Snarky_universe.Default (Prover_state) ()
+
+and Prover_state : sig
+  type t = Universe.Field.Constant.t [@@deriving yojson]
+end = struct
+  type t = Universe.Field.Constant.t [@@deriving yojson]
+end
+
 open! Universe.Impl
 open! Universe
-
 module Witness = Field
 
 let input = InputSpec.[(module Field)]
 
-let main (preimage : Witness.t) h () =
+let main (h : Hash.t) () =
+  let preimage =
+    exists Field.typ ~compute:(fun () -> As_prover.get_state ())
+  in
   Field.assertEqual (Hash.hash [|preimage|]) h
 
-let () = InputSpec.run_main input (module Witness) main
+let () = InputSpec.run_main input Prover_state.of_yojson main

--- a/examples/sfbw/ex00_preimage/ex00_preimage.re
+++ b/examples/sfbw/ex00_preimage/ex00_preimage.re
@@ -1,12 +1,25 @@
-module Universe = (val Snarky_universe.default());
+module rec Universe:
+  Snarky_universe.Intf.S with type Impl.prover_state = Prover_state.t =
+  Snarky_universe.Default(
+    Prover_state,
+    {},
+  )
+and Prover_state: {
+  [@deriving yojson]
+  type t = Universe.Field.Constant.t;
+} = {
+  [@deriving yojson]
+  type t = Universe.Field.Constant.t;
+};
+
 open! Universe.Impl;
 open! Universe;
 
-module Witness = Field;
-
 let input = InputSpec.[(module Field)];
 
-let main = (preimage: Witness.t, h, ()) =>
+let main = (h: Hash.t, ()) => {
+  let preimage = exists(Field.typ, ~compute=() => {As_prover.get_state()});
   Field.assertEqual(Hash.hash([|preimage|]), h);
+};
 
-InputSpec.run_main(input, (module Witness), main);
+InputSpec.run_main(input, Prover_state.of_yojson, main);

--- a/examples/sfbw/ex01_small_preimage/ex01_small_preimage.ml.ignore
+++ b/examples/sfbw/ex01_small_preimage/ex01_small_preimage.ml.ignore
@@ -1,23 +1,33 @@
-module Universe = (val Snarky_universe.default ())
-open! Universe.Impl
-open! Universe
+module rec Universe :
+  (Snarky_universe.Intf.S with type Impl.prover_state = Prover_state.t) =
+  Snarky_universe.Default (Prover_state) ()
 
-module Witness = struct
+and Prover_state : sig
+  type t = bool array [@@deriving yojson]
+
+  val length : int
+
+  val typ : (Universe.Bool.t array, t) Universe.Impl.Typ.t
+end = struct
+  open! Universe.Impl
+  open! Universe
+
+  type t = bool array [@@deriving yojson]
+
   let length = 32
-
-  type t = Bool.t array
-
-  module Constant = struct
-    type t = bool array [@@deriving yojson]
-  end
 
   let typ = Typ.array ~length Bool.typ
 end
 
+open! Universe.Impl
+open! Universe
+
 let input = InputSpec.[(module Field)]
 
-(* Proves that there is a 32-bit preimage to the hash *)
-let main (preimage : Witness.t) h () =
+let main h () =
+  let preimage =
+    exists Prover_state.typ ~compute:(fun () -> As_prover.get_state ())
+  in
   Field.assertEqual (Hash.hash [|Field.ofBits preimage|]) h
 
-let () = InputSpec.run_main input (module Witness) main
+let () = InputSpec.run_main input Prover_state.of_yojson main

--- a/examples/sfbw/ex02_merkle_list/ex02_merkle_list.ml.ignore
+++ b/examples/sfbw/ex02_merkle_list/ex02_merkle_list.ml.ignore
@@ -1,30 +1,36 @@
-module Universe = (val Snarky_universe.default ())
-open! Universe.Impl
-open! Universe
+module rec Universe :
+  (Snarky_universe.Intf.S with type Impl.prover_state = Prover_state.t) =
+  Snarky_universe.Default (Prover_state) ()
 
-module Witness = struct
+and Prover_state : sig
+  type t = Universe.Hash.Constant.t array [@@deriving yojson]
+
+  val length : int
+
+  val typ : (Universe.Hash.t array, t) Universe.Impl.Typ.t
+end = struct
+  open! Universe.Impl
+  open! Universe
+
+  type t = Hash.Constant.t array [@@deriving yojson]
+
   let length = 32
-
-  type t = Hash.t array
-
-  module Constant = struct
-    type t = Hash.Constant.t array [@@deriving yojson]
-  end
 
   let typ = Typ.array ~length Hash.typ
 end
 
+open! Universe.Impl
+open! Universe
+
 let input = InputSpec.[(module Field); (module Field)]
 
-(* Proves that there is a path [hn, ..., h1] such that
-   hash (h1, hash(h2, hash(h3, ..., hash(hn, x) ... ))) = root *)
-let main (path : Witness.t) supposed_root x () =
+let main supposed_root x () =
+  let path =
+    exists Prover_state.typ ~compute:(fun () -> As_prover.get_state ())
+  in
   let actual_root =
-    Array.fold_left (fun acc h ->
-        Hash.hash [| h; acc |])
-        x
-        path
+    Array.fold_left (fun acc h -> Hash.hash [|h; acc|]) x path
   in
   Hash.assertEqual actual_root supposed_root
 
-let () = InputSpec.run_main input (module Witness) main
+let () = InputSpec.run_main input Prover_state.of_yojson main

--- a/examples/sfbw/ex02_merkle_list/ex02_merkle_list.re
+++ b/examples/sfbw/ex02_merkle_list/ex02_merkle_list.re
@@ -1,29 +1,41 @@
-module Universe = (val Snarky_universe.default());
-open! Universe.Impl;
-open! Universe;
+module rec Universe:
+  Snarky_universe.Intf.S with type Impl.prover_state = Prover_state.t =
+  Snarky_universe.Default(
+    Prover_state,
+    {},
+  )
+and Prover_state: {
+  [@deriving yojson]
+  type t = array(Universe.Hash.Constant.t);
 
-module Witness = {
+  let length: int;
+
+  let typ: Universe.Impl.Typ.t(array(Universe.Hash.t), t);
+} = {
+  open! Universe.Impl;
+  open! Universe;
+
+  [@deriving yojson]
+  type t = array(Hash.Constant.t);
+
   let length = 32;
-
-  type t = array(Hash.t);
-
-  module Constant = {
-    [@deriving yojson]
-    type t = array(Hash.Constant.t);
-  };
 
   let typ = Typ.array(~length, Hash.typ);
 };
+
+open! Universe.Impl;
+open! Universe;
 
 let input = InputSpec.[(module Field), (module Field)];
 
 /* Proves that there is a path [hn, ..., h1] such that
    hash (h1, hash(h2, hash(h3, ..., hash(hn, x) ... ))) = root */
-let main = (path: Witness.t, supposed_root, x, ()) => {
+let main = (supposed_root, x, ()) => {
+  let path = exists(Prover_state.typ, ~compute=() => {As_prover.get_state()});
   let actual_root =
     Array.fold_left((acc, h) => Hash.hash([|h, acc|]), x, path);
 
   Hash.assertEqual(actual_root, supposed_root);
 };
 
-InputSpec.run_main(input, (module Witness), main);
+InputSpec.run_main(input, Prover_state.of_yojson, main);

--- a/examples/sfbw/ex03_merkle_tree/ex03_merkle_tree.ml.ignore
+++ b/examples/sfbw/ex03_merkle_tree/ex03_merkle_tree.ml.ignore
@@ -1,32 +1,51 @@
-module Universe = (val Snarky_universe.default ())
+module rec Universe :
+  (Snarky_universe.Intf.S with type Impl.prover_state = Prover_state.t) =
+  Snarky_universe.Default (Prover_state) ()
+
+and Prover_state : sig
+  type t = int * Universe.Hash.Constant.t array [@@deriving yojson]
+
+  val depth : int
+
+  val typ :
+    (Universe.Bool.t array * Universe.Hash.t array, t) Universe.Impl.Typ.t
+end = struct
+  open! Universe.Impl
+  open! Universe
+
+  type t = int * Hash.Constant.t array [@@deriving yojson]
+
+  let depth = 32
+
+  let typ =
+    Typ.tuple2 (MerkleTree.Index.typ ~depth) (MerkleTree.Path.typ ~depth)
+end
+
 open! Universe.Impl
 open! Universe
 
-let depth = 32
-
-module Witness = struct
-  type t = Bool.t array * Hash.t array
-
-  module Constant = struct
-    type t = int * Hash.Constant.t array [@@deriving yojson]
-  end
-
-  let typ =
-    Typ.tuple2
-      (MerkleTree.Index.typ ~depth)
-      (MerkleTree.Path.typ ~depth)
-end
+let depth = Prover_state.depth
 
 let input = InputSpec.[(module Hash); (module Field)]
 
-let main ((index, path) : Witness.t) supposed_root elt () =
+let main supposed_root elt () =
+  let index, path =
+    exists Prover_state.typ ~compute:(fun () -> As_prover.get_state ())
+  in
   let acc = ref elt in
   for i = 0 to depth - 1 do
-      let bit = index.(i) in
-      let left = Hash.( bit -? path.(i) -: !acc ) in
-      let right = Hash.( bit -? !acc -: path.(i) ) in
-      acc := Hash.hash [| left; right |]
-  done;
+    let bit = index.(i) in
+    let left =
+      let open Hash in
+      bit -? path.(i) -: !acc
+    in
+    let right =
+      let open Hash in
+      bit -? !acc -: path.(i)
+    in
+    acc := Hash.hash [|left; right|]
+  done ;
   Hash.assertEqual !acc supposed_root
 
-let () = InputSpec.run_main input (module Witness) main
+;;
+InputSpec.run_main input Prover_state.of_yojson main

--- a/examples/sfbw/ex_bools/ex_bools.re
+++ b/examples/sfbw/ex_bools/ex_bools.re
@@ -1,45 +1,60 @@
-module Universe = (val Snarky_universe.default ());
+module rec Universe:
+  Snarky_universe.Intf.S with type Impl.prover_state = Prover_state.t =
+  Snarky_universe.Default(
+    Prover_state,
+    {},
+  )
+and Prover_state: {
+  [@deriving yojson]
+  type t = Universe.Field.Constant.t;
+} = {
+  open! Universe.Impl;
+  open! Universe;
+
+  [@deriving yojson]
+  type t = Field.Constant.t;
+};
 
 open! Universe.Impl;
 open! Universe;
 
-module Witness = Field;
-
 let input = InputSpec.[(module Hash)];
 
 /* Let's say field element is "special" if it is either
-  - A perfect square and less than 2^32 and even.
-  - Not a perfect square and less than 256 = 2^8
-*/
+     - A perfect square and less than 2^32 and even.
+     - Not a perfect square and less than 256 = 2^8
+   */
 
-let assertSpecial = (x) => {
+let assertSpecial = x => {
   /* This implicitly asserts that x fits in 32 bits, which means it's < 2^32. */
   let bits = Field.toBits(~length=32, x);
-  let fitsIn8Bits = Bool.negate(Bool.any(Array.to_list(Array.sub(bits, 8, 24))));
+  let fitsIn8Bits =
+    Bool.negate(Bool.any(Array.to_list(Array.sub(bits, 8, 24))));
   let isSquare = Field.isSquare(x);
   Bool.assertAny([
-    Bool.all([ isSquare, Bool.negate(bits[31]) ]),
-    Bool.all([ Bool.negate(isSquare), fitsIn8Bits ])
+    Bool.all([isSquare, Bool.negate(bits[31])]),
+    Bool.all([Bool.negate(isSquare), fitsIn8Bits]),
   ]);
 };
 
 /*
-Exercise ideas
-- arithmetiziation: implement boolean ops
-- internal handlers
+ Exercise ideas
+ - arithmetiziation: implement boolean ops
+ - internal handlers
 
-Examples with integers
-- 
+ Examples with integers
+ -
 
-/* Floating point arithmetic */
-Fun exercises to give people to do
-- 
-*/
+ /* Floating point arithmetic */
+ Fun exercises to give people to do
+ -
+ */
 
 /* Proves that we know a preimage to the given hash which is special */
-let main = (preimage: Witness.t, h, ()) => {
+let main = (h, ()) => {
+  let preimage = exists(Field.typ, ~compute=() => {As_prover.get_state()});
   Field.assertEqual(Hash.hash([|preimage|]), h);
   assertSpecial(preimage);
 };
 
-InputSpec.run_main(input, (module Witness), main);
+InputSpec.run_main(input, Prover_state.of_yojson, main);

--- a/snarky_curve/snarky_curve.ml
+++ b/snarky_curve/snarky_curve.ml
@@ -45,7 +45,7 @@ module type Constant_intf = sig
 end
 
 module type Inputs_intf = sig
-  module Impl : Snarky.Snark_intf.Run with type prover_state = unit
+  module Impl : Snarky.Snark_intf.Run
 
   module F : sig
     include
@@ -177,7 +177,7 @@ module Make_checked (Inputs : Inputs_intf) = struct
         ~there:Constant.to_affine_exn ~back:Constant.of_affine
     in
     { unchecked with
-      check= (fun t -> make_checked (fun () -> assert_on_curve t)) }
+      check= (fun t -> make_stateless_checked (fun () -> assert_on_curve t)) }
 
   open Bitstring_lib.Bitstring
 

--- a/snarky_universe/group.ml
+++ b/snarky_universe/group.ml
@@ -153,9 +153,7 @@ module Make (C : sig
 
   val curve : field Curve.t
 end)
-(Impl : Snarky.Snark_intf.Run
-        with type prover_state = unit
-         and type field = C.field)
+(Impl : Snarky.Snark_intf.Run with type field = C.field)
 () =
 struct
   let {a; b; one} = params_of_curve C.curve

--- a/snarky_universe/intf.ml
+++ b/snarky_universe/intf.ml
@@ -107,7 +107,7 @@ module Field = struct
 end
 
 module type S = sig
-  module Impl : Snarky.Snark_intf.Run with type prover_state = unit
+  module Impl : Snarky.Snark_intf.Run
 
   module Bool : sig
     open Impl

--- a/snarky_universe/snarky_universe.mli
+++ b/snarky_universe/snarky_universe.mli
@@ -1,3 +1,5 @@
+module Intf = Intf
+
 type proof_system = Groth16 | GrothMaller17
 
 module Make (C : sig
@@ -6,11 +8,26 @@ module Make (C : sig
   val curve : field Curve.t
 
   val system : proof_system
+end) (Prover_state : sig
+  type t
 end)
-() : Intf.S
+() : Intf.S with type Impl.prover_state = Prover_state.t
 
 val create :
-  'f Curve.t -> proof_system -> (module Intf.S with type Impl.field = 'f)
+     'f Curve.t
+  -> proof_system
+  -> (module Intf.S with type Impl.field = 'f and type Impl.prover_state = 'a)
 
 val default :
-  unit -> (module Intf.S with type Impl.field = Snarky.Backends.Bn128.Field.t)
+     unit
+  -> (module Intf.S
+        with type Impl.field = Snarky.Backends.Bn128.Field.t
+         and type Impl.prover_state = 'a)
+
+module Default (Prover_state : sig
+  type t
+end)
+() :
+  Intf.S
+  with type Impl.prover_state = Prover_state.t
+   and type Impl.field = Snarky.Backends.Bn128.Field.t

--- a/src/snark_intf.ml
+++ b/src/snark_intf.ml
@@ -2197,6 +2197,9 @@ module type Run_basic = sig
 
   val make_checked : (unit -> 'a) -> ('a, prover_state, field) Types.Checked.t
 
+  val make_stateless_checked :
+    (unit -> 'a) -> ('a, unit, field) Types.Checked.t
+
   val constraint_system :
        exposing:(unit -> 'a, _, 'k_var, _) Data_spec.t
     -> 'k_var


### PR DESCRIPTION
This PR adds direct support for `prover_state` to `js_snarky`. This mean that
* the prover can be passed data without needing to expose it directly in the R1CS
* the hack for working around this limitation can be removed.