### PR TITLE
OCaml record representation for groth16 proofs

### DIFF
--- a/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_curve.cpp.template
+++ b/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_curve.cpp.template
@@ -848,6 +848,21 @@ r1cs_gg_ppzksnark_proof<ppT>* CURVE_PREFIX(proof_create)(
   return new r1cs_gg_ppzksnark_proof<ppT>(res);
 }
 
+bool CURVE_PREFIX(proof_verify_components)(
+    libff::G1<ppT>* a,
+    libff::G2<ppT>* b,
+    libff::G1<ppT>* c,
+    r1cs_gg_ppzksnark_verification_key<ppT>* key,
+    std::vector<FieldT>* primary_input) {
+
+  r1cs_gg_ppzksnark_proof<ppT> p = r1cs_gg_ppzksnark_proof<ppT>();
+  p.g_A = *a;
+  p.g_B = *b;
+  p.g_C = *c;
+
+  return r1cs_gg_ppzksnark_verifier_weak_IC(*key, *primary_input, p);
+}
+
 void CURVE_PREFIX(proof_delete)(r1cs_gg_ppzksnark_proof<ppT>* proof) {
   delete proof;
 }


### PR DESCRIPTION
I am swapping Groth16 with BG18 in Coda, so now Groth16 proofs will be broadcast on the network. So, we need to perform the subgroup check when verifying and we would like to have control over the wire representation of Groth16 proofs.

This PR adds an OCaml record representing Groth16 proofs so we can have control over the wire format, and performs the subgroup check in verification.