### PR TITLE
Store R1CS hash with keys by default, re-generate when reading

### DIFF
--- a/snarkyjs/bin/index.js
+++ b/snarkyjs/bin/index.js
@@ -12,7 +12,7 @@ function fail(err) {
 };
 
 if (arguments.length === 0) {
-  console.log("Expected an argument.\nPossible commands are:\n  init\t\tInitialize a js_snarky project");
+  console.log("Expected an argument.\nPossible commands are:\n  init\t\tInitialize a snarkyjs project");
   process.exit(1);
 }
 else if (arguments[0] === "init") {
@@ -32,7 +32,7 @@ else if (arguments[0] === "init") {
  *****************************************************************************/
     if (!fs.existsSync("src/dune")) {
       const dune = `(executable
- (name js_snarky_project)
+ (name snarkyjs_project)
  (modes native)
  (libraries core_kernel snarky snarky_universe)
  (preprocess (pps ppx_snarky ppx_jane ppx_deriving ppx_deriving_yojson)))
@@ -40,9 +40,9 @@ else if (arguments[0] === "init") {
       fs.writeFile("src/dune", dune, fail);
     }
 /*****************************************************************************
- * src/js_snarky_project.ml.ignore
+ * src/snarkyjs_project.ml.ignore
  *****************************************************************************/
-    if (!fs.existsSync("src/js_snarky_project.ml.ignore")) {
+    if (!fs.existsSync("src/snarkyjs_project.ml.ignore")) {
       const main = `module Universe = (val Snarky_universe.default ())
 
 open! Universe.Impl
@@ -77,12 +77,12 @@ let main witness field_elt _bit () =
 let () =
   InputSpec.run_main input (module Witness) main
 `;
-      fs.writeFile("src/js_snarky_project.ml.ignore", main, fail);
+      fs.writeFile("src/snarkyjs_project.ml.ignore", main, fail);
     }
 /*****************************************************************************
- * src/js_snarky_project.re
+ * src/snarkyjs_project.re
  *****************************************************************************/
-    if (!fs.existsSync("src/js_snarky_project.re")) {
+    if (!fs.existsSync("src/snarkyjs_project.re")) {
       const main = `module Universe = (val Snarky_universe.default());
 
 open! Universe.Impl;
@@ -121,16 +121,7 @@ let main = (witness, field_elt, _bit, ()) => {
 
 let () = InputSpec.run_main(input, (module Witness), main);
 `;
-      fs.writeFile("src/js_snarky_project.re", main, fail);
-    }
-/*****************************************************************************
- * src/run_snarky.ml
- *****************************************************************************/
-    if (!fs.existsSync("src/run_snarky.ml")) {
-      const run_snarky = `let () =
-  Main.Universe.InputSpec.run_main Main.input (module Main.Witness) Main.main
-`;
-      fs.writeFile("src/run_snarky.ml", run_snarky, fail);
+      fs.writeFile("src/snarkyjs_project.re", main, fail);
     }
   };
   if (fs.existsSync("src")) {
@@ -142,8 +133,8 @@ let () = InputSpec.run_main(input, (module Witness), main);
  * index.js
  *****************************************************************************/
   if (!fs.existsSync("index.js")) {
-    const index = `const Snarky = require("js_snarky");
-const snarky = new Snarky("src/js_snarky_project.exe");
+    const index = `const Snarky = require("snarkyjs");
+const snarky = new Snarky("src/snarkyjs_project.exe");
 
 var prove_and_verify = function(statement, witness) {
   return snarky.prove({
@@ -182,9 +173,9 @@ prove_and_verify(["2", true], "9").then(function() {
   "description": "",
   "main": "index.js",
   "scripts": {
-    "build": "dune build src/js_snarky_project.exe",
+    "build": "dune build src/snarkyjs_project.exe",
     "clean": "dune clean",
-    "watch": "dune build -w src/js_snarky_project.exe"
+    "watch": "dune build -w src/snarkyjs_project.exe"
   },
   "author": "you",
   "license": "UNLICENSED"
@@ -201,6 +192,6 @@ prove_and_verify(["2", true], "9").then(function() {
     fs.writeFile("dune", pkg, fail);
   }
 } else {
-  console.log("Unrecognised command " + arguments[0] + ".\nPossible commands are:\n  init\t\tInitialize a js_snarky project");
+  console.log("Unrecognised command " + arguments[0] + ".\nPossible commands are:\n  init\t\tInitialize a snarkyjs project");
   process.exit(1);
 }

--- a/snarkyjs/index.js
+++ b/snarkyjs/index.js
@@ -78,9 +78,30 @@ module.exports = exports = function (name) {
         });
       }, function (err) { return err; });
   };
+  var generate_keys = function() {
+    var query_json = JSON.stringify({"command": "verify"});
+    return communicate(query_json).then(function (response_json) {
+        return new Promise (function (resolve, reject) {
+          var response = JSON.parse(response_json);
+          if (response.name == "error") {
+            reject(new Error(response.message));
+          } else if (response.name == "keys_generated") {
+            resolve({
+              "proving_key_path": response.proving_key_path,
+              "verification_key_path": response.verification_key_path
+            });
+          } else {
+            reject(new Error(
+              "Expected name 'keys_generated', but received '" + response.name + "' from process."
+            ));
+          }
+        });
+      }, function (err) { return err; });
+  };
   return {
     prove: prove,
     verify: verify,
+    generate_keys: generate_keys,
     kill: function() { snarky_process.kill('SIGINT'); }
   };
 };

--- a/snarkyjs/index.js
+++ b/snarkyjs/index.js
@@ -79,7 +79,7 @@ module.exports = exports = function (name) {
       }, function (err) { return err; });
   };
   var generate_keys = function() {
-    var query_json = JSON.stringify({"command": "verify"});
+    var query_json = JSON.stringify({"command": "generate_keys"});
     return communicate(query_json).then(function (response_json) {
         return new Promise (function (resolve, reject) {
           var response = JSON.parse(response_json);

--- a/src/backend_extended.ml
+++ b/src/backend_extended.ml
@@ -144,6 +144,8 @@ module type S = sig
 
     val r1cs_constraint_system : t -> R1CS_constraint_system.t
 
+    val set_constraint_system : t -> R1CS_constraint_system.t -> unit
+
     include Stringable.S with type t := t
 
     val to_bigstring : t -> Bigstring.t

--- a/src/backend_intf.ml
+++ b/src/backend_intf.ml
@@ -101,6 +101,8 @@ module type S = sig
 
     val r1cs_constraint_system : t -> R1CS_constraint_system.t
 
+    val set_constraint_system : t -> R1CS_constraint_system.t -> unit
+
     val to_string : t -> string
 
     val of_string : string -> t

--- a/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_curve.cpp.template
+++ b/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_curve.cpp.template
@@ -637,6 +637,11 @@ r1cs_constraint_system<FieldT>* CURVE_PREFIX(proving_key_r1cs_constraint_system)
   return &pk->constraint_system;
 }
 
+void CURVE_PREFIX(proving_key_r1cs_set_constraint_system)(
+    r1cs_gg_ppzksnark_proving_key<ppT>* pk, r1cs_constraint_system<FieldT>* r1cs) {
+  pk->constraint_system = *r1cs;
+}
+
 std::string* CURVE_PREFIX(proving_key_to_string)(r1cs_gg_ppzksnark_proving_key<ppT>* pk) {
   std::stringstream stream;
   stream << *pk;
@@ -878,6 +883,11 @@ r1cs_constraint_system<FieldT>* CURVE_PREFIX(gm_proving_key_r1cs_constraint_syst
   return &pk->constraint_system;
 }
 
+void CURVE_PREFIX(gm_proving_key_r1cs_set_constraint_system)(
+    r1cs_se_ppzksnark_proving_key<ppT>* pk, r1cs_constraint_system<FieldT>* r1cs) {
+  pk->constraint_system = *r1cs;
+}
+
 std::string* CURVE_PREFIX(gm_proving_key_to_string)(r1cs_se_ppzksnark_proving_key<ppT>* pk) {
   std::stringstream stream;
   stream << *pk;
@@ -1040,6 +1050,11 @@ libff::G1<ppT>* CURVE_PREFIX(gm_proof_c)(r1cs_se_ppzksnark_proof<ppT>* proof) {
 r1cs_constraint_system<FieldT>* CURVE_PREFIX(bg_proving_key_r1cs_constraint_system)(
     r1cs_bg_ppzksnark_proving_key<ppT>* pk) {
   return &pk->constraint_system;
+}
+
+void CURVE_PREFIX(bg_proving_key_r1cs_set_constraint_system)(
+    r1cs_bg_ppzksnark_proving_key<ppT>* pk, r1cs_constraint_system<FieldT>* r1cs) {
+  pk->constraint_system = *r1cs;
 }
 
 std::string* CURVE_PREFIX(bg_proving_key_to_string)(r1cs_bg_ppzksnark_proving_key<ppT>* pk) {

--- a/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_curve.cpp.template
+++ b/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_curve.cpp.template
@@ -637,7 +637,7 @@ r1cs_constraint_system<FieldT>* CURVE_PREFIX(proving_key_r1cs_constraint_system)
   return &pk->constraint_system;
 }
 
-void CURVE_PREFIX(proving_key_r1cs_set_constraint_system)(
+void CURVE_PREFIX(proving_key_set_constraint_system)(
     r1cs_gg_ppzksnark_proving_key<ppT>* pk, r1cs_constraint_system<FieldT>* r1cs) {
   pk->constraint_system = *r1cs;
 }
@@ -883,7 +883,7 @@ r1cs_constraint_system<FieldT>* CURVE_PREFIX(gm_proving_key_r1cs_constraint_syst
   return &pk->constraint_system;
 }
 
-void CURVE_PREFIX(gm_proving_key_r1cs_set_constraint_system)(
+void CURVE_PREFIX(gm_proving_key_set_constraint_system)(
     r1cs_se_ppzksnark_proving_key<ppT>* pk, r1cs_constraint_system<FieldT>* r1cs) {
   pk->constraint_system = *r1cs;
 }
@@ -1052,7 +1052,7 @@ r1cs_constraint_system<FieldT>* CURVE_PREFIX(bg_proving_key_r1cs_constraint_syst
   return &pk->constraint_system;
 }
 
-void CURVE_PREFIX(bg_proving_key_r1cs_set_constraint_system)(
+void CURVE_PREFIX(bg_proving_key_set_constraint_system)(
     r1cs_bg_ppzksnark_proving_key<ppT>* pk, r1cs_constraint_system<FieldT>* r1cs) {
   pk->constraint_system = *r1cs;
 }

--- a/src/libsnark.ml
+++ b/src/libsnark.ml
@@ -1448,6 +1448,8 @@ module Make_proof_system_keys (M : Proof_system_inputs_intf) = struct
     val to_bigstring : t -> Bigstring.t
 
     val of_bigstring : Bigstring.t -> t
+
+    val set_constraint_system : t -> M.R1CS_constraint_system.t -> unit
   end = struct
     include Proving_key.Make
               (Ctypes_foreign)
@@ -1554,6 +1556,11 @@ module Make_proof_system_keys (M : Proof_system_inputs_intf) = struct
         let t = stub str in
         Caml.Gc.finalise (fun _ -> delete t) t ;
         t
+
+    let set_constraint_system : t -> M.R1CS_constraint_system.t -> unit =
+      foreign
+        (func_name "set_constraint_system")
+        (typ @-> M.R1CS_constraint_system.typ @-> returning void)
   end
 
   module Verification_key : sig

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -52,8 +52,26 @@ struct
       create ?message key ~primary ~auxiliary
   end
 
-  module Verification_key = Verification_key
-  module Proving_key = Proving_key
+  module Verification_key = struct
+    include Verification_key
+
+    type verification_key = t [@@deriving bin_io]
+
+    module With_r1cs_hash = struct
+      type t = Md5.t * verification_key [@@deriving bin_io]
+    end
+  end
+
+  module Proving_key = struct
+    include Proving_key
+
+    type proving_key = t [@@deriving bin_io]
+
+    module With_r1cs_hash = struct
+      type t = Md5.t * proving_key [@@deriving bin_io]
+    end
+  end
+
   module Keypair = Keypair
   module Var = Var
   module Field0 = Field
@@ -677,8 +695,10 @@ struct
         ; handler: Request.Handler.t
         ; mutable proving_key: Proving_key.t option
         ; mutable verification_key: Verification_key.t option
+        ; mutable r1cs_digest: Md5.t option
         ; proving_key_path: string option
-        ; verification_key_path: string option }
+        ; verification_key_path: string option
+        ; keys_have_hashes: bool }
 
       let rec allocate_inputs : type checked k1 k2.
              reduce_to_prover:(int ref -> checked -> checked)
@@ -700,8 +720,10 @@ struct
             ; handler= Request.Handler.fail
             ; proving_key= None
             ; verification_key= None
+            ; r1cs_digest= None
             ; proving_key_path= None
-            ; verification_key_path= None }
+            ; verification_key_path= None
+            ; keys_have_hashes= false }
         | {alloc; check; store; _} :: t' ->
             let before_input = !next_input in
             let var = Typ.Alloc.run alloc (alloc_var next_input) in
@@ -719,8 +741,10 @@ struct
                 ; handler
                 ; proving_key
                 ; verification_key
+                ; r1cs_digest
                 ; proving_key_path
-                ; verification_key_path } =
+                ; verification_key_path
+                ; keys_have_hashes } =
               allocate_inputs ~reduce_to_prover check_inputs next_input t'
                 compute
             in
@@ -756,11 +780,13 @@ struct
             ; handler
             ; proving_key
             ; verification_key
+            ; r1cs_digest
             ; proving_key_path
-            ; verification_key_path }
+            ; verification_key_path
+            ; keys_have_hashes }
 
       let create ~reduce_to_prover ?proving_key ?verification_key
-          ?proving_key_path ?verification_key_path
+          ?proving_key_path ?verification_key_path ?(keys_with_hashes = true)
           ?(handlers = ([] : Handler.t list)) ?(reduce = false) ~public_input
           compute =
         let next_input = ref 1 in
@@ -779,7 +805,8 @@ struct
         ; verification_key
         ; proving_key_path
         ; verification_key_path
-        ; handler }
+        ; handler
+        ; keys_have_hashes= keys_with_hashes }
 
       let run_proof_system ~run ?(reduce = !reduce_to_prover) ~input ?system
           ?eval_constraints ?(handlers = ([] : Handler.t list)) proof_system s
@@ -804,6 +831,8 @@ struct
         in
         let prover_state, a = run compute prover_state in
         Option.iter prover_state.system ~f:(fun system ->
+            proof_system.r1cs_digest
+            <- Some (R1CS_constraint_system.digest system) ;
             let aux_input_size =
               !(prover_state.next_auxiliary) - (1 + num_inputs)
             in
@@ -819,20 +848,36 @@ struct
         system
 
       let digest ~run proof_system =
-        let system = constraint_system ~run proof_system in
-        R1CS_constraint_system.digest system
+        match proof_system.r1cs_digest with
+        | Some digest ->
+            (* Use cached digest. *)
+            digest
+        | None ->
+            let system = constraint_system ~run proof_system in
+            R1CS_constraint_system.digest system
 
       let generate_keypair ~run proof_system =
-        let keypair = Keypair.generate (constraint_system ~run proof_system) in
+        let system = constraint_system ~run proof_system in
+        let keypair = Keypair.generate system in
         proof_system.proving_key <- Some keypair.pk ;
         proof_system.verification_key <- Some keypair.vk ;
         (* Write keys to the corresponding files. *)
-        Option.iter proof_system.proving_key_path ~f:(fun path ->
-            Out_channel.write_all path ~data:(Proving_key.to_string keypair.pk)
-        ) ;
-        Option.iter proof_system.verification_key_path ~f:(fun path ->
-            Out_channel.write_all path
-              ~data:(Verification_key.to_string keypair.vk) ) ;
+        if proof_system.keys_have_hashes then (
+          let digest = digest ~run proof_system in
+          Option.iter proof_system.proving_key_path ~f:(fun path ->
+              Bin_prot_io.write
+                (module Proving_key.With_r1cs_hash)
+                path ~data:(digest, keypair.pk) ) ;
+          Option.iter proof_system.verification_key_path ~f:(fun path ->
+              Bin_prot_io.write
+                (module Verification_key.With_r1cs_hash)
+                path ~data:(digest, keypair.vk) ) )
+        else (
+          Option.iter proof_system.proving_key_path ~f:(fun path ->
+              Bin_prot_io.write (module Proving_key) path ~data:keypair.pk ) ;
+          Option.iter proof_system.verification_key_path ~f:(fun path ->
+              Bin_prot_io.write (module Verification_key) path ~data:keypair.vk
+          ) ) ;
         keypair
 
       let run_with_input ~run ?reduce ~public_input ?system ?eval_constraints
@@ -883,18 +928,53 @@ struct
         Or_error.map ~f:(Fn.const ())
           (run_checked' ~run ?reduce ~public_input ?handlers proof_system s)
 
-      let read_proving_key proof_system =
+      let read_proving_key ?r1cs proof_system =
         match proof_system.proving_key_path with
         | Some path -> (
-          try Some (Proving_key.of_string (In_channel.read_all path))
+          try
+            let ret =
+              match r1cs with
+              | Some r1cs ->
+                  let digest = R1CS_constraint_system.digest r1cs in
+                  proof_system.r1cs_digest <- Some digest ;
+                  let digest', pk =
+                    Bin_prot_io.read (module Proving_key.With_r1cs_hash) path
+                  in
+                  if Md5.equal digest digest' then (
+                    (* We don't store the R1CS for keys, so set it here if we
+                       know it.
+                    *)
+                    Backend.Proving_key.set_constraint_system pk r1cs ;
+                    Some pk )
+                  else None
+              | None ->
+                  Some (Bin_prot_io.read (module Proving_key) path)
+            in
+            Option.iter ret ~f:(fun key -> proof_system.proving_key <- Some key) ;
+            ret
           with _ -> None )
         | None ->
             None
 
-      let read_verification_key proof_system =
+      let read_verification_key ?digest proof_system =
         match proof_system.verification_key_path with
         | Some path -> (
-          try Some (Verification_key.of_string (In_channel.read_all path))
+          try
+            let ret =
+              match digest with
+              | Some digest ->
+                  let digest', vk =
+                    Bin_prot_io.read
+                      (module Verification_key.With_r1cs_hash)
+                      path
+                  in
+                  if Md5.equal digest digest' then Some vk else None
+              | None ->
+                  Some (Bin_prot_io.read (module Verification_key) path)
+            in
+            Option.iter ret ~f:(fun key ->
+                proof_system.verification_key <- Some key ) ;
+            ret
           with _ -> None )
         | None ->
             None
@@ -906,7 +986,13 @@ struct
             ~f:(fun f -> f ())
             [ (fun () -> proving_key)
             ; (fun () -> proof_system.proving_key)
-            ; (fun () -> read_proving_key proof_system)
+            ; (fun () ->
+                let r1cs =
+                  if proof_system.keys_have_hashes then
+                    Some (constraint_system ~run proof_system)
+                  else None
+                in
+                read_proving_key ?r1cs proof_system )
             ; (fun () -> Some (generate_keypair ~run proof_system).pk) ]
         in
         let system =
@@ -921,7 +1007,8 @@ struct
         let {input; aux; _} = state in
         Proof.create ?message proving_key ~primary:input ~auxiliary:aux
 
-      let verify ~public_input ?verification_key ?message proof_system proof =
+      let verify ~run ~public_input ?verification_key ?message proof_system
+          proof =
         let input =
           proof_system.provide_inputs (Field.Vector.create ()) public_input
         in
@@ -930,7 +1017,13 @@ struct
             ~f:(fun f -> f ())
             [ (fun () -> verification_key)
             ; (fun () -> proof_system.verification_key)
-            ; (fun () -> read_verification_key proof_system)
+            ; (fun () ->
+                let digest =
+                  if proof_system.keys_have_hashes then
+                    Some (digest ~run proof_system)
+                  else None
+                in
+                read_verification_key ?digest proof_system )
             ; (fun () ->
                 failwith
                   "Could not verify the proof; no verification key has been \
@@ -1577,10 +1670,11 @@ struct
     type ('a, 's, 'inputs) t = (('a, 's) Checked.t, 'inputs, 's) proof_system
 
     let create ?proving_key ?verification_key ?proving_key_path
-        ?verification_key_path ?handlers ?reduce ~public_input checked =
+        ?verification_key_path ?keys_with_hashes ?handlers ?reduce
+        ~public_input checked =
       create ~reduce_to_prover:Runner.reduce_to_prover ?proving_key
-        ?verification_key ?proving_key_path ?verification_key_path ?handlers
-        ?reduce ~public_input checked
+        ?verification_key ?proving_key_path ?verification_key_path
+        ?keys_with_hashes ?handlers ?reduce ~public_input checked
 
     let constraint_system (proof_system : _ t) =
       constraint_system ~run:Checked.run proof_system
@@ -1606,7 +1700,8 @@ struct
         ?message proof_system
 
     let verify ~public_input ?verification_key ?message (proof_system : _ t) =
-      verify ~public_input ?verification_key ?message proof_system
+      verify ~run:Checked.run ~public_input ?verification_key ?message
+        proof_system
 
     let generate_witness ~public_input ?handlers ?reduce (proof_system : _ t) =
       generate_witness ~run:Checked.run ~public_input ?handlers ?reduce
@@ -2235,11 +2330,13 @@ module Run = struct
         (unit -> 'a, 'public_input, prover_state) proof_system
 
       let create ?proving_key ?verification_key ?proving_key_path
-          ?verification_key_path ?handlers ~public_input checked =
+          ?verification_key_path ?keys_with_hashes ?handlers ~public_input
+          checked =
         create
           ~reduce_to_prover:(fun _i f -> f)
           ?proving_key ?verification_key ?proving_key_path
-          ?verification_key_path ?handlers ~public_input checked
+          ?verification_key_path ?keys_with_hashes ?handlers ~public_input
+          checked
 
       let mark_active ~f =
         let counters = !active_counters in
@@ -2284,7 +2381,7 @@ module Run = struct
 
       let verify ~public_input ?verification_key ?message (proof_system : _ t)
           =
-        verify ~public_input ?verification_key ?message proof_system
+        verify ~run ~public_input ?verification_key ?message proof_system
 
       let generate_witness ~public_input ?handlers (proof_system : _ t) s =
         mark_active ~f:(fun () ->

--- a/src/snark_intf.ml
+++ b/src/snark_intf.ml
@@ -19,6 +19,8 @@ module type Basic = sig
   module Proving_key : sig
     type t [@@deriving bin_io]
 
+    type proving_key = t [@@deriving bin_io]
+
     val to_string : t -> string
 
     val of_string : string -> t
@@ -26,12 +28,18 @@ module type Basic = sig
     val to_bigstring : t -> Bigstring.t
 
     val of_bigstring : Bigstring.t -> t
+
+    module With_r1cs_hash : sig
+      type t = Md5.t * proving_key [@@deriving bin_io]
+    end
   end
 
   (** The {!module:Backend_intf.S.Verification_key} module from the backend. *)
   module Verification_key : sig
     type t [@@deriving bin_io]
 
+    type verification_key = t [@@deriving bin_io]
+
     val to_string : t -> string
 
     val of_string : string -> t
@@ -39,6 +47,10 @@ module type Basic = sig
     val to_bigstring : t -> Bigstring.t
 
     val of_bigstring : Bigstring.t -> t
+
+    module With_r1cs_hash : sig
+      type t = Md5.t * verification_key [@@deriving bin_io]
+    end
   end
 
   (** The finite field over which the R1CS operates. *)
@@ -989,6 +1001,7 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
       -> ?verification_key:Verification_key.t
       -> ?proving_key_path:string
       -> ?verification_key_path:string
+      -> ?keys_with_hashes:bool
       -> ?handlers:Handler.t list
       -> ?reduce:bool
       -> public_input:( ('a, 's) Checked.t
@@ -1014,6 +1027,10 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
           the verification key can be found. If the file does not exist and no
           [verification_key] argument is given, the generated key will be
           written to this file.
+        - [keys_with_hashes] determines whether keys read from and written to
+          the [proving_key_path] and [verification_key_path] should include a
+          MD5 digest of the constraint system.
+          Default value: [true].
         - [handlers] -- optional, the list of handlers that should be used to
           handle requests made from the checked computation
         - [reduce] -- optional, default [false], whether to perform the
@@ -1508,6 +1525,8 @@ module type Run_basic = sig
   module Proving_key : sig
     type t [@@deriving bin_io]
 
+    type proving_key = t [@@deriving bin_io]
+
     val to_string : t -> string
 
     val of_string : string -> t
@@ -1515,12 +1534,18 @@ module type Run_basic = sig
     val to_bigstring : t -> Bigstring.t
 
     val of_bigstring : Bigstring.t -> t
+
+    module With_r1cs_hash : sig
+      type t = Md5.t * proving_key [@@deriving bin_io]
+    end
   end
 
   (** The {!module:Backend_intf.S.Verification_key} module from the backend. *)
   module Verification_key : sig
     type t [@@deriving bin_io]
 
+    type verification_key = t [@@deriving bin_io]
+
     val to_string : t -> string
 
     val of_string : string -> t
@@ -1528,6 +1553,10 @@ module type Run_basic = sig
     val to_bigstring : t -> Bigstring.t
 
     val of_bigstring : Bigstring.t -> t
+
+    module With_r1cs_hash : sig
+      type t = Md5.t * verification_key [@@deriving bin_io]
+    end
   end
 
   (** The rank-1 constraint system used by this instance. See
@@ -2083,6 +2112,7 @@ module type Run_basic = sig
       -> ?verification_key:Verification_key.t
       -> ?proving_key_path:string
       -> ?verification_key_path:string
+      -> ?keys_with_hashes:bool
       -> ?handlers:Handler.t list
       -> public_input:( unit -> 'a
                       , unit

--- a/src/toplevel.ml
+++ b/src/toplevel.ml
@@ -505,6 +505,13 @@ struct
               Yojson.Safe.pretty_to_channel stdout
                 (`Assoc
                   [("name", `String "verified"); ("verified", `Bool verified)])
+          | Some (`String "generate_keys") | Some (`String "generate-keys") ->
+              ignore (Proof_system.generate_keypair proof_system) ;
+              Yojson.Safe.pretty_to_channel stdout
+                (`Assoc
+                  [ ("name", `String "keys_generated")
+                  ; ("proving_key_path", `String "proving_key.pk")
+                  ; ("verification_key_path", `String "verification_key.vk") ])
           | Some _ ->
               report_error ~full:"unknown command." ~json:"Unknown command"
           | None ->


### PR DESCRIPTION
This PR tweaks the `Proof_system` interface to
* by default, store the r1cs hash with the proving key
* reject the proving key if the r1cs hash doesn't match
  - this causes a fresh key to be generated

This also tidies up the `snarkyjs` node command, so the names match the `js_snarky` -> `snarkyjs` change, and so that the default set-up steps work again with:
```bash
sudo npm install -g path/to/snarkyjs
cd new/project/directory
snarkyjs init ; npm link snarkyjs
node index.js
```