### PR TITLE
[Meja] Generate unique type variable names for printing

### DIFF
--- a/meja/src/typechecker.ml
+++ b/meja/src/typechecker.ml
@@ -26,7 +26,7 @@ type error =
   | Not_extensible of Longident.t
   | Extension_different_arity of Longident.t
 
-exception Error of Location.t * error
+exception Error of Location.t * Envi.t * error
 
 let map_none x f = match x with Some x -> x | None -> f ()
 
@@ -65,7 +65,7 @@ let unpack_decls ~loc typ ctyp env =
 
 let rec check_type_aux ~loc typ ctyp env =
   if Type1.contains typ ~in_:ctyp || Type1.contains ctyp ~in_:typ then
-    raise (Error (loc, Recursive_variable typ)) ;
+    raise (Error (loc, env, Recursive_variable typ)) ;
   let check_type_aux = check_type_aux ~loc in
   Type1.unify_depths typ ctyp ;
   let typ = repr typ in
@@ -102,7 +102,7 @@ let rec check_type_aux ~loc typ ctyp env =
     | Ok () ->
         ()
     | Unequal_lengths ->
-        raise (Error (loc, Cannot_unify (typ, ctyp))) )
+        raise (Error (loc, env, Cannot_unify (typ, ctyp))) )
   | ( Tarrow (typ1, typ2, Explicit, label1)
     , Tarrow (ctyp1, ctyp2, Explicit, label2) )
   | ( Tarrow (typ1, typ2, Implicit, label1)
@@ -124,7 +124,7 @@ let rec check_type_aux ~loc typ ctyp env =
         check_type_aux typ1 (Initial_env.Type.option ctyp1) env ;
         check_type_aux typ2 ctyp2 env
     | _ ->
-        raise (Error (loc, Cannot_unify (typ, ctyp))) )
+        raise (Error (loc, env, Cannot_unify (typ, ctyp))) )
   | Tctor variant, Tctor constr_variant -> (
     (* Always try to unfold first, so that type aliases with phantom
          parameters can unify, as in OCaml.
@@ -151,8 +151,8 @@ let rec check_type_aux ~loc typ ctyp env =
           | Ok env ->
               env
           | Unequal_lengths ->
-              raise (Error (loc, Cannot_unify (typ, ctyp)))
-        else raise (Error (loc, Cannot_unify (typ, ctyp))) )
+              raise (Error (loc, env, Cannot_unify (typ, ctyp)))
+        else raise (Error (loc, env, Cannot_unify (typ, ctyp))) )
   | Tctor _, _ | _, Tctor _ ->
       (* Unfold an alias and compare again *)
       let typ, ctyp =
@@ -160,18 +160,18 @@ let rec check_type_aux ~loc typ ctyp env =
         | Some (typ, ctyp) ->
             (typ, ctyp)
         | None ->
-            raise (Error (loc, Cannot_unify (typ, ctyp)))
+            raise (Error (loc, env, Cannot_unify (typ, ctyp)))
       in
       check_type_aux typ ctyp env
   | _, _ ->
-      raise (Error (loc, Cannot_unify (typ, ctyp)))
+      raise (Error (loc, env, Cannot_unify (typ, ctyp)))
 
 let check_type ~loc env typ constr_typ =
   match check_type_aux ~loc typ constr_typ env with
-  | exception Error (_, err) ->
+  | exception Error (_, _, err) ->
       let typ = Type1.flatten typ in
       let constr_typ = Type1.flatten constr_typ in
-      raise (Error (loc, Check_failed (typ, constr_typ, err)))
+      raise (Error (loc, env, Check_failed (typ, constr_typ, err)))
   | () ->
       ()
 
@@ -237,7 +237,7 @@ let get_field (field : lid) env =
       backtrack snap ;
       (ident, i, fld_type, rcd_type)
   | _ ->
-      raise (Error (loc, Unbound ("record field", field)))
+      raise (Error (loc, env, Unbound ("record field", field)))
 
 let get_field_of_decl typ decl_vars params field_decls (field : lid) env =
   match field with
@@ -264,7 +264,7 @@ let get_ctor (name : lid) env =
     | Some x ->
         x
     | None ->
-        raise (Error (loc, Unbound ("constructor", name)))
+        raise (Error (loc, env, Unbound ("constructor", name)))
   in
   let ctors =
     match decl.tdec_desc with
@@ -353,7 +353,7 @@ let rec check_pattern env typ pat =
             | `Both (typ1, typ2) ->
                 check_type ~loc env typ1 typ2
             | _ ->
-                raise (Error (loc, Variable_on_one_side key)) )
+                raise (Error (loc, env, Variable_on_one_side key)) )
       in
       ( {Typedast.pat_loc= loc; pat_type= typ; pat_desc= Tpat_or (p1, p2)}
       , names1
@@ -362,7 +362,7 @@ let rec check_pattern env typ pat =
       check_type ~loc env typ Initial_env.Type.int ;
       ({Typedast.pat_loc= loc; pat_type= typ; pat_desc= Tpat_int i}, [], env)
   | Ppat_record [] ->
-      raise (Error (loc, Empty_record))
+      raise (Error (loc, env, Empty_record))
   | Ppat_record ((field, _) :: _ as fields) ->
       let typ, field_decls, decl_vars, type_params =
         match Envi.TypeDecl.find_unaliased_of_type ~loc typ env with
@@ -387,7 +387,7 @@ let rec check_pattern env typ pat =
               check_type ~loc env typ decl_type ;
               (decl_type, field_decls, tdec_params, vars)
           | _ ->
-              raise (Error (loc, Unbound ("record field", field))) )
+              raise (Error (loc, env, Unbound ("record field", field))) )
       in
       let field_infos =
         List.map fields ~f:(fun (field, _p) ->
@@ -395,8 +395,10 @@ let rec check_pattern env typ pat =
               get_field_of_decl typ decl_vars type_params field_decls field env
             in
             ( try check_type ~loc:field.loc env record_typ typ
-              with Error (_, Check_failed (_, _, Cannot_unify (typ, _))) ->
-                raise (Error (field.loc, Wrong_record_field (field.txt, typ)))
+              with
+              | Error (_, env, Check_failed (_, _, Cannot_unify (typ, _))) ->
+                raise
+                  (Error (field.loc, env, Wrong_record_field (field.txt, typ)))
             ) ;
             (field_typ, Location.mkloc path field.loc) )
       in
@@ -440,7 +442,7 @@ and check_patterns env typs pats =
             let name = Ident.name name in
             String.Table.update names_table name ~f:(function
               | Some _ ->
-                  raise (Error (loc, Repeated_pattern_variable name))
+                  raise (Error (loc, env, Repeated_pattern_variable name))
               | None ->
                   () ) ) ;
         (pat :: rev_pats, List.rev_append names rev_names, env) )
@@ -706,7 +708,8 @@ let rec get_expression env expected exp =
                 check_type ~loc env typ fld_type ;
                 (Path.Pident fld_ident, fld_type)
             | None ->
-                raise (Error (loc, Wrong_record_field (field.txt, e.exp_type)))
+                raise
+                  (Error (loc, env, Wrong_record_field (field.txt, e.exp_type)))
             )
           | _ -> (
             match Envi.TypeDecl.find_of_field ~mode field env with
@@ -729,14 +732,14 @@ let rec get_expression env expected exp =
                 in
                 (fld_ident, fld_type)
             | _ ->
-                raise (Error (loc, Unbound ("record field", field))) )
+                raise (Error (loc, env, Unbound ("record field", field))) )
       in
       ( { exp_loc= loc
         ; exp_type= typ
         ; exp_desc= Texp_field (e, Location.mkloc fld_ident field.loc) }
       , env )
   | Pexp_record ([], _) ->
-      raise (Error (loc, Empty_record))
+      raise (Error (loc, env, Empty_record))
   | Pexp_record (((field, _) :: _ as fields), ext) ->
       let typ, ext, env =
         match ext with
@@ -770,7 +773,7 @@ let rec get_expression env expected exp =
               check_type ~loc env typ decl_type ;
               (decl_type, field_decls, tdec_params, vars)
           | _ ->
-              raise (Error (loc, Unbound ("record field", field))) )
+              raise (Error (loc, env, Unbound ("record field", field))) )
       in
       let type_vars = List.map ~f:(Type1.get_mode mode) type_vars in
       let bound_vars = List.map ~f:(Type1.get_mode mode) bound_vars in
@@ -782,13 +785,15 @@ let rec get_expression env expected exp =
               get_field_of_decl typ type_vars bound_vars field_decls field !env
             in
             ( try check_type ~loc:field.loc !env record_typ typ
-              with Error (_, Check_failed (_, _, Cannot_unify (typ, _))) ->
-                raise (Error (field.loc, Wrong_record_field (field.txt, typ)))
+              with
+              | Error (_, env, Check_failed (_, _, Cannot_unify (typ, _))) ->
+                raise
+                  (Error (field.loc, env, Wrong_record_field (field.txt, typ)))
             ) ;
             let e, env' = get_expression !env field_typ e in
             ( if fields_filled.(i) then
               let name = (List.nth_exn field_decls i).fld_ident in
-              raise (Error (field.loc, Repeated_field name)) ) ;
+              raise (Error (field.loc, !env, Repeated_field name)) ) ;
             fields_filled.(i) <- true ;
             env := env' ;
             (Location.mkloc path field.loc, e) )
@@ -804,7 +809,7 @@ let rec get_expression env expected exp =
                 if filled then names else fld_ident :: names )
           in
           if not (List.is_empty names) then
-            raise (Error (loc, Missing_fields names)) ) ;
+            raise (Error (loc, !env, Missing_fields names)) ) ;
       ({exp_loc= loc; exp_type= typ; exp_desc= Texp_record (fields, ext)}, !env)
   | Pexp_ctor (name, arg) ->
       let name', typ, arg_typ = get_ctor name env in
@@ -818,12 +823,12 @@ let rec get_expression env expected exp =
         | None ->
             let typ = Envi.Type.Mk.tuple ~mode [] env in
             ( try check_type ~loc env arg_typ typ
-              with _ -> raise (Error (loc, Argument_expected name.txt)) ) ;
+              with _ -> raise (Error (loc, env, Argument_expected name.txt)) ) ;
             (None, env)
       in
       ({exp_loc= loc; exp_type= typ; exp_desc= Texp_ctor (name', arg)}, env)
   | Pexp_unifiable _ ->
-      raise (Error (loc, Unifiable_expr))
+      raise (Error (loc, env, Unifiable_expr))
   | Pexp_if (e1, e2, None) ->
       check_type ~loc env Initial_env.Type.unit expected ;
       let e1, env = get_expression env Initial_env.Type.bool e1 in
@@ -873,7 +878,7 @@ and check_binding ?(toplevel = false) (env : Envi.t) p e : 's =
         | [(name, typ)] ->
             (name, Type1.flatten typ)
         | _ ->
-            raise (Error (loc, No_instance implicit.exp_type))
+            raise (Error (loc, env, No_instance implicit.exp_type))
       in
       let e =
         match p.pat_desc with
@@ -913,7 +918,7 @@ and check_binding ?(toplevel = false) (env : Envi.t) p e : 's =
                   ; exp_loc= loc }
                 , env )
             | _ ->
-                raise (Error (var.exp_loc, No_unifiable_expr)) )
+                raise (Error (var.exp_loc, env, No_unifiable_expr)) )
       in
       let p =
         { Typedast.pat_loc= p.pat_loc
@@ -931,18 +936,18 @@ let type_extension ~loc variant ctors env =
     | open_decl ->
         open_decl
     | exception _ ->
-        raise (Error (loc, Unbound ("type constructor", var_ident)))
+        raise (Error (loc, env, Unbound ("type constructor", var_ident)))
   in
   ( match tdec_desc with
   | TOpen ->
       ()
   | _ ->
-      raise (Error (loc, Not_extensible var_ident.txt)) ) ;
+      raise (Error (loc, env, Not_extensible var_ident.txt)) ) ;
   ( match List.iter2 tdec_params var_params ~f:(fun _ _ -> ()) with
   | Ok _ ->
       ()
   | Unequal_lengths ->
-      raise (Error (loc, Extension_different_arity var_ident.txt)) ) ;
+      raise (Error (loc, env, Extension_different_arity var_ident.txt)) ) ;
   let tdec_ident =
     match path with
     | Pident name ->
@@ -1385,21 +1390,21 @@ let check (ast : statement list) (env : Envi.t) =
 
 open Format
 
-let pp_typ = Typeprint.type_expr
+let pp_typ = ref (fun _fmt _typ -> failwith "Typechecked.pp_typ uninitialised")
 
 let rec report_error ppf = function
   | Check_failed (typ, constr_typ, err) ->
       fprintf ppf
         "@[<v>@[<hov>Incompatible types@ @[<h>%a@] and@ @[<h>%a@]:@]@;%a@]"
-        pp_typ typ pp_typ constr_typ report_error err
+        !pp_typ typ !pp_typ constr_typ report_error err
   | Cannot_unify (typ, constr_typ) ->
-      fprintf ppf "@[<hov>Cannot unify@ @[<h>%a@] and@ @[<h>%a@]@]" pp_typ typ
-        pp_typ constr_typ
+      fprintf ppf "@[<hov>Cannot unify@ @[<h>%a@] and@ @[<h>%a@]@]" !pp_typ typ
+        !pp_typ constr_typ
   | Recursive_variable typ ->
       fprintf ppf
         "@[<hov>The variable@ @[<h>%a@] would have an instance that contains \
          itself.@]"
-        pp_typ typ
+        !pp_typ typ
   | Unbound (kind, value) ->
       fprintf ppf "@[<hov>Unbound %s@ %a.@]" kind Longident.pp value.txt
   | Unbound_value value ->
@@ -1422,7 +1427,7 @@ let rec report_error ppf = function
       fprintf ppf
         "@[<hov>This record expression is expected to have type@ \
          @[<h>%a@]@;The field %a does not belong to type@ @[<h>%a@].@]"
-        pp_typ typ Longident.pp field pp_typ typ
+        !pp_typ typ Longident.pp field !pp_typ typ
   | Repeated_field field ->
       fprintf ppf "@[<hov>The record field %a is defined several times.@]"
         Ident.pprint field
@@ -1443,7 +1448,7 @@ let rec report_error ppf = function
       fprintf ppf
         "@[<hov>Could not find an instance for an implicit variable of type@ \
          @[<h>%a@].@]"
-        pp_typ typ
+        !pp_typ typ
   | Argument_expected lid ->
       fprintf ppf "@[<hov>The constructor %a expects an argument.@]"
         Longident.pp lid
@@ -1458,7 +1463,15 @@ let rec report_error ppf = function
 
 let () =
   Location.register_error_of_exn (function
-    | Error (loc, err) ->
-        Some (Location.error_of_printer ~loc report_error err)
+    | Error (loc, env, err) ->
+        let snap = Type1.Snapshot.create () in
+        let set_var_names = Envi.set_var_names env in
+        (pp_typ :=
+           fun fmt typ ->
+             Typeprint.type_expr fmt
+               (set_var_names.type_expr set_var_names typ)) ;
+        let err_msg = Location.error_of_printer ~loc report_error err in
+        (pp_typ := fun _fmt _typ -> failwith "Typechecked.pp_typ uninitialised") ;
+        Type1.backtrack snap ; Some err_msg
     | _ ->
         None )

--- a/meja/tests/module-scoping.stderr
+++ b/meja/tests/module-scoping.stderr
@@ -1,4 +1,4 @@
 File "tests/module-scoping.meja", line 33, characters 14-15:
-Error: Incompatible types B.t -> B.A.t -> B.B.t -> _ and
-       t -> A.t -> B.t -> _:
+Error: Incompatible types B.t -> B.A.t -> B.B.t -> 'a and
+       t -> A.t -> B.t -> 'b:
        Cannot unify B.t and t

--- a/meja/tests/record_wrong_accessor.stderr
+++ b/meja/tests/record_wrong_accessor.stderr
@@ -1,3 +1,3 @@
 File "tests/record_wrong_accessor.meja", line 9, characters 8-9:
-Error: Incompatible types X.t(_) and t(int, int, int):
-       Cannot unify X.t(_) and t(int, int, int)
+Error: Incompatible types X.t('a) and t(int, int, int):
+       Cannot unify X.t('a) and t(int, int, int)

--- a/meja/tests/recursive-type.stderr
+++ b/meja/tests/recursive-type.stderr
@@ -1,3 +1,3 @@
 File "tests/recursive-type.meja", line 11, characters 10-11:
-Error: Incompatible types (_, _) and (_, (_, _)):
-       The variable _ would have an instance that contains itself.
+Error: Incompatible types ('c, 'd) and ('c, ('c, 'd)):
+       The variable 'd would have an instance that contains itself.

--- a/meja/tests/wrong_labelled_arg.stderr
+++ b/meja/tests/wrong_labelled_arg.stderr
@@ -1,3 +1,3 @@
 File "tests/wrong_labelled_arg.meja", line 3, characters 27-31:
-Error: Incompatible types a:_ -> _ and b:_ -> _:
-       Cannot unify a:_ -> _ and b:_ -> _
+Error: Incompatible types a:'a -> 'a and b:'b -> 'c:
+       Cannot unify a:'a -> 'a and b:'b -> 'c

--- a/meja/tests/wrong_optional_arg.stderr
+++ b/meja/tests/wrong_optional_arg.stderr
@@ -1,3 +1,3 @@
 File "tests/wrong_optional_arg.meja", line 5, characters 32-34:
-Error: Incompatible types option(_) and int:
-       Cannot unify option(_) and int
+Error: Incompatible types option('a) and int:
+       Cannot unify option('a) and int


### PR DESCRIPTION
This PR
* adds a mechanism for generating distinct type variable names
* uses this mechanism to assign distinct type variable names to each type in `Typechecker` error messages
  - This makes several ambiguous/unclear error messages clearer, most notably `tests/recursive-type.stderr`

This will also form a necessary part of printing out module signatures when performing multi-file builds: we will need to functor the module over the snarky interface *and the signatures of all modules on which it depends* in order to allow switching between fields and proof systems easily, and so we need to be able to print signatures including type variables unambiguously.