### PR TITLE
[Meja] Scoped implicits

### DIFF
--- a/meja/ocaml/of_typedast.ml
+++ b/meja/ocaml/of_typedast.ml
@@ -418,6 +418,12 @@ let rec of_expression_desc ?loc = function
       Exp.let_ ?loc Nonrecursive
         [Vb.mk (of_pattern p) (of_expression e_rhs)]
         (of_expression e)
+  | Texp_instance (name, e_rhs, e) ->
+      Exp.let_ ?loc Nonrecursive
+        [ Vb.mk
+            (Pat.var ~loc:name.loc (of_ident_loc name))
+            (of_expression e_rhs) ]
+        (of_expression e)
   | Texp_tuple es ->
       Exp.tuple ?loc (List.map ~f:of_expression es)
   | Texp_match (e, cases) ->

--- a/meja/ocaml/of_typedast.ml
+++ b/meja/ocaml/of_typedast.ml
@@ -553,6 +553,9 @@ let rec of_statement_desc ?loc = function
         (Mtd.mk ?loc ?typ:(of_module_sig msig) (of_ident_loc name))
   | Tstmt_open name ->
       Str.open_ ?loc (Opn.mk ?loc (Of_ocaml.open_of_name (of_path_loc name)))
+  | Tstmt_open_instance _ ->
+      Str.eval ?loc
+        (Exp.construct ?loc (Location.mknoloc (Longident.Lident "()")) None)
   | Tstmt_typeext (variant, ctors) ->
       let params =
         List.map variant.var_params ~f:(fun typ -> (of_type_expr typ, Invariant)

--- a/meja/ocaml/to_ocaml.ml
+++ b/meja/ocaml/to_ocaml.ml
@@ -249,6 +249,9 @@ let rec of_statement_desc ?loc = function
       Str.modtype ?loc (Mtd.mk ?loc ?typ:(of_module_sig msig) name)
   | Pstmt_open name ->
       Str.open_ ?loc (Opn.mk ?loc (Of_ocaml.open_of_name name))
+  | Pstmt_open_instance _ ->
+      Str.eval ?loc
+        (Exp.construct ?loc (Location.mknoloc (Longident.Lident "()")) None)
   | Pstmt_typeext (variant, ctors) ->
       let params =
         List.map variant.var_params ~f:(fun typ -> (of_type_expr typ, Invariant)

--- a/meja/ocaml/to_ocaml.ml
+++ b/meja/ocaml/to_ocaml.ml
@@ -116,6 +116,10 @@ let rec of_expression_desc ?loc = function
       Exp.let_ ?loc Nonrecursive
         [Vb.mk (of_pattern p) (of_expression e_rhs)]
         (of_expression e)
+  | Pexp_instance (name, e_rhs, e) ->
+      Exp.let_ ?loc Nonrecursive
+        [Vb.mk (Pat.var ~loc:name.loc name) (of_expression e_rhs)]
+        (of_expression e)
   | Pexp_tuple es ->
       Exp.tuple ?loc (List.map ~f:of_expression es)
   | Pexp_match (e, cases) ->

--- a/meja/src/envi.ml
+++ b/meja/src/envi.ml
@@ -22,7 +22,6 @@ type error =
   | Lident_unhandled of string * Longident.t
   | Constraints_not_satisfied of type_expr * type_decl
   | No_unifiable_implicit
-  | Multiple_instances of type_expr
   | Recursive_load of string
   | Predeclared_types of Ident.t list
   | Functor_in_module_sig
@@ -32,24 +31,12 @@ exception Error of Location.t * error
 
 module TypeEnvi = struct
   type t =
-    { instance_id: int
-    ; implicit_vars: Typedast.expression list
+    { implicit_vars: Typedast.expression list
     ; implicit_id: int
-    ; instances: (int * type_expr) list
     ; predeclared_types: int IdTbl.t }
 
   let empty =
-    { instance_id= 1
-    ; implicit_id= 1
-    ; implicit_vars= []
-    ; instances= []
-    ; predeclared_types= IdTbl.empty }
-
-  let next_instance_id env =
-    (env.instance_id, {env with instance_id= env.instance_id + 1})
-
-  let add_implicit_instance id typ env =
-    {env with instances= (id, typ) :: env.instances}
+    {implicit_id= 1; implicit_vars= []; predeclared_types= IdTbl.empty}
 end
 
 type 'a or_deferred =
@@ -80,7 +67,10 @@ module Scope = struct
     ; ctors: (type_decl * int) IdTbl.t
     ; modules: t or_path IdTbl.t
     ; module_types: t or_path IdTbl.t
-    ; instances: Path.t Int.Map.t
+    ; instances: (Path.t * Path.t * type_expr) list
+          (* First path is relative to the scope, second is relative to the
+             current scope.
+          *)
     ; mode: mode }
 
   let load_module :
@@ -97,7 +87,7 @@ module Scope = struct
     ; ctors= IdTbl.empty
     ; modules= IdTbl.empty
     ; module_types= IdTbl.empty
-    ; instances= Int.Map.empty
+    ; instances= []
     ; mode }
 
   let add_name key typ scope =
@@ -190,7 +180,7 @@ module Scope = struct
     let acc =
       IdTbl.fold2_names module_types1 module_types2 ~init:acc ~f:module_types
     in
-    let acc = Map.fold2 instances1 instances2 ~init:acc ~f:instances in
+    let acc = instances acc instances1 instances2 in
     let acc = IdTbl.fold2_names names1 names2 ~init:acc ~f:names in
     acc
 
@@ -247,8 +237,7 @@ module Scope = struct
     ; module_types=
         IdTbl.merge_skewed_names module_types1 module_types2
           ~combine:(multiple_definition "module type")
-    ; instances=
-        Map.merge_skewed instances1 instances2 ~combine:(fun ~key:_ _ v -> v)
+    ; instances= instances2 @ instances1
     ; mode= weakest_mode mode1 mode2 }
 
   let add_module name m scope =
@@ -302,7 +291,11 @@ module Scope = struct
       ; ctors= IdTbl.map ctors ~f:(fun (decl, i) -> (subst_type_decl decl, i))
       ; modules= IdTbl.map ~f:subst_scope_or_path modules
       ; module_types= IdTbl.map ~f:subst_scope_or_path module_types
-      ; instances
+      ; instances=
+          List.map instances ~f:(fun (local_path, global_path, typ) ->
+              ( local_path
+              , Subst.expression_path s global_path
+              , subst_type_expr typ ) )
       ; mode }
     and subst_scope_or_path = function
       | Immediate scope ->
@@ -316,7 +309,7 @@ module Scope = struct
       let scope = subst scope in
       backtrack_replace snap ; scope
 
-  let build_subst ~type_subst ~module_subst s
+  let build_subst ~type_subst ~module_subst ~expr_subst s
       { kind= _
       ; names= _
       ; type_variables= _
@@ -325,7 +318,7 @@ module Scope = struct
       ; ctors= _
       ; modules
       ; module_types= _
-      ; instances= _
+      ; instances
       ; mode= _ } =
     let s =
       IdTbl.fold_keys ~init:s type_decls ~f:(fun s ident ->
@@ -336,6 +329,11 @@ module Scope = struct
       IdTbl.fold_keys ~init:s modules ~f:(fun s ident ->
           let src_path, dst_path = module_subst ident in
           Subst.with_module src_path dst_path s )
+    in
+    let s =
+      List.fold ~init:s instances ~f:(fun s (local_path, global_path, _) ->
+          let src_path, dst_path = expr_subst ~local_path global_path in
+          Subst.with_expression src_path dst_path s )
     in
     s
 
@@ -348,9 +346,12 @@ module Scope = struct
           let add_name ident =
             (Path.Pident ident, Path.dot (Pident name) ident)
           in
+          let add_outer_module ~local_path:_ path =
+            (path, Path.add_outer_module name path)
+          in
           let name_subst =
             build_subst Subst.empty x ~type_subst:add_name
-              ~module_subst:add_name
+              ~module_subst:add_name ~expr_subst:add_outer_module
           in
           Immediate (subst name_subst x)
     in
@@ -565,9 +566,10 @@ let open_module ?mode env =
 
 let open_namespace_scope ?mode path scope env =
   let add_name ident = (Path.dot path ident, Path.Pident ident) in
+  let expr_subst ~local_path path = (path, local_path) in
   let subst =
     Scope.build_subst Subst.empty scope ~type_subst:add_name
-      ~module_subst:add_name
+      ~module_subst:add_name ~expr_subst
   in
   let scope = Scope.subst subst scope in
   let mode = mode_or_default mode env in
@@ -603,9 +605,10 @@ let pop_module ~loc env =
         raise (Error (of_prim __POS__, Wrong_scope_kind "module"))
     | Open path ->
         let add_name ident = (Path.Pident ident, Path.dot path ident) in
+        let expr_subst ~local_path:_ path' = (path', Path.pdot path path') in
         let subst =
           Scope.build_subst Subst.empty scope ~type_subst:add_name
-            ~module_subst:add_name
+            ~module_subst:add_name ~expr_subst
         in
         let scopes = List.map ~f:(Scope.subst subst) scopes in
         all_scopes scopes env
@@ -642,20 +645,25 @@ let find_type_variable ~mode name env =
 
 let add_module (name : Ident.t) m =
   let add_name ident = (Path.Pident ident, Path.dot (Pident name) ident) in
+  let expr_subst ~local_path:_ path =
+    (path, Path.add_outer_module name path)
+  in
   let subst =
     Scope.build_subst Subst.empty m ~type_subst:add_name ~module_subst:add_name
+      ~expr_subst
   in
   let m = Scope.subst subst m in
   map_current_scope ~f:(fun scope ->
       let scope = Scope.add_module name (Scope.Immediate m) scope in
       { scope with
         instances=
-          Map.merge scope.instances m.instances ~f:(fun ~key:_ data ->
-              match data with
-              | `Left x ->
-                  Some x
-              | `Both (_, x) | `Right x ->
-                  Some (Path.add_outer_module name x) ) } )
+          (* Use the rev versions to automatically get tail-recursion for
+             append.
+          *)
+          List.rev_append
+            (List.rev_map m.instances ~f:(fun (local_path, global_path, typ) ->
+                 (Path.add_outer_module name local_path, global_path, typ) ))
+            scope.instances } )
 
 let add_deferred_module (name : Ident.t) lid =
   map_current_scope ~f:(Scope.add_module name (Scope.Deferred lid))
@@ -693,12 +701,10 @@ let find_module_deferred ~mode ~loc (lid : lid) env =
 
 let add_implicit_instance name typ env =
   let path = Path.Pident name in
-  let id, type_env = TypeEnvi.next_instance_id env.resolve_env.type_env in
   let env =
     map_current_scope env ~f:(fun scope ->
-        {scope with instances= Map.set ~key:id ~data:path scope.instances} )
+        {scope with instances= (path, path, typ) :: scope.instances} )
   in
-  env.resolve_env.type_env <- TypeEnvi.add_implicit_instance id typ type_env ;
   env
 
 let find_of_lident ~mode ~kind ~get_name (lid : lid) env =
@@ -1028,29 +1034,29 @@ module Type = struct
        ; implicit_id= implicit_id + 1 } ;
     new_exp
 
-  let implicit_instances ~(unifies : env -> type_expr -> type_expr -> bool)
+  let implicit_instance ~(unifies : env -> type_expr -> type_expr -> bool)
       (typ : type_expr) typ_vars env =
-    List.filter_map env.resolve_env.type_env.instances
-      ~f:(fun (id, instance_typ) ->
-        let instance_typ = copy instance_typ env in
-        let snapshot = Snapshot.create () in
-        if unifies env typ instance_typ then
-          if
-            Set.exists typ_vars ~f:(fun var -> not (phys_equal var (repr var)))
-          then (
-            (* There is at least one variable that hasn't been instantiated.
-               In particular, this must mean that it was less general than the
-               variable that it unified with, or that a parent type expression
-               instantiated a type variable in the target type, and so this
-               instance isn't general enough to satisfy the target type.
-            *)
-            backtrack snapshot ;
-            None )
-          else
-            List.find_map env.scope_stack ~f:(fun {instances; _} ->
-                Option.map (Map.find instances id) ~f:(fun path ->
-                    (path, instance_typ) ) )
-        else None )
+    List.find_map env.scope_stack ~f:(fun scope ->
+        List.find_map scope.instances ~f:(fun (_, path, instance_typ) ->
+            let instance_typ = copy instance_typ env in
+            let snapshot = Snapshot.create () in
+            if unifies env typ instance_typ then
+              if
+                Set.exists typ_vars ~f:(fun var ->
+                    not (phys_equal var (repr var)) )
+              then (
+                (* There is at least one variable that hasn't been instantiated.
+                   In particular, this must mean that it was less general than
+                   the variable that it unified with, or that a parent type
+                   expression instantiated a type variable in the target type,
+                   and so this instance isn't general enough to satisfy the
+                   target type.
+                *)
+                backtrack snapshot ;
+                None )
+              else (* TODO: Shadowing check. *)
+                Some (path, instance_typ)
+            else None ) )
 
   let generate_implicits e env =
     let loc = e.Typedast.exp_loc in
@@ -1074,8 +1080,8 @@ module Type = struct
         ~f:(fun ({Typedast.exp_loc; exp_type; _} as exp) ->
           let exp_type = flatten exp_type in
           let typ_vars = type_vars exp_type in
-          match implicit_instances ~unifies exp_type typ_vars env with
-          | [(name, instance_typ)] ->
+          match implicit_instance ~unifies exp_type typ_vars env with
+          | Some (name, instance_typ) ->
               let name = Location.mkloc name exp_loc in
               let e =
                 generate_implicits
@@ -1090,10 +1096,8 @@ module Type = struct
               | _ ->
                   raise (Error (exp.exp_loc, No_unifiable_implicit)) ) ;
               false
-          | [] ->
-              true
-          | _ ->
-              raise (Error (exp_loc, Multiple_instances exp_type)) )
+          | None ->
+              true )
     in
     let new_implicits = env.resolve_env.type_env.implicit_vars in
     env.resolve_env.type_env
@@ -1328,11 +1332,6 @@ let report_error ppf = function
         pp_typ typ pp_decl_typ decl
   | No_unifiable_implicit ->
       fprintf ppf "Internal error: Implicit variable is not unifiable."
-  | Multiple_instances typ ->
-      fprintf ppf
-        "@[<hov>Multiple instances were found satisfying @[<h>%a@],@ could \
-         not decide between them.@]"
-        pp_typ typ
   | Recursive_load filename ->
       fprintf ppf
         "@[<hov>Circular dependency found; tried to re-load @[<h>%s@]@]"

--- a/meja/src/ident.ml
+++ b/meja/src/ident.ml
@@ -17,6 +17,8 @@ let mode {ident_mode= mode; _} = mode
 
 let compare {ident_id= id1; _} {ident_id= id2; _} = Int.compare id1 id2
 
+let equal {ident_id= id1; _} {ident_id= id2; _} = Int.equal id1 id2
+
 let pprint fmt {ident_name; _} = Ast_types.pp_name fmt ident_name
 
 let debug_print fmt {ident_name; ident_id; ident_mode} =

--- a/meja/src/ident.mli
+++ b/meja/src/ident.mli
@@ -1,5 +1,5 @@
 (** Unique identifiers. *)
-type t [@@deriving sexp]
+type t [@@deriving sexp, equal, compare]
 
 type ident = t
 
@@ -11,11 +11,6 @@ val name : t -> string
 
 val mode : t -> Ast_types.mode
 (** Retrieve the mode passed to [create]. *)
-
-val compare : t -> t -> int
-(** Compare two names. This is 0 iff they originate from the same call to
-    [create].
-*)
 
 val pprint : Format.formatter -> t -> unit
 (** Pretty print. Identifiers that do not begin with a letter or underscore

--- a/meja/src/parser_impl.mly
+++ b/meja/src/parser_impl.mly
@@ -152,6 +152,8 @@ structure_item:
     { mkstmt ~pos:$loc (Pstmt_modtype (x, m)) }
   | OPEN x = as_loc(longident(UIDENT, UIDENT))
     { mkstmt ~pos:$loc (Pstmt_open x) }
+  | OPEN INSTANCE x = as_loc(longident(UIDENT, UIDENT))
+    { mkstmt ~pos:$loc (Pstmt_open_instance x) }
   | TYPE x = decl_type(type_lident) PLUSEQUAL
     maybe(BAR) ctors = list(ctor_decl, BAR)
     { let (x, params) = x in

--- a/meja/src/parser_impl.mly
+++ b/meja/src/parser_impl.mly
@@ -523,6 +523,8 @@ block:
     { mkexp ~pos:$loc (Pexp_seq (e1, rest)) }
   | LET x = pat EQUAL lhs = expr SEMI rhs = block
     { mkexp ~pos:$loc (Pexp_let (x, lhs, rhs)) }
+  | INSTANCE x = as_loc(lident) EQUAL lhs = expr SEMI rhs = block
+    { mkexp ~pos:$loc (Pexp_instance (x, lhs, rhs)) }
   | LET pat EQUAL expr err = err
     { raise (Error (err, Missing_semi)) }
   | expr err = err

--- a/meja/src/parsetypes.ml
+++ b/meja/src/parsetypes.ml
@@ -116,6 +116,7 @@ and statement_desc =
   | Pstmt_module of str * module_expr
   | Pstmt_modtype of str * module_sig
   | Pstmt_open of lid
+  | Pstmt_open_instance of lid
   | Pstmt_typeext of variant * ctor_decl list
   | Pstmt_request of
       type_expr * ctor_decl * (pattern option * expression) option

--- a/meja/src/parsetypes.ml
+++ b/meja/src/parsetypes.ml
@@ -65,6 +65,7 @@ and expression_desc =
   | Pexp_newtype of str * expression
   | Pexp_seq of expression * expression
   | Pexp_let of pattern * expression * expression
+  | Pexp_instance of str * expression * expression
   | Pexp_constraint of expression * type_expr
   | Pexp_tuple of expression list
   | Pexp_match of expression * (pattern * expression) list

--- a/meja/src/parsetypes_iter.ml
+++ b/meja/src/parsetypes_iter.ml
@@ -237,6 +237,8 @@ let statement_desc iter = function
       str iter name ; iter.module_sig iter mty
   | Pstmt_open name ->
       lid iter name
+  | Pstmt_open_instance name ->
+      lid iter name
   | Pstmt_typeext (typ, ctors) ->
       iter.variant iter typ ;
       List.iter ~f:(iter.ctor_decl iter) ctors

--- a/meja/src/parsetypes_iter.ml
+++ b/meja/src/parsetypes_iter.ml
@@ -146,6 +146,8 @@ let expression_desc iter = function
       iter.expression iter e1 ; iter.expression iter e2
   | Pexp_let (p, e1, e2) ->
       iter.pattern iter p ; iter.expression iter e1 ; iter.expression iter e2
+  | Pexp_instance (name, e1, e2) ->
+      str iter name ; iter.expression iter e1 ; iter.expression iter e2
   | Pexp_constraint (e, typ) ->
       iter.type_expr iter typ ; iter.expression iter e
   | Pexp_tuple es ->

--- a/meja/src/parsetypes_map.ml
+++ b/meja/src/parsetypes_map.ml
@@ -159,6 +159,11 @@ let expression_desc mapper = function
         ( mapper.pattern mapper p
         , mapper.expression mapper e1
         , mapper.expression mapper e2 )
+  | Pexp_instance (name, e1, e2) ->
+      Pexp_instance
+        ( str mapper name
+        , mapper.expression mapper e1
+        , mapper.expression mapper e2 )
   | Pexp_constraint (e, typ) ->
       Pexp_constraint (mapper.expression mapper e, mapper.type_expr mapper typ)
   | Pexp_tuple es ->

--- a/meja/src/parsetypes_map.ml
+++ b/meja/src/parsetypes_map.ml
@@ -261,6 +261,8 @@ let statement_desc mapper = function
       Pstmt_modtype (str mapper name, mapper.module_sig mapper mty)
   | Pstmt_open name ->
       Pstmt_open (lid mapper name)
+  | Pstmt_open_instance name ->
+      Pstmt_open_instance (lid mapper name)
   | Pstmt_typeext (typ, ctors) ->
       Pstmt_typeext
         (mapper.variant mapper typ, List.map ~f:(mapper.ctor_decl mapper) ctors)

--- a/meja/src/path.ml
+++ b/meja/src/path.ml
@@ -32,6 +32,27 @@ let rec debug_print ppf path =
 let dot (path : t) (ident : Ident.t) =
   Pdot (path, Ident.mode ident, Ident.name ident)
 
+(** Deconstruct a path to an [Ident.t] and a list of mode, name pairs, from
+    innermost to outermost.
+
+    For example, [deconstruct(A.B.C.d) = (A, [(_, "B"); (_, "C"); (_, "d")])].
+*)
+let deconstruct path =
+  let rec go l = function
+    | Pident ident ->
+        (ident, l)
+    | Pdot (path, mode, name) ->
+        go ((mode, name) :: l) path
+    | Papply _ ->
+        failwith "Path.deconstruct: Unhandled Papply."
+  in
+  go [] path
+
+let pdot (root_path : t) (path : t) =
+  let ident, mode_names = deconstruct path in
+  List.fold ~init:(dot root_path ident) mode_names ~f:(fun path (mode, name) ->
+      Pdot (path, mode, name) )
+
 (** Create a path from a list of [Ident.t]s. *)
 let of_idents idents =
   match idents with

--- a/meja/src/pprint.ml
+++ b/meja/src/pprint.ml
@@ -197,6 +197,9 @@ let rec expression_desc fmt = function
   | Pexp_let (p, e1, e2) ->
       fprintf fmt "let@[<hv2>@ %a@] =@ @[<hv2>%a@];@;@]@ %a" pattern p
         expression e1 expression e2
+  | Pexp_instance (name, e1, e2) ->
+      fprintf fmt "let@[<hv2>@ %s@] =@ @[<hv2>%a@];@;@]@ %a" name.txt
+        expression e1 expression e2
   | Pexp_constraint (e, typ) ->
       fprintf fmt "(@[<hv1>%a :@ %a@])" expression e type_expr typ
   | Pexp_tuple es ->

--- a/meja/src/subst.ml
+++ b/meja/src/subst.ml
@@ -6,14 +6,21 @@ open Core_kernel
          In particular, the type of a record argument to a GADT constructor has
          name A.B.X, where X is the name of the constructor.
 *)
-type t = {types: Path.t Path.Map.t; modules: Path.t Path.Map.t}
+type t =
+  { types: Path.t Path.Map.t
+  ; modules: Path.t Path.Map.t
+  ; expressions: Path.t Path.Map.t }
 
-let empty = {types= Path.Map.empty; modules= Path.Map.empty}
+let empty =
+  {types= Path.Map.empty; modules= Path.Map.empty; expressions= Path.Map.empty}
 
 let with_type src dst s = {s with types= Map.set ~key:src ~data:dst s.types}
 
 let with_module src dst s =
   {s with modules= Map.set ~key:src ~data:dst s.modules}
+
+let with_expression src dst s =
+  {s with expressions= Map.set ~key:src ~data:dst s.expressions}
 
 let rec module_path s path =
   match Map.find s.modules path with
@@ -40,6 +47,19 @@ let type_path s path =
         Pdot (module_path s path, mode, name)
     | Papply _ ->
         failwith "Subst.type_path: Unhandled Papply" )
+
+let expression_path s path =
+  match Map.find s.expressions path with
+  | Some path ->
+      path
+  | None -> (
+    match path with
+    | Pident _ ->
+        path
+    | Pdot (path, mode, name) ->
+        Pdot (module_path s path, mode, name)
+    | Papply _ ->
+        failwith "Subst.expression_path: Unhandled Papply" )
 
 let type0_mapper s =
   {Type0_map.default_mapper with path= (fun _mapper -> type_path s)}

--- a/meja/src/typechecker.ml
+++ b/meja/src/typechecker.ml
@@ -1223,6 +1223,11 @@ let rec check_statement env stmt =
       ( Envi.open_namespace_scope path m env
       , { Typedast.stmt_loc= loc
         ; stmt_desc= Tstmt_open (Location.mkloc path name.loc) } )
+  | Pstmt_open_instance name ->
+      let path, m = Envi.find_module ~mode ~loc name env in
+      ( Envi.open_instance_scope path m env
+      , { Typedast.stmt_loc= loc
+        ; stmt_desc= Tstmt_open_instance (Location.mkloc path name.loc) } )
   | Pstmt_typeext (variant, ctors) ->
       let env, variant, ctors = type_extension ~loc variant ctors env in
       (env, {Typedast.stmt_loc= loc; stmt_desc= Tstmt_typeext (variant, ctors)})

--- a/meja/src/typechecker.ml
+++ b/meja/src/typechecker.ml
@@ -616,6 +616,7 @@ let rec get_expression env expected exp =
         pattern {Typedast_iter.default_iterator with pattern} p ;
         Option.value_exn !ret
       in
+      let typ = polymorphise typ env in
       let env = Envi.add_implicit_instance ident.txt typ env in
       let e2, env = get_expression env expected e2 in
       let implicits_instantiated =

--- a/meja/src/typechecker.ml
+++ b/meja/src/typechecker.ml
@@ -600,6 +600,35 @@ let rec get_expression env expected exp =
       Envi.Type.update_depths env e2.exp_type ;
       ( {exp_loc= loc; exp_type= e2.exp_type; exp_desc= Texp_let (p, e1, e2)}
       , env )
+  | Pexp_instance (name, e1, e2) ->
+      let env = Envi.open_expr_scope env in
+      let p = Ast_build.Pat.var ~loc:name.loc name.txt in
+      let p, e1, env = check_binding env p e1 in
+      let ident, typ =
+        let ret = ref None in
+        let pattern iter pat =
+          match pat.Typedast.pat_desc with
+          | Tpat_variable name ->
+              ret := Some (name, pat.Typedast.pat_type)
+          | _ ->
+              Typedast_iter.default_iterator.pattern iter pat
+        in
+        pattern {Typedast_iter.default_iterator with pattern} p ;
+        Option.value_exn !ret
+      in
+      let env = Envi.add_implicit_instance ident.txt typ env in
+      let e2, env = get_expression env expected e2 in
+      let implicits_instantiated =
+        (* Instantiate any implicits that we can within this scope. *)
+        Envi.Type.flattened_implicit_vars ~loc ~toplevel:false ~unifies Typeset.empty env
+      in
+      assert (List.is_empty implicits_instantiated) ;
+      let env = Envi.close_expr_scope env in
+      Envi.Type.update_depths env e2.exp_type ;
+      ( { exp_loc= loc
+        ; exp_type= e2.exp_type
+        ; exp_desc= Texp_instance (ident, e1, e2) }
+      , env )
   | Pexp_constraint (e, typ') ->
       let typ, env = Typet.Type.import typ' env in
       check_type ~loc env expected typ.type_type ;

--- a/meja/src/typechecker.ml
+++ b/meja/src/typechecker.ml
@@ -620,7 +620,8 @@ let rec get_expression env expected exp =
       let e2, env = get_expression env expected e2 in
       let implicits_instantiated =
         (* Instantiate any implicits that we can within this scope. *)
-        Envi.Type.flattened_implicit_vars ~loc ~toplevel:false ~unifies Typeset.empty env
+        Envi.Type.flattened_implicit_vars ~loc ~toplevel:false ~unifies
+          Typeset.empty env
       in
       assert (List.is_empty implicits_instantiated) ;
       let env = Envi.close_expr_scope env in

--- a/meja/src/typedast.ml
+++ b/meja/src/typedast.ml
@@ -147,6 +147,7 @@ and statement_desc =
   | Tstmt_module of ident * module_expr
   | Tstmt_modtype of ident * module_sig
   | Tstmt_open of path
+  | Tstmt_open_instance of path
   | Tstmt_typeext of variant * ctor_decl list
   | Tstmt_request of
       type_expr * ctor_decl * (pattern option * expression) option

--- a/meja/src/typedast.ml
+++ b/meja/src/typedast.ml
@@ -95,6 +95,7 @@ and expression_desc =
   | Texp_newtype of ident * expression
   | Texp_seq of expression * expression
   | Texp_let of pattern * expression * expression
+  | Texp_instance of ident * expression * expression
   | Texp_constraint of expression * type_expr
   | Texp_tuple of expression list
   | Texp_match of expression * (pattern * expression) list

--- a/meja/src/typedast_iter.ml
+++ b/meja/src/typedast_iter.ml
@@ -164,6 +164,8 @@ let expression_desc iter = function
       iter.expression iter e1 ; iter.expression iter e2
   | Texp_let (p, e1, e2) ->
       iter.pattern iter p ; iter.expression iter e1 ; iter.expression iter e2
+  | Texp_instance (name, e1, e2) ->
+      ident iter name ; iter.expression iter e1 ; iter.expression iter e2
   | Texp_constraint (e, typ) ->
       iter.type_expr iter typ ; iter.expression iter e
   | Texp_tuple es ->

--- a/meja/src/typedast_iter.ml
+++ b/meja/src/typedast_iter.ml
@@ -282,6 +282,8 @@ let statement_desc iter = function
       ident iter name ; iter.module_sig iter mty
   | Tstmt_open name ->
       path iter name
+  | Tstmt_open_instance name ->
+      path iter name
   | Tstmt_typeext (typ, ctors) ->
       iter.variant iter typ ;
       List.iter ~f:(iter.ctor_decl iter) ctors

--- a/meja/src/typedast_map.ml
+++ b/meja/src/typedast_map.ml
@@ -323,6 +323,8 @@ let statement_desc mapper = function
       Tstmt_modtype (ident mapper name, mapper.module_sig mapper mty)
   | Tstmt_open name ->
       Tstmt_open (path mapper name)
+  | Tstmt_open_instance name ->
+      Tstmt_open_instance (path mapper name)
   | Tstmt_typeext (typ, ctors) ->
       Tstmt_typeext
         (mapper.variant mapper typ, List.map ~f:(mapper.ctor_decl mapper) ctors)

--- a/meja/src/typedast_map.ml
+++ b/meja/src/typedast_map.ml
@@ -221,6 +221,11 @@ let expression_desc mapper = function
         ( mapper.pattern mapper p
         , mapper.expression mapper e1
         , mapper.expression mapper e2 )
+  | Texp_instance (name, e1, e2) ->
+      Texp_instance
+        ( ident mapper name
+        , mapper.expression mapper e1
+        , mapper.expression mapper e2 )
   | Texp_constraint (e, typ) ->
       Texp_constraint (mapper.expression mapper e, mapper.type_expr mapper typ)
   | Texp_tuple es ->

--- a/meja/src/untype_ast.ml
+++ b/meja/src/untype_ast.ml
@@ -185,6 +185,8 @@ let rec expression_desc = function
       Pexp_seq (expression e1, expression e2)
   | Texp_let (p, e1, e2) ->
       Pexp_let (pattern p, expression e1, expression e2)
+  | Texp_instance (name, e1, e2) ->
+      Pexp_instance (map_loc ~f:Ident.name name, expression e1, expression e2)
   | Texp_constraint (e, typ) ->
       Pexp_constraint (expression e, type_expr typ)
   | Texp_tuple es ->

--- a/meja/src/untype_ast.ml
+++ b/meja/src/untype_ast.ml
@@ -274,6 +274,8 @@ let rec statement_desc = function
       Pstmt_modtype (map_loc ~f:Ident.name name, module_sig msig)
   | Tstmt_open path ->
       Pstmt_open (map_loc ~f:longident_of_path path)
+  | Tstmt_open_instance path ->
+      Pstmt_open_instance (map_loc ~f:longident_of_path path)
   | Tstmt_typeext (typ, ctors) ->
       Pstmt_typeext (variant typ, List.map ~f:ctor_decl ctors)
   | Tstmt_request (arg, ctor, handler) ->

--- a/meja/tests/expression-instance.meja
+++ b/meja/tests/expression-instance.meja
@@ -21,6 +21,8 @@ let b = fun () => {
     instance g = fun (i, j) => {i + j;};
     ignore(a(1));
     ignore(a(true));
+    ignore(a());
+    ignore(a((true, false)));
   };
   ignore(a(1));
   ignore(a(true));

--- a/meja/tests/expression-instance.meja
+++ b/meja/tests/expression-instance.meja
@@ -1,0 +1,27 @@
+let f = fun {x : int} => {
+  x;
+};
+
+let g = fun () => {
+  instance y = 15;
+  f;
+};
+
+let a = fun {f : int -> 'a -> 'a} (x) => {
+  f(12, x);
+};
+
+instance h = fun (_, x) => {
+  x;
+};
+
+let b = fun () => {
+  {
+    instance f = fun (_, x) => {x;};
+    instance g = fun (i, j) => {i + j;};
+    ignore(a(1));
+    ignore(a(true));
+  };
+  ignore(a(1));
+  ignore(a(true));
+};

--- a/meja/tests/expression-instance.ml
+++ b/meja/tests/expression-instance.ml
@@ -15,6 +15,8 @@ let b () =
   (let f _ x = x in
    let g i j = i + j in
    ignore (a g 1) ;
-   ignore (a f true)) ;
+   ignore (a f true) ;
+   ignore (a f ()) ;
+   ignore (a f (true, false))) ;
   ignore (a h 1) ;
   ignore (a h true)

--- a/meja/tests/expression-instance.ml
+++ b/meja/tests/expression-instance.ml
@@ -1,0 +1,20 @@
+module Impl = Snarky.Snark.Make (Snarky.Backends.Mnt4.Default)
+open Impl
+
+let f (x : int) = x
+
+let g () =
+  let y = 15 in
+  f y
+
+let a (f : int -> 'a -> 'a) x = f 12 x
+
+let h _ x = x
+
+let b () =
+  (let f _ x = x in
+   let g i j = i + j in
+   ignore (a g 1) ;
+   ignore (a f true)) ;
+  ignore (a h 1) ;
+  ignore (a h true)

--- a/meja/tests/open-instance.meja
+++ b/meja/tests/open-instance.meja
@@ -1,0 +1,17 @@
+module X = {
+  instance x = 15;
+};
+
+let f = fun {x : int} => {
+  x;
+};
+
+let a = f;
+
+instance y = 15;
+
+let b = f;
+
+open instance X;
+
+let c = f;

--- a/meja/tests/open-instance.ml
+++ b/meja/tests/open-instance.ml
@@ -1,0 +1,19 @@
+module Impl = Snarky.Snark.Make (Snarky.Backends.Mnt4.Default)
+open Impl
+
+module X = struct
+  let x = 15
+end
+
+let f (x : int) = x
+
+let a = f X.x
+
+let y = 15
+
+let b = f y
+
+;;
+()
+
+let c = f X.x


### PR DESCRIPTION
This PR
* changes the instance resolution algorithm to accept the first instance found, instead of failing with an error
* makes instances scope local
  - this ensures that the paths to instances always resolve correctly
* adds an `open implicit M` statement for any module `M`
  - this allows us to include the instances from an external module even when it isn't otherwise referred to, and without having to open it when we don't necessarily want it open
  - this also gives us an easy way to override instances by including a module with some different instances
* adds a expression-level `instance`
  - this was the main motivation, for use in the `Typ.t` generation
  - this will also allow us to create and instantiate expression-local request handlers when row-subtyping is (finally) implemented

This was originally part of the ongoing tri-stitching/`Typ.t` generation typechecker overhaul, but this is separate enough to break out as its own PR.