### PR TITLE
Sponge reorg

### DIFF
--- a/sponge/intf.ml
+++ b/sponge/intf.ml
@@ -63,3 +63,26 @@ module type Permutation = sig
 
   val block_cipher : Field.t Params.t -> Field.t array -> Field.t array
 end
+
+module type Hash = sig
+  module Field : sig
+    type t
+  end
+
+  module State : sig
+    type _ t
+  end
+
+  val update :
+       Field.t Params.t
+    -> state:Field.t State.t
+    -> Field.t array
+    -> Field.t State.t
+
+  val digest : Field.t State.t -> Field.t
+
+  val initial_state : Field.t State.t
+
+  val hash :
+    ?init:Field.t State.t -> Field.t Params.t -> Field.t array -> Field.t
+end

--- a/sponge/params.sage
+++ b/sponge/params.sage
@@ -4,6 +4,9 @@ import hashlib
 MNT4298_r = 475922286169261325753349249653048451545124878552823515553267735739164647307408490559963137
 MNT4753_r = 41898490967918953402344214791240637128170709919953949071783502921025352812571106773058893763790338921418070971888458477323173057491593855069696241854796396165721416325350064441470418137846398469611935719059908164220784476160001
 
+MNT6298_r = 475922286169261325753349249653048451545124879242694725395555128576210262817955800483758081
+MNT6753_r = 41898490967918953402344214791240637128170709919953949071783502921025352812571106773058893763790338921418070971888253786114353726529584385201591605722013126468931404347949840543007986327743462853720628051692141265303114721689601
+
 BN128_r = 21888242871839275222246405745257275088548364400416034343698204186575808495617
 
 def random_value(F, prefix, i):
@@ -19,8 +22,8 @@ def round_constants(F):
     return [ [ random_value(F, name, r * m + i) for i in xrange(m) ]
             for r in xrange( rounds ) ]
 
-def matrix_str(rows):
-    return '[|' + ';'.join('[|' + ';'.join('"{}"'.format(str(x)) for x in row) + '|]' for row in rows) + '|]'
+def matrix_str(of_string_wrap, rows):
+    return '[|' + ';'.join('[|' + ';'.join(of_string_wrap('"{}"'.format(str(x))) for x in row) + '|]' for row in rows) + '|]'
 
 def mds(F):
     name = prefix + 'MDS'
@@ -50,9 +53,50 @@ def mds(F):
             # There are no eigenvalues in the field.
             return mds
 
-for name, r in [  ('Bn128', BN128_r), ('Mnt4_298', MNT4298_r), ('Mnt4_753', MNT4753_r) ]:
-  F = FiniteField(r)
-  print ('let params_{} = '.format(name)
-          + '{ Params.mds=' + matrix_str(mds(F)) + ';'
-          + 'round_constants= ' + matrix_str(round_constants(F))
-          + '}' )
+if sys.argv[1] == 'coda':
+    def module_strs(name, r_small, r_medium):
+        wrap = lambda s: 'str {}'.format(s)
+
+        F_small = FiniteField(r_small)
+        F_medium = FiniteField(r_medium)
+        strs = [
+            ('let str x = {}_full.Bigint.R.(to_field (of_decimal_string x))'.format(name)),
+            ('''[%%import "../../config.mlh"]'''),
+            ('''[%%if curve_size = 298]'''),
+            ('let inv_alpha = "432656623790237568866681136048225865041022616866203195957516123399240588461280445963602851"'),
+            ('let mds ='),
+            (matrix_str(wrap, mds(F_small))),
+            ('let round_constants ='),
+            (matrix_str(wrap, round_constants(F_small))),
+            ('''
+            [%%elif
+            curve_size = 753]'''),
+            ('let inv_alpha = "38089537243562684911222013446582397389246099927230862792530457200932138920519187975508085239809399019470973610807689524839248234083267140972451128958905814696110378477590967674064016488951271336010850653690825603837076796509091"'),
+            ('let mds ='),
+            (matrix_str(wrap, mds(F_medium))),
+            ('let round_constants ='),
+            (matrix_str(wrap, round_constants(F_medium))),
+            ('''
+            [%%else]
+
+            [%%show
+            curve_size]
+
+            [%%error
+            "invalid value for \\"curve_size\\""]
+
+            [%%endif]''') ]
+        return 'module {} = struct {} end'.format(name, '\n'.join(strs))
+
+    print 'open Curve_choice'
+    print module_strs('Tick', MNT4298_r, MNT4753_r)
+    print module_strs('Tock', MNT6298_r, MNT6753_r)
+
+else:
+    for name, r in [  ('Bn128', BN128_r), ('Mnt4_298', MNT4298_r), ('Mnt4_753', MNT4753_r) ]:
+        wrap = lambda x: x
+        F = FiniteField(r)
+        print ('let params_{} = '.format(name)
+                + '{ Params.mds=' + matrix_str(wrap, mds(F)) + ';'
+                + 'round_constants= ' + matrix_str(wrap, round_constants(F))
+                + '}' )

--- a/sponge/sponge.ml
+++ b/sponge/sponge.ml
@@ -1,4 +1,5 @@
 open Core_kernel
+module Intf = Intf
 
 module Params = struct
   include Params

--- a/sponge/sponge.mli
+++ b/sponge/sponge.mli
@@ -1,3 +1,5 @@
+module Intf = Intf
+
 module Params : sig
   type 'a t = 'a Params.t [@@deriving bin_io]
 
@@ -25,19 +27,5 @@ module Poseidon (Inputs : Intf.Inputs.Poseidon) :
 module Make_operations (Field : Intf.Field) :
   Intf.Operations with module Field := Field
 
-module Make (P : Intf.Permutation) : sig
-  open P
-
-  val update :
-       Field.t Params.t
-    -> state:Field.t State.t
-    -> Field.t array
-    -> Field.t State.t
-
-  val digest : Field.t State.t -> Field.t
-
-  val initial_state : Field.t State.t
-
-  val hash :
-    ?init:Field.t State.t -> Field.t Params.t -> Field.t array -> Field.t
-end
+module Make (P : Intf.Permutation) :
+  Intf.Hash with module State := State and module Field := P.Field


### PR DESCRIPTION
This just reorganizes a bit of code in the sponge library, adds back some ocaml codegen for the parameter generation which is specific to coda, and adds in parameter generation for the Tock/MNT6 curves, which is needed for switching Bowe--Gabizon18 with Groth16.