### PR TITLE
[Meja] Signatures

### DIFF
--- a/meja/meja.ml
+++ b/meja/meja.ml
@@ -59,6 +59,7 @@ let add_preamble impl_mod curve proofs ast =
 let main =
   let file = ref None in
   let ocaml_file = ref None in
+  let meji_file = ref None in
   let ast_file = ref None in
   let binml_file = ref None in
   let default = ref true in
@@ -89,6 +90,9 @@ let main =
     ; ( "--binml"
       , Arg.String (set_and_clear_default binml_file)
       , "output a binary ml file" )
+    ; ( "--meji-out"
+      , Arg.String (set_and_clear_default meji_file)
+      , "output a meja interface file" )
     ; ( "--meji"
       , Arg.String (fun filename -> meji_files := filename :: !meji_files)
       , "load a .meji interface file" )
@@ -250,6 +254,10 @@ let main =
         Pparse.write_ast Pparse.Structure file ocaml_ast
     | None ->
         () ) ;
+    do_output !meji_file (fun fmt ->
+        Typeprint.signature fmt
+          (List.concat_map ast ~f:(fun stmt -> stmt.stmt_sig)) ;
+        Format.pp_print_newline fmt () ) ;
     exit 0
   with exn ->
     ( if !exn_backtraces then

--- a/meja/ocaml/of_typedast.ml
+++ b/meja/ocaml/of_typedast.ml
@@ -532,7 +532,7 @@ and of_module_sig_desc ?loc = function
               "Cannot generate OCaml for a functor signature with an abstract \
                signature"
       in
-      Some (Mty.functor_ ?loc name (of_module_sig f) msig)
+      Some (Mty.functor_ ?loc (of_ident_loc name) (of_module_sig f) msig)
 
 and of_module_sig msig = of_module_sig_desc ~loc:msig.msig_loc msig.msig_desc
 
@@ -611,6 +611,7 @@ and of_module_desc ?loc = function
   | Tmod_name name ->
       Mod.ident ?loc (of_path_loc name)
   | Tmod_functor (name, f, m) ->
-      Mod.functor_ ?loc name (of_module_sig f) (of_module_expr m)
+      Mod.functor_ ?loc (of_ident_loc name) (of_module_sig f)
+        (of_module_expr m)
 
 let of_file = List.map ~f:of_statement

--- a/meja/scripts/run-tests.sh
+++ b/meja/scripts/run-tests.sh
@@ -44,7 +44,7 @@ run_test() {
   else
     BACKTRACE_FLAG="--compiler-backtraces"
   fi
-  run_dune exec meja/meja.exe -- $BACKTRACE_FLAG --ml "tests/out/$1.ml" --stderr "tests/out/$1.stderr" "tests/$1.meja" 2> /dev/null
+  run_dune exec meja/meja.exe -- $BACKTRACE_FLAG --ml "tests/out/$1.ml" --meji-out "tests/out/$1.meji" --stderr "tests/out/$1.stderr" "tests/$1.meja" 2> /dev/null
   if [ $? -ne 0 ]; then
     if [ -e "tests/$1.fail" ]; then
       if [[ "$update_output" -eq 0 ]]; then
@@ -79,6 +79,7 @@ run_test() {
     ocamlformat tests/out/$1.ml > tests/out/$1.ml.reformat &&
     mv tests/out/$1.ml.reformat tests/out/$1.ml
     check_diff $1.ml
+    check_diff $1.meji
   fi
     check_diff $1.stderr
 }

--- a/meja/src/envi.ml
+++ b/meja/src/envi.ml
@@ -310,7 +310,7 @@ module Scope = struct
       let scope = subst scope in
       backtrack_replace snap ; scope
 
-  let build_subst ~type_subst ~module_subst ~expr_subst s
+  let build_subst ~type_subst ~module_subst ?expr_subst s
       { kind= _
       ; names= _
       ; type_variables= _
@@ -332,9 +332,13 @@ module Scope = struct
           Subst.with_module src_path dst_path s )
     in
     let s =
-      List.fold ~init:s instances ~f:(fun s (local_path, global_path, _) ->
-          let src_path, dst_path = expr_subst ~local_path global_path in
-          Subst.with_expression src_path dst_path s )
+      match expr_subst with
+      | Some expr_subst ->
+          List.fold ~init:s instances ~f:(fun s (local_path, global_path, _) ->
+              let src_path, dst_path = expr_subst ~local_path global_path in
+              Subst.with_expression src_path dst_path s )
+      | None ->
+          s
     in
     s
 

--- a/meja/src/pprint.ml
+++ b/meja/src/pprint.ml
@@ -311,12 +311,15 @@ let rec signature_desc fmt = function
 
 and signature_item fmt sigi = signature_desc fmt sigi.sig_desc
 
-and signature fmt sigs = List.iter (signature_item fmt) sigs
+and signature fmt sigs =
+  fprintf fmt "@[<hv>" ;
+  List.iter (signature_item fmt) sigs ;
+  fprintf fmt "@]"
 
 and module_sig_desc ~prefix fmt = function
   | Pmty_sig msig ->
       prefix fmt ;
-      fprintf fmt "{@[<hv1>@;%a@]}" signature msig
+      fprintf fmt "{@[<1>@;%a@]}" signature msig
   | Pmty_name name ->
       prefix fmt ; Longident.pp fmt name.txt
   | Pmty_alias name ->

--- a/meja/src/type0.ml
+++ b/meja/src/type0.ml
@@ -69,6 +69,5 @@ and module_sig =
   | Mname of Path.t
   | Malias of Path.t
   | Mabstract
-  (* TODO: The first argument should be an Ident.t. *)
-  | Mfunctor of string * module_sig * module_sig
+  | Mfunctor of Ident.t * module_sig * module_sig
 [@@deriving sexp]

--- a/meja/src/type0.ml
+++ b/meja/src/type0.ml
@@ -49,3 +49,26 @@ and type_decl_desc =
   | TExtend of Path.t * ctor_decl list
       (** Internal; this should never be present in the AST. *)
 [@@deriving sexp]
+
+type signature = signature_item list [@@deriving sexp]
+
+and signature_item =
+  | Svalue of Ident.t * type_expr
+  | Sinstance of Ident.t * type_expr
+  | Stype of Ident.t * type_decl
+  | Srectype of (Ident.t * type_decl) list
+  | Smodule of Ident.t * module_sig
+  | Smodtype of Ident.t * module_sig
+  | Stypeext of variant * ctor_decl list
+  | Srequest of type_expr * ctor_decl
+  | Sprover of signature
+[@@deriving sexp]
+
+and module_sig =
+  | Msig of signature
+  | Mname of Path.t
+  | Malias of Path.t
+  | Mabstract
+  (* TODO: The first argument should be an Ident.t. *)
+  | Mfunctor of string * module_sig * module_sig
+[@@deriving sexp]

--- a/meja/src/type0.ml
+++ b/meja/src/type0.ml
@@ -61,12 +61,18 @@ and type_decl_desc =
       (** Internal; this should never be present in the AST. *)
 [@@deriving sexp]
 
+type conv_type =
+  | Conv_with of Ident.t * mode * type_decl
+  | Conv_to of type_expr
+[@@deriving sexp]
+
 type signature = signature_item list [@@deriving sexp]
 
 and signature_item =
   | Svalue of Ident.t * type_expr
   | Sinstance of Ident.t * type_expr
   | Stype of Ident.t * type_decl
+  | Sconvtype of Ident.t * type_decl * conv_type * Ident.t * type_expr
   | Srectype of (Ident.t * type_decl) list
   | Smodule of Ident.t * module_sig
   | Smodtype of Ident.t * module_sig

--- a/meja/src/typechecker.ml
+++ b/meja/src/typechecker.ml
@@ -1156,6 +1156,7 @@ and check_module_sig env msig =
       , env )
   | Pmty_functor (f_name, f, msig) ->
       let f, f_mty, env = check_module_sig env f in
+      let f_name = map_loc ~f:(Ident.create ~mode) f_name in
       let ftor f_instance =
         (* We want the functored module to be accessible only in un-prefixed
            space.
@@ -1164,7 +1165,6 @@ and check_module_sig env msig =
         (* TODO: This name should be constant, and the underlying module
            substituted.
         *)
-        let f_name = map_loc ~f:(Ident.create ~mode) f_name in
         let env =
           match f_instance with
           | Envi.Scope.Immediate f ->
@@ -1430,6 +1430,7 @@ and check_module_expr env m =
       (* Remove the module placed on the stack by the caller. *)
       let _, env = Envi.pop_module ~loc env in
       let f, f', env = check_module_sig env f in
+      let f_name = map_loc ~f:(Ident.create ~mode) f_name in
       let ftor f_instance =
         (* We want the functored module to be accessible only in un-prefixed
            space.
@@ -1438,7 +1439,6 @@ and check_module_expr env m =
         (* TODO: This name should be constant, and the underlying module
            substituted.
         *)
-        let f_name = map_loc ~f:(Ident.create ~mode) f_name in
         let env =
           match f_instance with
           | Envi.Scope.Immediate f ->

--- a/meja/src/typechecker.ml
+++ b/meja/src/typechecker.ml
@@ -974,7 +974,10 @@ let type_extension ~loc variant ctors env =
   in
   let variant =
     { Typedast.var_ident= Location.mkloc path var_ident.loc
-    ; var_params= decl.tdec_params }
+    ; var_params= decl.tdec_params
+    ; var_var=
+        { var_ident= path
+        ; var_params= List.map decl.tdec_params ~f:(fun x -> x.type_type) } }
   in
   (env, variant, ctors)
 

--- a/meja/src/typedast.ml
+++ b/meja/src/typedast.ml
@@ -17,7 +17,8 @@ and type_desc =
   | Ttyp_poly of type_expr list * type_expr
   | Ttyp_prover of type_expr
 
-and variant = {var_ident: path; var_params: type_expr list}
+and variant =
+  {var_ident: path; var_params: type_expr list; var_var: Type0.variant}
 
 type field_decl =
   { fld_ident: ident

--- a/meja/src/typedast.ml
+++ b/meja/src/typedast.ml
@@ -138,7 +138,7 @@ and module_sig_desc =
   | Tmty_name of path
   | Tmty_alias of path
   | Tmty_abstract
-  | Tmty_functor of str * module_sig * module_sig
+  | Tmty_functor of ident * module_sig * module_sig
 
 type statement =
   {stmt_desc: statement_desc; stmt_loc: Location.t; stmt_sig: Type0.signature}
@@ -165,4 +165,4 @@ and module_expr =
 and module_desc =
   | Tmod_struct of statements
   | Tmod_name of path
-  | Tmod_functor of str * module_sig * module_expr
+  | Tmod_functor of ident * module_sig * module_expr

--- a/meja/src/typedast.ml
+++ b/meja/src/typedast.ml
@@ -109,7 +109,8 @@ and expression_desc =
   | Texp_if of expression * expression * expression option
   | Texp_prover of expression
 
-type signature_item = {sig_desc: signature_desc; sig_loc: Location.t}
+type signature_item =
+  {sig_desc: signature_desc; sig_loc: Location.t; sig_sig: Type0.signature}
 
 and signature = signature_item list
 
@@ -127,7 +128,10 @@ and signature_desc =
   | Tsig_multiple of signature
   | Tsig_prover of signature
 
-and module_sig = {msig_desc: module_sig_desc; msig_loc: Location.t}
+and module_sig =
+  { msig_desc: module_sig_desc
+  ; msig_loc: Location.t
+  ; msig_msig: Type0.module_sig }
 
 and module_sig_desc =
   | Tmty_sig of signature
@@ -136,7 +140,8 @@ and module_sig_desc =
   | Tmty_abstract
   | Tmty_functor of str * module_sig * module_sig
 
-type statement = {stmt_desc: statement_desc; stmt_loc: Location.t}
+type statement =
+  {stmt_desc: statement_desc; stmt_loc: Location.t; stmt_sig: Type0.signature}
 
 and statements = statement list
 
@@ -154,7 +159,8 @@ and statement_desc =
   | Tstmt_multiple of statements
   | Tstmt_prover of statements
 
-and module_expr = {mod_desc: module_desc; mod_loc: Location.t}
+and module_expr =
+  {mod_desc: module_desc; mod_loc: Location.t; mod_msig: Type0.module_sig}
 
 and module_desc =
   | Tmod_struct of statements

--- a/meja/src/typedast_iter.ml
+++ b/meja/src/typedast_iter.ml
@@ -68,8 +68,10 @@ let type_desc iter = function
   | Ttyp_prover typ ->
       iter.type_expr iter typ
 
-let variant iter {var_ident; var_params} =
+let variant iter {var_ident; var_params; var_var} =
   path iter var_ident ;
+  (* No iteration into [var_var]. May be done manually. *)
+  ignore var_var ;
   List.iter ~f:(iter.type_expr iter) var_params
 
 let field_decl iter {fld_ident; fld_type; fld_loc; fld_fld} =

--- a/meja/src/typedast_iter.ml
+++ b/meja/src/typedast_iter.ml
@@ -78,7 +78,7 @@ let field_decl iter {fld_ident; fld_type; fld_loc; fld_fld} =
   iter.location iter fld_loc ;
   ident iter fld_ident ;
   iter.type_expr iter fld_type ;
-  (* TODO: Type0_iterator *)
+  (* No iteration into [fld_fld]. May be done manually. *)
   ignore fld_fld
 
 let ctor_args iter = function
@@ -92,7 +92,7 @@ let ctor_decl iter {ctor_ident; ctor_args; ctor_ret; ctor_loc; ctor_ctor} =
   ident iter ctor_ident ;
   iter.ctor_args iter ctor_args ;
   Option.iter ~f:(iter.type_expr iter) ctor_ret ;
-  (* TODO: Type0_iterator *)
+  (* No iteration into [ctor_ctor]. May be done manually. *)
   ignore ctor_ctor
 
 let type_decl iter {tdec_ident; tdec_params; tdec_desc; tdec_loc; tdec_tdec} =
@@ -100,7 +100,7 @@ let type_decl iter {tdec_ident; tdec_params; tdec_desc; tdec_loc; tdec_tdec} =
   ident iter tdec_ident ;
   List.iter ~f:(iter.type_expr iter) tdec_params ;
   iter.type_decl_desc iter tdec_desc ;
-  (* TODO: Type0_iterator *)
+  (* No iteration into [tdec_tdec]. May be done manually. *)
   ignore tdec_tdec
 
 let type_decl_desc iter = function
@@ -222,8 +222,10 @@ let convert_desc iter = function
 
 let signature iter = List.iter ~f:(iter.signature_item iter)
 
-let signature_item iter {sig_desc; sig_loc} =
+let signature_item iter {sig_desc; sig_loc; sig_sig} =
   iter.location iter sig_loc ;
+  (* No iteration into [sig_sig]. May be done manually. *)
+  ignore sig_sig ;
   iter.signature_desc iter sig_desc
 
 let signature_desc iter = function
@@ -247,8 +249,10 @@ let signature_desc iter = function
   | Tsig_prover sigs ->
       iter.signature iter sigs
 
-let module_sig iter {msig_desc; msig_loc} =
+let module_sig iter {msig_desc; msig_loc; msig_msig} =
   iter.location iter msig_loc ;
+  (* No iteration into [msig_msig]. May be done manually. *)
+  ignore msig_msig ;
   iter.module_sig_desc iter msig_desc
 
 let module_sig_desc iter = function
@@ -265,8 +269,10 @@ let module_sig_desc iter = function
 
 let statements iter = List.iter ~f:(iter.statement iter)
 
-let statement iter {stmt_desc; stmt_loc} =
+let statement iter {stmt_desc; stmt_loc; stmt_sig} =
   iter.location iter stmt_loc ;
+  (* No iteration into [stmt_sig]. May be done manually. *)
+  ignore stmt_sig ;
   iter.statement_desc iter stmt_desc
 
 let statement_desc iter = function
@@ -298,8 +304,10 @@ let statement_desc iter = function
   | Tstmt_prover stmts ->
       iter.statements iter stmts
 
-let module_expr iter {mod_desc; mod_loc} =
+let module_expr iter {mod_desc; mod_loc; mod_msig} =
   iter.location iter mod_loc ;
+  (* No iteration into [mod_msig]. May be done manually. *)
+  ignore mod_msig ;
   iter.module_desc iter mod_desc
 
 let module_desc iter = function

--- a/meja/src/typedast_iter.ml
+++ b/meja/src/typedast_iter.ml
@@ -265,7 +265,7 @@ let module_sig_desc iter = function
   | Tmty_abstract ->
       ()
   | Tmty_functor (name, fsig, msig) ->
-      str iter name ; iter.module_sig iter fsig ; iter.module_sig iter msig
+      ident iter name ; iter.module_sig iter fsig ; iter.module_sig iter msig
 
 let statements iter = List.iter ~f:(iter.statement iter)
 
@@ -316,7 +316,7 @@ let module_desc iter = function
   | Tmod_name name ->
       path iter name
   | Tmod_functor (name, fsig, me) ->
-      str iter name ; iter.module_sig iter fsig ; iter.module_expr iter me
+      ident iter name ; iter.module_sig iter fsig ; iter.module_expr iter me
 
 let location (_iter : iterator) (_ : Location.t) = ()
 

--- a/meja/src/typedast_map.ml
+++ b/meja/src/typedast_map.ml
@@ -84,9 +84,10 @@ let type_desc mapper typ =
   | Ttyp_prover typ ->
       Ttyp_prover (mapper.type_expr mapper typ)
 
-let variant mapper {var_ident; var_params} =
+let variant mapper {var_ident; var_params; var_var} =
   { var_ident= path mapper var_ident
-  ; var_params= List.map ~f:(mapper.type_expr mapper) var_params }
+  ; var_params= List.map ~f:(mapper.type_expr mapper) var_params
+  ; var_var= mapper.type0.variant mapper.type0 var_var }
 
 let field_decl mapper {fld_ident; fld_type; fld_loc; fld_fld} =
   { fld_loc= mapper.location mapper fld_loc

--- a/meja/src/typedast_map.ml
+++ b/meja/src/typedast_map.ml
@@ -301,7 +301,7 @@ let module_sig_desc mapper = function
       Tmty_abstract
   | Tmty_functor (name, fsig, msig) ->
       Tmty_functor
-        ( str mapper name
+        ( ident mapper name
         , mapper.module_sig mapper fsig
         , mapper.module_sig mapper msig )
 
@@ -354,7 +354,7 @@ let module_desc mapper = function
       Tmod_name (path mapper name)
   | Tmod_functor (name, fsig, me) ->
       Tmod_functor
-        ( str mapper name
+        ( ident mapper name
         , mapper.module_sig mapper fsig
         , mapper.module_expr mapper me )
 

--- a/meja/src/typedast_map.ml
+++ b/meja/src/typedast_map.ml
@@ -255,9 +255,10 @@ let expression_desc mapper = function
 
 let signature mapper = List.map ~f:(mapper.signature_item mapper)
 
-let signature_item mapper {sig_desc; sig_loc} =
+let signature_item mapper {sig_desc; sig_loc; sig_sig} =
   { sig_loc= mapper.location mapper sig_loc
-  ; sig_desc= mapper.signature_desc mapper sig_desc }
+  ; sig_desc= mapper.signature_desc mapper sig_desc
+  ; sig_sig= mapper.type0.signature mapper.type0 sig_sig }
 
 let signature_desc mapper = function
   | Tsig_value (name, typ) ->
@@ -284,9 +285,10 @@ let signature_desc mapper = function
   | Tsig_prover sigs ->
       Tsig_prover (mapper.signature mapper sigs)
 
-let module_sig mapper {msig_desc; msig_loc} =
+let module_sig mapper {msig_desc; msig_loc; msig_msig} =
   { msig_loc= mapper.location mapper msig_loc
-  ; msig_desc= mapper.module_sig_desc mapper msig_desc }
+  ; msig_desc= mapper.module_sig_desc mapper msig_desc
+  ; msig_msig= mapper.type0.module_sig mapper.type0 msig_msig }
 
 let module_sig_desc mapper = function
   | Tmty_sig sigs ->
@@ -305,9 +307,10 @@ let module_sig_desc mapper = function
 
 let statements mapper = List.map ~f:(mapper.statement mapper)
 
-let statement mapper {stmt_desc; stmt_loc} =
+let statement mapper {stmt_desc; stmt_loc; stmt_sig} =
   { stmt_loc= mapper.location mapper stmt_loc
-  ; stmt_desc= mapper.statement_desc mapper stmt_desc }
+  ; stmt_desc= mapper.statement_desc mapper stmt_desc
+  ; stmt_sig= mapper.type0.signature mapper.type0 stmt_sig }
 
 let statement_desc mapper = function
   | Tstmt_value (p, e) ->
@@ -339,9 +342,10 @@ let statement_desc mapper = function
   | Tstmt_prover stmts ->
       Tstmt_prover (mapper.statements mapper stmts)
 
-let module_expr mapper {mod_desc; mod_loc} =
+let module_expr mapper {mod_desc; mod_loc; mod_msig} =
   { mod_loc= mapper.location mapper mod_loc
-  ; mod_desc= mapper.module_desc mapper mod_desc }
+  ; mod_desc= mapper.module_desc mapper mod_desc
+  ; mod_msig= mapper.type0.module_sig mapper.type0 mod_msig }
 
 let module_desc mapper = function
   | Tmod_struct stmts ->

--- a/meja/src/typeprint.ml
+++ b/meja/src/typeprint.ml
@@ -101,9 +101,7 @@ let type_decl_desc fmt = function
         (pp_print_list ~pp_sep:comma_sep field_decl)
         fields
   | TVariant ctors ->
-      fprintf fmt " =@ %a"
-        (pp_print_list ~pp_sep:bar_sep ctor_decl)
-        ctors
+      fprintf fmt " =@ %a" (pp_print_list ~pp_sep:bar_sep ctor_decl) ctors
   | TOpen ->
       fprintf fmt " =@ .."
   | TExtend (name, ctors) ->

--- a/meja/src/typeprint.ml
+++ b/meja/src/typeprint.ml
@@ -99,7 +99,10 @@ let and_type_decl fmt (ident, decl) =
   (match decl.tdec_params with [] -> () | _ -> tuple fmt decl.tdec_params) ;
   type_decl_desc fmt decl.tdec_desc
 
-let rec signature fmt sigs = List.iter (signature_item fmt) sigs
+let rec signature fmt sigs =
+  fprintf fmt "@[<hv>" ;
+  List.iter (signature_item fmt) sigs ;
+  fprintf fmt "@]"
 
 and signature_item fmt = function
   | Svalue (name, typ) ->
@@ -139,7 +142,7 @@ and signature_item fmt = function
 and module_sig ~prefix fmt = function
   | Msig msig ->
       prefix fmt ;
-      fprintf fmt "{@[<hv1>@;%a@]}" signature msig
+      fprintf fmt "{@[<1>@;%a@]}" signature msig
   | Mname name ->
       prefix fmt ; Path.pp fmt name
   | Malias name ->

--- a/meja/src/typeprint.ml
+++ b/meja/src/typeprint.ml
@@ -95,24 +95,28 @@ let type_decl_desc fmt = function
   | TAbstract ->
       ()
   | TAlias typ ->
-      fprintf fmt "@ =@ @[<hv>%a@]" type_expr typ
+      fprintf fmt " =@ %a" type_expr typ
   | TRecord fields ->
-      fprintf fmt "@ =@ {@[<hv2>%a@]}"
+      fprintf fmt " =@ {@[<hv2>%a@]}"
         (pp_print_list ~pp_sep:comma_sep field_decl)
         fields
   | TVariant ctors ->
-      fprintf fmt "@ =@ %a" (pp_print_list ~pp_sep:bar_sep ctor_decl) ctors
+      fprintf fmt " =@ %a"
+        (pp_print_list ~pp_sep:bar_sep ctor_decl)
+        ctors
   | TOpen ->
-      fprintf fmt "@ =@ .."
+      fprintf fmt " =@ .."
   | TExtend (name, ctors) ->
       fprintf fmt "@ /*@[%a +=@ %a@]*/" Path.pp name
         (pp_print_list ~pp_sep:bar_sep ctor_decl)
         ctors
 
 let type_decl type_keyword fmt (ident, decl) =
-  fprintf fmt "%s %a" type_keyword Ident.pprint ident ;
+  fprintf fmt "@[<hov2>%s @[<hv>%a@," type_keyword Ident.pprint ident ;
   (match decl.tdec_params with [] -> () | _ -> tuple fmt decl.tdec_params) ;
-  type_decl_desc fmt decl.tdec_desc
+  fprintf fmt "@]" ;
+  type_decl_desc fmt decl.tdec_desc ;
+  fprintf fmt "@]"
 
 let conv_type fmt = function
   | Conv_with (ident, mode, decl) ->

--- a/meja/src/typet.ml
+++ b/meja/src/typet.ml
@@ -92,7 +92,13 @@ module Type = struct
             (Type1.get_mode mode decl.tdec_ret)
             env
         in
-        ( { type_desc= Ttyp_ctor {var_params; var_ident}
+        ( { type_desc=
+              Ttyp_ctor
+                { var_params
+                ; var_ident
+                ; var_var=
+                    { var_params= List.map ~f:type0 var_params
+                    ; var_ident= var_ident.txt } }
           ; type_loc= loc
           ; type_type= typ }
         , env )

--- a/meja/src/untype_ast.ml
+++ b/meja/src/untype_ast.ml
@@ -253,7 +253,8 @@ and module_sig_desc = function
   | Tmty_abstract ->
       Pmty_abstract
   | Tmty_functor (name, fsig, msig) ->
-      Pmty_functor (name, module_sig fsig, module_sig msig)
+      Pmty_functor
+        (map_loc ~f:Ident.name name, module_sig fsig, module_sig msig)
 
 and module_sig msig =
   { Parsetypes.msig_desc= module_sig_desc msig.Typedast.msig_desc
@@ -298,7 +299,7 @@ and module_desc = function
   | Tmod_name path ->
       Pmod_name (map_loc ~f:longident_of_path path)
   | Tmod_functor (name, fsig, m) ->
-      Pmod_functor (name, module_sig fsig, module_expr m)
+      Pmod_functor (map_loc ~f:Ident.name name, module_sig fsig, module_expr m)
 
 and module_expr m =
   {Parsetypes.mod_desc= module_desc m.Typedast.mod_desc; mod_loc= m.mod_loc}

--- a/meja/src/untype_ast.ml
+++ b/meja/src/untype_ast.ml
@@ -92,7 +92,7 @@ let rec type_desc = function
 and type_expr {type_desc= typ; type_loc; type_type= _} =
   {type_desc= type_desc typ; type_loc}
 
-and variant {Typedast.var_ident; var_params} =
+and variant {Typedast.var_ident; var_params; var_var= _} =
   { Parsetypes.var_ident= map_loc ~f:longident_of_path var_ident
   ; var_params= List.map ~f:type_expr var_params }
 

--- a/meja/tests/comments.meji
+++ b/meja/tests/comments.meji
@@ -1,3 +1,13 @@
-let x : (int, int, int);  let y : (int, int);  let f : int;  let g : int; 
-let h : unit;  let i : unit; 
+let x : (int, int, int);
+
+let y : (int, int);
+
+let f : int;
+
+let g : int;
+
+let h : unit;
+
+let i : unit;
+
 

--- a/meja/tests/comments.meji
+++ b/meja/tests/comments.meji
@@ -1,0 +1,3 @@
+let x : (int, int, int);  let y : (int, int);  let f : int;  let g : int; 
+let h : unit;  let i : unit; 
+

--- a/meja/tests/corecursive-types.meji
+++ b/meja/tests/corecursive-types.meji
@@ -1,7 +1,7 @@
 module type T =
   {
-    type t('a, 'b) = U(T.u('a, 'b)) | A('a);type u('a, 'b) = T(T.t('a, 'b))
-      | B('b)
+    type t('a, 'b) = U(u('a, 'b)) | A('a);type u('a, 'b) = T(t('a, 'b)) | B(
+      'b)
     
     }; 
 type t('a, 'b) = U(u('a, 'b)) | A('a);type u('a, 'b) = T(t('a, 'b)) | B('b) 

--- a/meja/tests/corecursive-types.meji
+++ b/meja/tests/corecursive-types.meji
@@ -3,7 +3,14 @@ module type T =
     type t('a, 'b) = U(u('a, 'b)) | A('a);type u('a, 'b) = T(t('a, 'b)) | B(
       'b)
     
-    }; 
-type t('a, 'b) = U(u('a, 'b)) | A('a);type u('a, 'b) = T(t('a, 'b)) | B('b) 
-let x : t(int, bool);  let y : t(int, bool);  let z : bool -> t(int, bool); 
+    };
+
+type t('a, 'b) = U(u('a, 'b)) | A('a);type u('a, 'b) = T(t('a, 'b)) | B('b)
+
+let x : t(int, bool);
+
+let y : t(int, bool);
+
+let z : bool -> t(int, bool);
+
 

--- a/meja/tests/corecursive-types.meji
+++ b/meja/tests/corecursive-types.meji
@@ -1,11 +1,12 @@
 module type T =
   {
-    type t('a, 'b) = U(u('a, 'b)) | A('a);type u('a, 'b) = T(t('a, 'b)) | B(
-      'b)
+    type t('a, 'b) = U(u('a, 'b)) | A('a)
+    and u('a, 'b) = T(t('a, 'b)) | B('b);
     
     };
 
-type t('a, 'b) = U(u('a, 'b)) | A('a);type u('a, 'b) = T(t('a, 'b)) | B('b)
+type t('a, 'b) = U(u('a, 'b)) | A('a)
+and u('a, 'b) = T(t('a, 'b)) | B('b);
 
 let x : t(int, bool);
 

--- a/meja/tests/corecursive-types.meji
+++ b/meja/tests/corecursive-types.meji
@@ -1,0 +1,9 @@
+module type T =
+  {
+    type t('a, 'b) = U(T.u('a, 'b)) | A('a);type u('a, 'b) = T(T.t('a, 'b))
+      | B('b)
+    
+    }; 
+type t('a, 'b) = U(u('a, 'b)) | A('a);type u('a, 'b) = T(t('a, 'b)) | B('b) 
+let x : t(int, bool);  let y : t(int, bool);  let z : bool -> t(int, bool); 
+

--- a/meja/tests/expression-instance.meji
+++ b/meja/tests/expression-instance.meji
@@ -1,0 +1,11 @@
+let f : {int} -> int;
+
+let g : unit -> int;
+
+let a : {int -> 'a -> 'a} -> 'a -> 'a;
+
+let h : _ -> _ -> _;
+
+let b : unit -> unit;
+
+

--- a/meja/tests/gadt-record-variables.meji
+++ b/meja/tests/gadt-record-variables.meji
@@ -1,0 +1,4 @@
+type t = A{x: 'a} : t;  let x : t;  let y : t; 
+type u(_) = Int(int) : u(int) | Bool(bool) : u(bool) | Unit : u(unit); 
+type v = B{x: u('a)} : v;  let a : v;  let b : v;  let c : v; 
+

--- a/meja/tests/gadt-record-variables.meji
+++ b/meja/tests/gadt-record-variables.meji
@@ -1,4 +1,17 @@
-type t = A{x: 'a} : t;  let x : t;  let y : t; 
-type u(_) = Int(int) : u(int) | Bool(bool) : u(bool) | Unit : u(unit); 
-type v = B{x: u('a)} : v;  let a : v;  let b : v;  let c : v; 
+type t = A{x: 'a} : t;
+
+let x : t;
+
+let y : t;
+
+type u(_) = Int(int) : u(int) | Bool(bool) : u(bool) | Unit : u(unit);
+
+type v = B{x: u('a)} : v;
+
+let a : v;
+
+let b : v;
+
+let c : v;
+
 

--- a/meja/tests/if-then-else.meji
+++ b/meja/tests/if-then-else.meji
@@ -1,0 +1,3 @@
+let x : bool;  let y : unit;  let z : bool -> _ -> _ -> _; 
+let a : bool -> _ -> _ -> _;  let b : unit -> unit; 
+

--- a/meja/tests/if-then-else.meji
+++ b/meja/tests/if-then-else.meji
@@ -1,3 +1,11 @@
-let x : bool;  let y : unit;  let z : bool -> _ -> _ -> _; 
-let a : bool -> _ -> _ -> _;  let b : unit -> unit; 
+let x : bool;
+
+let y : unit;
+
+let z : bool -> _ -> _ -> _;
+
+let a : bool -> _ -> _ -> _;
+
+let b : unit -> unit;
+
 

--- a/meja/tests/implicits.meji
+++ b/meja/tests/implicits.meji
@@ -14,7 +14,9 @@ let h :
       (string, string, string, string, string, string),
       (string, string, string, string, string, string));
 
-type conv('a, 'b) = {conv: 'a -> 'b};
+convertible type conv('a, 'b) = {conv: 'a -> 'b}
+with prover conv('a, 'b) = {conv: 'a -> 'b}
+by conv_typ;
 
 let conv : {conv(_, _)} -> _ -> _;
 

--- a/meja/tests/implicits.meji
+++ b/meja/tests/implicits.meji
@@ -1,0 +1,15 @@
+type showable('a) = {show: 'a -> string}; 
+let show : {showable(_)} -> _ -> string;  let f : 'a -> string; 
+let g : 'a -> 'a -> (string, string, string, string, string, string); 
+let h :
+  int
+  -> bool
+  -> float
+  -> ((string, string, string, string, string, string),
+      (string, string, string, string, string, string),
+      (string, string, string, string, string, string)); 
+type conv('a, 'b) = {conv: 'a -> 'b};  let conv : {conv(_, _)} -> _ -> _; 
+let conv_bool_int : conv(bool, int);  let i : bool -> (int -> 'a) -> 'a; 
+module T : { let conv_int_bool : conv(int, bool);  }; 
+let j : int -> (bool -> 'a) -> 'a; 
+

--- a/meja/tests/implicits.meji
+++ b/meja/tests/implicits.meji
@@ -1,15 +1,29 @@
-type showable('a) = {show: 'a -> string}; 
-let show : {showable(_)} -> _ -> string;  let f : 'a -> string; 
-let g : 'a -> 'a -> (string, string, string, string, string, string); 
+type showable('a) = {show: 'a -> string};
+
+let show : {showable(_)} -> _ -> string;
+
+let f : 'a -> string;
+
+let g : 'a -> 'a -> (string, string, string, string, string, string);
+
 let h :
   int
   -> bool
   -> float
   -> ((string, string, string, string, string, string),
       (string, string, string, string, string, string),
-      (string, string, string, string, string, string)); 
-type conv('a, 'b) = {conv: 'a -> 'b};  let conv : {conv(_, _)} -> _ -> _; 
-let conv_bool_int : conv(bool, int);  let i : bool -> (int -> 'a) -> 'a; 
-module T : { let conv_int_bool : conv(int, bool);  }; 
-let j : int -> (bool -> 'a) -> 'a; 
+      (string, string, string, string, string, string));
+
+type conv('a, 'b) = {conv: 'a -> 'b};
+
+let conv : {conv(_, _)} -> _ -> _;
+
+let conv_bool_int : conv(bool, int);
+
+let i : bool -> (int -> 'a) -> 'a;
+
+module T : { let conv_int_bool : conv(int, bool);  };
+
+let j : int -> (bool -> 'a) -> 'a;
+
 

--- a/meja/tests/labelled_args.meji
+++ b/meja/tests/labelled_args.meji
@@ -1,0 +1,9 @@
+let a : a:_ -> _;  let b : a:int -> int;  let c : ?a:bool -> unit -> bool; 
+let d : a:bool -> ?b:bool -> bool; 
+let e :
+  unit -> (list(int), int, int, bool, bool, bool, bool, bool, bool, bool); 
+let f : a:int -> ?b:bool -> int -> int;  let g : a:int -> int -> int; 
+let h : a:int -> ?b:bool -> int;  let i : ?b:bool -> int -> int; 
+let j : unit -> int;  let j : a:{int} -> b:{option(int)} -> int; 
+let x : int;  let k : int;  let y : option(int);  let l : int; 
+

--- a/meja/tests/labelled_args.meji
+++ b/meja/tests/labelled_args.meji
@@ -1,9 +1,32 @@
-let a : a:_ -> _;  let b : a:int -> int;  let c : ?a:bool -> unit -> bool; 
-let d : a:bool -> ?b:bool -> bool; 
+let a : a:_ -> _;
+
+let b : a:int -> int;
+
+let c : ?a:bool -> unit -> bool;
+
+let d : a:bool -> ?b:bool -> bool;
+
 let e :
-  unit -> (list(int), int, int, bool, bool, bool, bool, bool, bool, bool); 
-let f : a:int -> ?b:bool -> int -> int;  let g : a:int -> int -> int; 
-let h : a:int -> ?b:bool -> int;  let i : ?b:bool -> int -> int; 
-let j : unit -> int;  let j : a:{int} -> b:{option(int)} -> int; 
-let x : int;  let k : int;  let y : option(int);  let l : int; 
+  unit -> (list(int), int, int, bool, bool, bool, bool, bool, bool, bool);
+
+let f : a:int -> ?b:bool -> int -> int;
+
+let g : a:int -> int -> int;
+
+let h : a:int -> ?b:bool -> int;
+
+let i : ?b:bool -> int -> int;
+
+let j : unit -> int;
+
+let j : a:{int} -> b:{option(int)} -> int;
+
+let x : int;
+
+let k : int;
+
+let y : option(int);
+
+let l : int;
+
 

--- a/meja/tests/list.meji
+++ b/meja/tests/list.meji
@@ -1,0 +1,5 @@
+let x : list(int);  let y : list((int, int, int)); 
+let f : list(bool) -> (bool, bool, bool);  let g : (bool, bool, bool); 
+let (!) : bool -> bool;  let (+) : bool -> bool -> bool;  let h : list(bool);
+ let i : list(bool); 
+

--- a/meja/tests/list.meji
+++ b/meja/tests/list.meji
@@ -1,5 +1,17 @@
-let x : list(int);  let y : list((int, int, int)); 
-let f : list(bool) -> (bool, bool, bool);  let g : (bool, bool, bool); 
-let (!) : bool -> bool;  let (+) : bool -> bool -> bool;  let h : list(bool);
- let i : list(bool); 
+let x : list(int);
+
+let y : list((int, int, int));
+
+let f : list(bool) -> (bool, bool, bool);
+
+let g : (bool, bool, bool);
+
+let (!) : bool -> bool;
+
+let (+) : bool -> bool -> bool;
+
+let h : list(bool);
+
+let i : list(bool);
+
 

--- a/meja/tests/list_constructor_override.meji
+++ b/meja/tests/list_constructor_override.meji
@@ -1,6 +1,15 @@
-type nil;  type t('a) = [] : t(nil) | (::)('hd, t('tl)) : t('hd -> 'tl); 
-let x : t(nil);  let y : t(int -> nil); 
-let z : t(int -> bool -> unit -> nil); 
-let z : t(int -> bool -> unit -> nil); 
-module A : { type u('a, 'b) = []('a, 'b);  let x : u(int, bool);  }; 
+type nil;
+
+type t('a) = [] : t(nil) | (::)('hd, t('tl)) : t('hd -> 'tl);
+
+let x : t(nil);
+
+let y : t(int -> nil);
+
+let z : t(int -> bool -> unit -> nil);
+
+let z : t(int -> bool -> unit -> nil);
+
+module A : { type u('a, 'b) = []('a, 'b);  let x : u(int, bool);  };
+
 

--- a/meja/tests/list_constructor_override.meji
+++ b/meja/tests/list_constructor_override.meji
@@ -1,0 +1,6 @@
+type nil;  type t('a) = [] : t(nil) | (::)('hd, t('tl)) : t('hd -> 'tl); 
+let x : t(nil);  let y : t(int -> nil); 
+let z : t(int -> bool -> unit -> nil); 
+let z : t(int -> bool -> unit -> nil); 
+module A : { type u('a, 'b) = []('a, 'b);  let x : A.u(int, bool);  }; 
+

--- a/meja/tests/list_constructor_override.meji
+++ b/meja/tests/list_constructor_override.meji
@@ -2,5 +2,5 @@ type nil;  type t('a) = [] : t(nil) | (::)('hd, t('tl)) : t('hd -> 'tl);
 let x : t(nil);  let y : t(int -> nil); 
 let z : t(int -> bool -> unit -> nil); 
 let z : t(int -> bool -> unit -> nil); 
-module A : { type u('a, 'b) = []('a, 'b);  let x : A.u(int, bool);  }; 
+module A : { type u('a, 'b) = []('a, 'b);  let x : u(int, bool);  }; 
 

--- a/meja/tests/match.meji
+++ b/meja/tests/match.meji
@@ -1,8 +1,25 @@
-let x : int -> bool -> bool;  let y : (int -> int -> int -> _) -> _; 
-type t = {a: int, b: bool};  type u = {f: int -> int}; 
-type v('a, 'b) = {x: 'a, y: 'b, g: 'a -> 'b};  let z : t -> u -> int; 
-let a : t -> u -> int;  let b : int -> int; 
-let c : v('a, bool) -> v(int, bool); 
-type w('a) = A | B(int, int) : w(int) | C(w('b)) : w('b); 
-let d : w(int) -> int;  let if_ : bool -> 'a -> 'a -> 'a; 
+let x : int -> bool -> bool;
+
+let y : (int -> int -> int -> _) -> _;
+
+type t = {a: int, b: bool};
+
+type u = {f: int -> int};
+
+type v('a, 'b) = {x: 'a, y: 'b, g: 'a -> 'b};
+
+let z : t -> u -> int;
+
+let a : t -> u -> int;
+
+let b : int -> int;
+
+let c : v('a, bool) -> v(int, bool);
+
+type w('a) = A | B(int, int) : w(int) | C(w('b)) : w('b);
+
+let d : w(int) -> int;
+
+let if_ : bool -> 'a -> 'a -> 'a;
+
 

--- a/meja/tests/match.meji
+++ b/meja/tests/match.meji
@@ -1,0 +1,8 @@
+let x : int -> bool -> bool;  let y : (int -> int -> int -> _) -> _; 
+type t = {a: int, b: bool};  type u = {f: int -> int}; 
+type v('a, 'b) = {x: 'a, y: 'b, g: 'a -> 'b};  let z : t -> u -> int; 
+let a : t -> u -> int;  let b : int -> int; 
+let c : v('a, bool) -> v(int, bool); 
+type w('a) = A | B(int, int) : w(int) | C(w('b)) : w('b); 
+let d : w(int) -> int;  let if_ : bool -> 'a -> 'a -> 'a; 
+

--- a/meja/tests/match.meji
+++ b/meja/tests/match.meji
@@ -6,7 +6,9 @@ type t = {a: int, b: bool};
 
 type u = {f: int -> int};
 
-type v('a, 'b) = {x: 'a, y: 'b, g: 'a -> 'b};
+convertible type v('a, 'b) = {x: 'a, y: 'b, g: 'a -> 'b}
+with prover v('a, 'b) = {x: 'a, y: 'b, g: 'a -> 'b}
+by v_typ;
 
 let z : t -> u -> int;
 

--- a/meja/tests/module-signature.meji
+++ b/meja/tests/module-signature.meji
@@ -12,5 +12,6 @@ module type S =
     
     module Y : { type t = A | B;  type t += H | G | F  };
     
-    }; 
+    };
+
 

--- a/meja/tests/module-signature.meji
+++ b/meja/tests/module-signature.meji
@@ -4,11 +4,11 @@ module type S =
     
     type x;
     
-    instance x_inst : S.x;
+    instance x_inst : x;
     
-    module X : { type t = ..;  type S.X.t += B | A  };
+    module X : { type t = ..;  type t += B | A  };
     
-    type S.X.t += E | D | C
+    type X.t += E | D | C
     
     module Y : { type t = A | B;  type t += H | G | F  };
     

--- a/meja/tests/module-signature.meji
+++ b/meja/tests/module-signature.meji
@@ -1,0 +1,16 @@
+module type S =
+  {
+    let x : int;
+    
+    type x;
+    
+    instance x_inst : S.x;
+    
+    module X : { type t = ..;  type S.X.t += B | A  };
+    
+    type S.X.t += E | D | C
+    
+    module Y : { type t = A | B;  type t += H | G | F  };
+    
+    }; 
+

--- a/meja/tests/modules.meji
+++ b/meja/tests/modules.meji
@@ -1,4 +1,5 @@
-let x : int; 
+let x : int;
+
 module Test1 :
   {
     let x : int;
@@ -9,15 +10,29 @@ module Test1 :
     
     module Test2 : { let a : (int, int);  };
     
-    };  module Test2 = Test1;  module Test3 = Test1.Test2; 
-module Test4 = Test2.Test2; 
+    };
+
+module Test2 = Test1;
+
+module Test3 = Test1.Test2;
+
+module Test4 = Test2.Test2;
+
 module Test5 :
   {
     module Test :
       { module Test : { module Test = Test4;  let b : int;  };  };
     
-    };  let y : int;  let z : ((int, int), (int, int)); 
-let a : ((int, int), (int, int), (int, int));  let b : ((int, int), int); 
+    };
+
+let y : int;
+
+let z : ((int, int), (int, int));
+
+let a : ((int, int), (int, int), (int, int));
+
+let b : ((int, int), int);
+
 module Test6 :
   {
     let a : (int, int);
@@ -32,7 +47,8 @@ module Test6 :
     
     let e : int;
     
-    }; 
+    };
+
 module Test7 :
   {
     let a : (int, int);
@@ -45,5 +61,6 @@ module Test7 :
     
     let e : int;
     
-    }; 
+    };
+
 

--- a/meja/tests/modules.meji
+++ b/meja/tests/modules.meji
@@ -1,0 +1,49 @@
+let x : int; 
+module Test1 :
+  {
+    let x : int;
+    
+    let y : int;
+    
+    let z : (int, int);
+    
+    module Test2 : { let a : (int, int);  };
+    
+    };  module Test2 = Test1;  module Test3 = Test1.Test2; 
+module Test4 = Test2.Test2; 
+module Test5 :
+  {
+    module Test :
+      { module Test : { module Test = Test4;  let b : int;  };  };
+    
+    };  let y : int;  let z : ((int, int), (int, int)); 
+let a : ((int, int), (int, int), (int, int));  let b : ((int, int), int); 
+module Test6 :
+  {
+    let a : (int, int);
+    
+    let b : int;
+    
+    let c : int;
+    
+    let b : bool;
+    
+    let d : bool;
+    
+    let e : int;
+    
+    }; 
+module Test7 :
+  {
+    let a : (int, int);
+    
+    let b : bool;
+    
+    let c : int;
+    
+    let d : bool;
+    
+    let e : int;
+    
+    }; 
+

--- a/meja/tests/newtype.meji
+++ b/meja/tests/newtype.meji
@@ -1,3 +1,11 @@
-let f : ('a -> 'a) -> 'a -> 'a;  let g : ('a -> 'a) -> 'a -> 'a; 
-let id : _ -> _;  let a : int;  let d : bool; 
+let f : ('a -> 'a) -> 'a -> 'a;
+
+let g : ('a -> 'a) -> 'a -> 'a;
+
+let id : _ -> _;
+
+let a : int;
+
+let d : bool;
+
 

--- a/meja/tests/newtype.meji
+++ b/meja/tests/newtype.meji
@@ -1,0 +1,3 @@
+let f : ('a -> 'a) -> 'a -> 'a;  let g : ('a -> 'a) -> 'a -> 'a; 
+let id : _ -> _;  let a : int;  let d : bool; 
+

--- a/meja/tests/opaque.meji
+++ b/meja/tests/opaque.meji
@@ -1,0 +1,37 @@
+convertible type t = opaque(int)
+with prover t = int
+by typ;
+
+convertible type u('a) = opaque(option('a))
+with prover u('a) = option('a)
+by u_typ;
+
+convertible type v('a, 'b) = opaque(('a, 'b))
+with prover v('a, 'b) = ('a, 'b)
+by v_typ;
+
+Prover {type prover = A;  }
+
+convertible type w = opaque(prover)
+with prover w = prover
+by w_typ;
+
+module A :
+  {
+    convertible type opaque('a, 'b) = ('a, 'b)
+    with prover opaque('a, 'b) = ('a, 'b)
+    by opaque_typ;
+    
+    type t = opaque(int, bool);
+    
+    Prover {type u = opaque(int, bool);  }
+    
+    let opaque : unit;
+    
+    };
+
+convertible type x = opaque(prover)
+with prover x = prover
+by x_typ;
+
+

--- a/meja/tests/open-instance.meji
+++ b/meja/tests/open-instance.meji
@@ -1,0 +1,13 @@
+module X : { let x : int;  };
+
+let f : {int} -> int;
+
+let a : int;
+
+let y : int;
+
+let b : int;
+
+let c : int;
+
+

--- a/meja/tests/open-types.meji
+++ b/meja/tests/open-types.meji
@@ -1,0 +1,5 @@
+type t = ..;  type t += A  type t += B  let a : t;  let b : t; 
+module T : { type t = ..;  type T.t += C  };  let c : T.t;  type T.t += D 
+let d : T.t;  type u('a, 'b) = ..;  type u('a, 'b) += F('a) | E('a, 'b) 
+let e : u(int, bool);  let f : u(int, int);  let g : u(unit, bool); 
+

--- a/meja/tests/open-types.meji
+++ b/meja/tests/open-types.meji
@@ -1,5 +1,5 @@
 type t = ..;  type t += A  type t += B  let a : t;  let b : t; 
-module T : { type t = ..;  type T.t += C  };  let c : T.t;  type T.t += D 
+module T : { type t = ..;  type t += C  };  let c : T.t;  type T.t += D 
 let d : T.t;  type u('a, 'b) = ..;  type u('a, 'b) += F('a) | E('a, 'b) 
 let e : u(int, bool);  let f : u(int, int);  let g : u(unit, bool); 
 

--- a/meja/tests/open-types.meji
+++ b/meja/tests/open-types.meji
@@ -1,5 +1,29 @@
-type t = ..;  type t += A  type t += B  let a : t;  let b : t; 
-module T : { type t = ..;  type t += C  };  let c : T.t;  type T.t += D 
-let d : T.t;  type u('a, 'b) = ..;  type u('a, 'b) += F('a) | E('a, 'b) 
-let e : u(int, bool);  let f : u(int, int);  let g : u(unit, bool); 
+type t = ..;
+
+type t += A
+
+type t += B
+
+let a : t;
+
+let b : t;
+
+module T : { type t = ..;  type t += C  };
+
+let c : T.t;
+
+type T.t += D
+
+let d : T.t;
+
+type u('a, 'b) = ..;
+
+type u('a, 'b) += F('a) | E('a, 'b)
+
+let e : u(int, bool);
+
+let f : u(int, int);
+
+let g : u(unit, bool);
+
 

--- a/meja/tests/operator_names.meji
+++ b/meja/tests/operator_names.meji
@@ -1,4 +1,23 @@
-let (+) : int;  let (-) : int;  let (!) : _ -> int;  let (~-) : _ -> int; 
-let (||) : bool -> bool -> bool;  let a : bool;  let b : bool;  let c : int; 
-let d : int;  let e : int;  let f : (int -> int -> int) -> int; 
+let (+) : int;
+
+let (-) : int;
+
+let (!) : _ -> int;
+
+let (~-) : _ -> int;
+
+let (||) : bool -> bool -> bool;
+
+let a : bool;
+
+let b : bool;
+
+let c : int;
+
+let d : int;
+
+let e : int;
+
+let f : (int -> int -> int) -> int;
+
 

--- a/meja/tests/operator_names.meji
+++ b/meja/tests/operator_names.meji
@@ -1,0 +1,4 @@
+let (+) : int;  let (-) : int;  let (!) : _ -> int;  let (~-) : _ -> int; 
+let (||) : bool -> bool -> bool;  let a : bool;  let b : bool;  let c : int; 
+let d : int;  let e : int;  let f : (int -> int -> int) -> int; 
+

--- a/meja/tests/optional-explicit-argument.meji
+++ b/meja/tests/optional-explicit-argument.meji
@@ -1,2 +1,1 @@
-let f : ?x:int -> ?y:int -> ?z:int -> int -> int; 
-
+let f : ?x:int -> ?y:int -> ?z:int -> int -> int;  

--- a/meja/tests/optional-explicit-argument.meji
+++ b/meja/tests/optional-explicit-argument.meji
@@ -1,0 +1,2 @@
+let f : ?x:int -> ?y:int -> ?z:int -> int -> int; 
+

--- a/meja/tests/patterns.meji
+++ b/meja/tests/patterns.meji
@@ -1,2 +1,1 @@
-let x : int;  let y : int; 
-
+let x : int;  let y : int;  

--- a/meja/tests/patterns.meji
+++ b/meja/tests/patterns.meji
@@ -1,0 +1,2 @@
+let x : int;  let y : int; 
+

--- a/meja/tests/prover-mode.meji
+++ b/meja/tests/prover-mode.meji
@@ -5,6 +5,24 @@ let z : int;
 
 Prover {let z : bool;  }
 
-let z : int;
+let z : opaque(int);
+
+let z : boolean;
+
+convertible type t = {a: field, b: boolean}
+with prover t = {a: field, b: bool}
+by typ;
+
+let failwith_field : string -> field;
+
+Prover {let field_plus : field -> field;  let field_plus : field -> _;  }
+
+let in_out : t -> t;
+
+let a : _ -> _ -> t;
+
+let a_1 : field -> boolean -> t;
+
+let a_2 : field -> t;
 
 

--- a/meja/tests/prover-mode.meji
+++ b/meja/tests/prover-mode.meji
@@ -1,0 +1,4 @@
+module A :
+  { let x : int;  let y : int;  Prover {let x : bool;  let y : bool;  }  }; 
+let z : int;  Prover {let z : bool;  }  let z : int; 
+

--- a/meja/tests/prover-mode.meji
+++ b/meja/tests/prover-mode.meji
@@ -1,4 +1,10 @@
 module A :
-  { let x : int;  let y : int;  Prover {let x : bool;  let y : bool;  }  }; 
-let z : int;  Prover {let z : bool;  }  let z : int; 
+  { let x : int;  let y : int;  Prover {let x : bool;  let y : bool;  }  };
+
+let z : int;
+
+Prover {let z : bool;  }
+
+let z : int;
+
 

--- a/meja/tests/prover-test.meji
+++ b/meja/tests/prover-test.meji
@@ -1,0 +1,4 @@
+module type P = { Prover {let x : int;  let f : bool -> bool;  }  }; 
+module P : { Prover {let x : int;  let f : _ -> _;  }  };  let f : _ -> _; 
+Prover {let g : _ -> _;  }  let h : _ -> _;  let i : unit -> int; 
+

--- a/meja/tests/prover-test.meji
+++ b/meja/tests/prover-test.meji
@@ -1,4 +1,13 @@
-module type P = { Prover {let x : int;  let f : bool -> bool;  }  }; 
-module P : { Prover {let x : int;  let f : _ -> _;  }  };  let f : _ -> _; 
-Prover {let g : _ -> _;  }  let h : _ -> _;  let i : unit -> int; 
+module type P = { Prover {let x : int;  let f : bool -> bool;  }  };
+
+module P : { Prover {let x : int;  let f : _ -> _;  }  };
+
+let f : _ -> _;
+
+Prover {let g : _ -> _;  }
+
+let h : _ -> _;
+
+let i : unit -> int;
+
 

--- a/meja/tests/prover-test.meji
+++ b/meja/tests/prover-test.meji
@@ -8,6 +8,14 @@ Prover {let g : _ -> _;  }
 
 let h : _ -> _;
 
-let i : unit -> int;
+let i : unit -> opaque(int);
+
+type either('a, 'b) = Fst('a) | Snd('b);
+
+let j : _ -> _ -> opaque(either(_, int));
+
+let k : field -> opaque(either(_, int));
+
+let l : boolean -> boolean -> opaque(either(_, int));
 
 

--- a/meja/tests/prover-types.meji
+++ b/meja/tests/prover-types.meji
@@ -1,4 +1,9 @@
-type t;  Prover {type t1;  type t2;  } 
-let f : (t -> t1 -> t2) -> t -> t1 -> t2; 
-Prover {let f : (t -> t1 -> t2) -> t -> t1 -> t2;  } 
+type t;
+
+Prover {type t1;  type t2;  }
+
+let f : (t -> t1 -> t2) -> t -> t1 -> t2;
+
+Prover {let f : (t -> t1 -> t2) -> t -> t1 -> t2;  }
+
 

--- a/meja/tests/prover-types.meji
+++ b/meja/tests/prover-types.meji
@@ -1,0 +1,4 @@
+type t;  Prover {type t1;  type t2;  } 
+let f : (t -> t1 -> t2) -> t -> t1 -> t2; 
+Prover {let f : (t -> t1 -> t2) -> t -> t1 -> t2;  } 
+

--- a/meja/tests/prover-types.meji
+++ b/meja/tests/prover-types.meji
@@ -2,7 +2,7 @@ type t;
 
 Prover {type t1;  type t2;  }
 
-let f : (t -> t1 -> t2) -> t -> t1 -> t2;
+let f : (t -> opaque(t1) -> opaque(t2)) -> t -> opaque(t1) -> opaque(t2);
 
 Prover {let f : (t -> t1 -> t2) -> t -> t1 -> t2;  }
 

--- a/meja/tests/records.meji
+++ b/meja/tests/records.meji
@@ -1,0 +1,16 @@
+type t('a, 'b, 'c) = {a: 'a, b: 'b, c: 'c}; 
+let typ : Typ.t(t('a2, 'b2, 'c2), t('a1, 'b1, 'c1)); 
+let x : t(int, int, int);  let y : t(bool, bool, bool); 
+let z : t(int, bool, unit); 
+module X :
+  {
+    type t('a) = {a: 'a, b: 'a, c: 'a};
+    
+    let typ : Typ.t(X.t('a2), X.t('a1));
+    
+    let x : X.t(int);
+    
+    };  let a : X.t(int);  let b : X.t(int);  let c : t(int, int, int); 
+let d : (int, int);  let e : int;  let f : bool;  let g : unit; 
+let h : unit; 
+

--- a/meja/tests/records.meji
+++ b/meja/tests/records.meji
@@ -1,6 +1,6 @@
-type t('a, 'b, 'c) = {a: 'a, b: 'b, c: 'c};
-
-let typ : Typ.t(t('a2, 'b2, 'c2), t('a1, 'b1, 'c1));
+convertible type t('a, 'b, 'c) = {a: 'a, b: 'b, c: 'c}
+with prover t('a, 'b, 'c) = {a: 'a, b: 'b, c: 'c}
+by typ;
 
 let x : t(int, int, int);
 
@@ -10,9 +10,9 @@ let z : t(int, bool, unit);
 
 module X :
   {
-    type t('a) = {a: 'a, b: 'a, c: 'a};
-    
-    let typ : Typ.t(t('a2), t('a1));
+    convertible type t('a) = {a: 'a, b: 'a, c: 'a}
+    with prover t('a) = {a: 'a, b: 'a, c: 'a}
+    by typ;
     
     let x : t(int);
     

--- a/meja/tests/records.meji
+++ b/meja/tests/records.meji
@@ -6,9 +6,9 @@ module X :
   {
     type t('a) = {a: 'a, b: 'a, c: 'a};
     
-    let typ : Typ.t(X.t('a2), X.t('a1));
+    let typ : Typ.t(t('a2), t('a1));
     
-    let x : X.t(int);
+    let x : t(int);
     
     };  let a : X.t(int);  let b : X.t(int);  let c : t(int, int, int); 
 let d : (int, int);  let e : int;  let f : bool;  let g : unit; 

--- a/meja/tests/records.meji
+++ b/meja/tests/records.meji
@@ -1,7 +1,13 @@
-type t('a, 'b, 'c) = {a: 'a, b: 'b, c: 'c}; 
-let typ : Typ.t(t('a2, 'b2, 'c2), t('a1, 'b1, 'c1)); 
-let x : t(int, int, int);  let y : t(bool, bool, bool); 
-let z : t(int, bool, unit); 
+type t('a, 'b, 'c) = {a: 'a, b: 'b, c: 'c};
+
+let typ : Typ.t(t('a2, 'b2, 'c2), t('a1, 'b1, 'c1));
+
+let x : t(int, int, int);
+
+let y : t(bool, bool, bool);
+
+let z : t(int, bool, unit);
+
 module X :
   {
     type t('a) = {a: 'a, b: 'a, c: 'a};
@@ -10,7 +16,22 @@ module X :
     
     let x : t(int);
     
-    };  let a : X.t(int);  let b : X.t(int);  let c : t(int, int, int); 
-let d : (int, int);  let e : int;  let f : bool;  let g : unit; 
-let h : unit; 
+    };
+
+let a : X.t(int);
+
+let b : X.t(int);
+
+let c : t(int, int, int);
+
+let d : (int, int);
+
+let e : int;
+
+let f : bool;
+
+let g : unit;
+
+let h : unit;
+
 

--- a/meja/tests/request.meji
+++ b/meja/tests/request.meji
@@ -1,0 +1,4 @@
+request ('x) Request(list('x)) : Snarky__Request.t('x) 
+request ('x) Request2 : Snarky__Request.t('x) 
+request ('x) Request3(option('x)) : Snarky__Request.t('x) 
+

--- a/meja/tests/request.meji
+++ b/meja/tests/request.meji
@@ -1,4 +1,7 @@
-request ('x) Request(list('x)) : Snarky__Request.t('x) 
-request ('x) Request2 : Snarky__Request.t('x) 
-request ('x) Request3(option('x)) : Snarky__Request.t('x) 
+request ('x) Request(list('x)) : Snarky__Request.t('x)
+
+request ('x) Request2 : Snarky__Request.t('x)
+
+request ('x) Request3(option('x)) : Snarky__Request.t('x)
+
 

--- a/meja/tests/stdlib.meji
+++ b/meja/tests/stdlib.meji
@@ -1,3 +1,9 @@
-let test_plus : int;  let test_times : int;  let test_print_int : unit; 
-let fold_list : list(bool) -> bool; 
+let test_plus : int;
+
+let test_times : int;
+
+let test_print_int : unit;
+
+let fold_list : list(bool) -> bool;
+
 

--- a/meja/tests/stdlib.meji
+++ b/meja/tests/stdlib.meji
@@ -1,0 +1,3 @@
+let test_plus : int;  let test_times : int;  let test_print_int : unit; 
+let fold_list : list(bool) -> bool; 
+

--- a/meja/tests/test.meji
+++ b/meja/tests/test.meji
@@ -1,5 +1,27 @@
-let x : int;  let y : int;  let z : int;  let a : int;  let b : int; 
-let c : (int -> unit) -> int;  let d : _ -> _;  let e : int;  let f : _ -> _;
- let g : _ -> _;  let h : (int -> unit) -> int;  let i : unit -> unit; 
-let j : unit; 
+let x : int;
+
+let y : int;
+
+let z : int;
+
+let a : int;
+
+let b : int;
+
+let c : (int -> unit) -> int;
+
+let d : _ -> _;
+
+let e : int;
+
+let f : _ -> _;
+
+let g : _ -> _;
+
+let h : (int -> unit) -> int;
+
+let i : unit -> unit;
+
+let j : unit;
+
 

--- a/meja/tests/test.meji
+++ b/meja/tests/test.meji
@@ -1,0 +1,5 @@
+let x : int;  let y : int;  let z : int;  let a : int;  let b : int; 
+let c : (int -> unit) -> int;  let d : _ -> _;  let e : int;  let f : _ -> _;
+ let g : _ -> _;  let h : (int -> unit) -> int;  let i : unit -> unit; 
+let j : unit; 
+

--- a/meja/tests/tuples.meji
+++ b/meja/tests/tuples.meji
@@ -1,0 +1,3 @@
+let x : (int, int, int);  let f : _ -> _;  let y : (int, int, int); 
+let z : int;  let x_ : int;  let z : (int, _, _) -> (int, int); 
+

--- a/meja/tests/tuples.meji
+++ b/meja/tests/tuples.meji
@@ -1,3 +1,13 @@
-let x : (int, int, int);  let f : _ -> _;  let y : (int, int, int); 
-let z : int;  let x_ : int;  let z : (int, _, _) -> (int, int); 
+let x : (int, int, int);
+
+let f : _ -> _;
+
+let y : (int, int, int);
+
+let z : int;
+
+let x_ : int;
+
+let z : (int, _, _) -> (int, int);
+
 

--- a/meja/tests/typ-deriving.meji
+++ b/meja/tests/typ-deriving.meji
@@ -1,9 +1,21 @@
-type poly('a, 'b) = {a: 'a, b: 'b};  type t = poly(bool, field); 
-type var = poly(Boolean.var, Field.Var.t); 
-let typ : Typ.t(poly('a1, 'b1), poly('a, 'b)); 
-type u_poly('a1, 'b1) = {a1: 'a1, b1: 'b1};  type u('a) = u_poly('a, bool); 
-type u_var('a) = u_poly('a, Boolean.var); 
-let u_typ : Typ.t(u_poly('a11, 'b11), u_poly('a1, 'b1)); 
-type v('a, 'b) = {a2: 'a, b2: 'b}; 
-let v_typ : Typ.t(v('a1, 'b1), v('a, 'b)); 
+type poly('a, 'b) = {a: 'a, b: 'b};
+
+type t = poly(bool, field);
+
+type var = poly(Boolean.var, Field.Var.t);
+
+let typ : Typ.t(poly('a1, 'b1), poly('a, 'b));
+
+type u_poly('a1, 'b1) = {a1: 'a1, b1: 'b1};
+
+type u('a) = u_poly('a, bool);
+
+type u_var('a) = u_poly('a, Boolean.var);
+
+let u_typ : Typ.t(u_poly('a11, 'b11), u_poly('a1, 'b1));
+
+type v('a, 'b) = {a2: 'a, b2: 'b};
+
+let v_typ : Typ.t(v('a1, 'b1), v('a, 'b));
+
 

--- a/meja/tests/typ-deriving.meji
+++ b/meja/tests/typ-deriving.meji
@@ -1,0 +1,9 @@
+type poly('a, 'b) = {a: 'a, b: 'b};  type t = poly(bool, field); 
+type var = poly(Boolean.var, Field.Var.t); 
+let typ : Typ.t(poly('a1, 'b1), poly('a, 'b)); 
+type u_poly('a1, 'b1) = {a1: 'a1, b1: 'b1};  type u('a) = u_poly('a, bool); 
+type u_var('a) = u_poly('a, Boolean.var); 
+let u_typ : Typ.t(u_poly('a11, 'b11), u_poly('a1, 'b1)); 
+type v('a, 'b) = {a2: 'a, b2: 'b}; 
+let v_typ : Typ.t(v('a1, 'b1), v('a, 'b)); 
+

--- a/meja/tests/typ-deriving.meji
+++ b/meja/tests/typ-deriving.meji
@@ -1,21 +1,13 @@
-type poly('a, 'b) = {a: 'a, b: 'b};
+type t = {a: bool, b: field};
 
-type t = poly(bool, field);
+type u('a) = {a1: 'a, b1: bool};
 
-type var = poly(Boolean.var, Field.Var.t);
+convertible type v('a, 'b) = {a2: 'a, b2: 'b}
+with prover v('a, 'b) = {a2: 'a, b2: 'b}
+by v_typ;
 
-let typ : Typ.t(poly('a1, 'b1), poly('a, 'b));
+let x : _ -> v(_, _);
 
-type u_poly('a1, 'b1) = {a1: 'a1, b1: 'b1};
-
-type u('a) = u_poly('a, bool);
-
-type u_var('a) = u_poly('a, Boolean.var);
-
-let u_typ : Typ.t(u_poly('a11, 'b11), u_poly('a1, 'b1));
-
-type v('a, 'b) = {a2: 'a, b2: 'b};
-
-let v_typ : Typ.t(v('a1, 'b1), v('a, 'b));
+let y : unit -> v(boolean, boolean);
 
 

--- a/meja/tests/typ-explicit.meji
+++ b/meja/tests/typ-explicit.meji
@@ -1,2 +1,1 @@
-let typ : Typ.t(('var_a, 'var_b), ('value_a, 'value_b)); 
-
+let typ : Typ.t(('var_a, 'var_b), ('value_a, 'value_b));  

--- a/meja/tests/typ-explicit.meji
+++ b/meja/tests/typ-explicit.meji
@@ -1,0 +1,2 @@
+let typ : Typ.t(('var_a, 'var_b), ('value_a, 'value_b)); 
+

--- a/meja/tests/type-alias-unification.meji
+++ b/meja/tests/type-alias-unification.meji
@@ -1,8 +1,12 @@
 module Alias_alias :
   {
-    type u('a, 'b) = 'a -> 'a;
+    convertible type u('a, 'b) = 'a -> 'a
+    with prover u('a, 'b) = 'a -> 'a
+    by u_typ;
     
-    type v('a, 'b) = u('a, 'a);
+    convertible type v('a, 'b) = u('a, 'a)
+    with prover v('a, 'b) = u('a, 'a)
+    by v_typ;
     
     let f : u(int, bool) -> u(int, int);
     
@@ -30,11 +34,13 @@ module Alias_opaque :
 
 module Alias_record :
   {
-    type u('a, 'b) = {a: 'a, b: 'b};
+    convertible type u('a, 'b) = {a: 'a, b: 'b}
+    with prover u('a, 'b) = {a: 'a, b: 'b}
+    by u_typ;
     
-    let u_typ : Typ.t(u('a2, 'b2), u('a1, 'b1));
-    
-    type v('a, 'b) = u('a, 'a);
+    convertible type v('a, 'b) = u('a, 'a)
+    with prover v('a, 'b) = u('a, 'a)
+    by v_typ;
     
     let f : v(int, int) -> v(int, bool);
     

--- a/meja/tests/type-alias-unification.meji
+++ b/meja/tests/type-alias-unification.meji
@@ -12,7 +12,8 @@ module Alias_alias :
     
     let i : u(bool, bool) -> v(bool, unit);
     
-    }; 
+    };
+
 module Alias_opaque :
   {
     type u('a, 'b);
@@ -25,7 +26,8 @@ module Alias_opaque :
     
     let h : u(bool, bool) -> v(bool, unit);
     
-    }; 
+    };
+
 module Alias_record :
   {
     type u('a, 'b) = {a: 'a, b: 'b};
@@ -40,7 +42,8 @@ module Alias_record :
     
     let h : u(bool, bool) -> v(bool, unit);
     
-    }; 
+    };
+
 module Alias_variant :
   {
     type u('a, 'b) = A | B | C('a) | D('b);
@@ -53,5 +56,6 @@ module Alias_variant :
     
     let h : u(bool, bool) -> v(bool, unit);
     
-    }; 
+    };
+
 

--- a/meja/tests/type-alias-unification.meji
+++ b/meja/tests/type-alias-unification.meji
@@ -1,0 +1,57 @@
+module Alias_alias :
+  {
+    type u('a, 'b) = 'a -> 'a;
+    
+    type v('a, 'b) = Alias_alias.u('a, 'a);
+    
+    let f : Alias_alias.u(int, bool) -> Alias_alias.u(int, int);
+    
+    let g : Alias_alias.v(int, int) -> Alias_alias.v(int, bool);
+    
+    let h : Alias_alias.v(int, bool) -> Alias_alias.u(int, int);
+    
+    let i : Alias_alias.u(bool, bool) -> Alias_alias.v(bool, unit);
+    
+    }; 
+module Alias_opaque :
+  {
+    type u('a, 'b);
+    
+    type v('a, 'b) = Alias_opaque.u('a, 'a);
+    
+    let f : Alias_opaque.v(int, int) -> Alias_opaque.v(int, bool);
+    
+    let g : Alias_opaque.v(int, bool) -> Alias_opaque.u(int, int);
+    
+    let h : Alias_opaque.u(bool, bool) -> Alias_opaque.v(bool, unit);
+    
+    }; 
+module Alias_record :
+  {
+    type u('a, 'b) = {a: 'a, b: 'b};
+    
+    let u_typ : Typ.t(Alias_record.u('a2, 'b2), Alias_record.u('a1, 'b1));
+    
+    type v('a, 'b) = Alias_record.u('a, 'a);
+    
+    let f : Alias_record.v(int, int) -> Alias_record.v(int, bool);
+    
+    let g : Alias_record.v(int, bool) -> Alias_record.u(int, int);
+    
+    let h : Alias_record.u(bool, bool) -> Alias_record.v(bool, unit);
+    
+    }; 
+module Alias_variant :
+  {
+    type u('a, 'b) = A | B | C('a) | D('b);
+    
+    type v('a, 'b) = Alias_variant.u('a, 'a);
+    
+    let f : Alias_variant.v(int, int) -> Alias_variant.v(int, bool);
+    
+    let g : Alias_variant.v(int, bool) -> Alias_variant.u(int, int);
+    
+    let h : Alias_variant.u(bool, bool) -> Alias_variant.v(bool, unit);
+    
+    }; 
+

--- a/meja/tests/type-alias-unification.meji
+++ b/meja/tests/type-alias-unification.meji
@@ -2,56 +2,56 @@ module Alias_alias :
   {
     type u('a, 'b) = 'a -> 'a;
     
-    type v('a, 'b) = Alias_alias.u('a, 'a);
+    type v('a, 'b) = u('a, 'a);
     
-    let f : Alias_alias.u(int, bool) -> Alias_alias.u(int, int);
+    let f : u(int, bool) -> u(int, int);
     
-    let g : Alias_alias.v(int, int) -> Alias_alias.v(int, bool);
+    let g : v(int, int) -> v(int, bool);
     
-    let h : Alias_alias.v(int, bool) -> Alias_alias.u(int, int);
+    let h : v(int, bool) -> u(int, int);
     
-    let i : Alias_alias.u(bool, bool) -> Alias_alias.v(bool, unit);
+    let i : u(bool, bool) -> v(bool, unit);
     
     }; 
 module Alias_opaque :
   {
     type u('a, 'b);
     
-    type v('a, 'b) = Alias_opaque.u('a, 'a);
+    type v('a, 'b) = u('a, 'a);
     
-    let f : Alias_opaque.v(int, int) -> Alias_opaque.v(int, bool);
+    let f : v(int, int) -> v(int, bool);
     
-    let g : Alias_opaque.v(int, bool) -> Alias_opaque.u(int, int);
+    let g : v(int, bool) -> u(int, int);
     
-    let h : Alias_opaque.u(bool, bool) -> Alias_opaque.v(bool, unit);
+    let h : u(bool, bool) -> v(bool, unit);
     
     }; 
 module Alias_record :
   {
     type u('a, 'b) = {a: 'a, b: 'b};
     
-    let u_typ : Typ.t(Alias_record.u('a2, 'b2), Alias_record.u('a1, 'b1));
+    let u_typ : Typ.t(u('a2, 'b2), u('a1, 'b1));
     
-    type v('a, 'b) = Alias_record.u('a, 'a);
+    type v('a, 'b) = u('a, 'a);
     
-    let f : Alias_record.v(int, int) -> Alias_record.v(int, bool);
+    let f : v(int, int) -> v(int, bool);
     
-    let g : Alias_record.v(int, bool) -> Alias_record.u(int, int);
+    let g : v(int, bool) -> u(int, int);
     
-    let h : Alias_record.u(bool, bool) -> Alias_record.v(bool, unit);
+    let h : u(bool, bool) -> v(bool, unit);
     
     }; 
 module Alias_variant :
   {
     type u('a, 'b) = A | B | C('a) | D('b);
     
-    type v('a, 'b) = Alias_variant.u('a, 'a);
+    type v('a, 'b) = u('a, 'a);
     
-    let f : Alias_variant.v(int, int) -> Alias_variant.v(int, bool);
+    let f : v(int, int) -> v(int, bool);
     
-    let g : Alias_variant.v(int, bool) -> Alias_variant.u(int, int);
+    let g : v(int, bool) -> u(int, int);
     
-    let h : Alias_variant.u(bool, bool) -> Alias_variant.v(bool, unit);
+    let h : u(bool, bool) -> v(bool, unit);
     
     }; 
 

--- a/meja/tests/type_declarations.meji
+++ b/meja/tests/type_declarations.meji
@@ -1,9 +1,29 @@
-type t = int;  type u = (int, bool);  type v('a) = 'a; 
-type w(_) = A(int) | B('a) : w('a);  type x('a) = {a: 'a, b: int, c: bool}; 
-type y = x(unit);  type z = x(bool);  type a = x(x(x(w(x(t))))); 
+type t = int;
+
+type u = (int, bool);
+
+type v('a) = 'a;
+
+type w(_) = A(int) | B('a) : w('a);
+
+type x('a) = {a: 'a, b: int, c: bool};
+
+type y = x(unit);
+
+type z = x(bool);
+
+type a = x(x(x(w(x(t)))));
+
 type b('a, 'b, 'c) = First('a) : b('a, 'a, 'a) | Second('b, b('a, _, _)) :
   b('a, 'b, 'b) | Third('c, b('a, 'b, _)) : b('a, 'b, 'c) | Rotate(
-  b('a, 'b, 'c)) : b('b, 'c, 'a);  type unit = (); 
-type polycary = A('a) : polycary; 
-type c('a) = A{x: 'a} | B('a) | C{x: 'b} : c('b);  type d; 
+  b('a, 'b, 'c)) : b('b, 'c, 'a);
+
+type unit = ();
+
+type polycary = A('a) : polycary;
+
+type c('a) = A{x: 'a} | B('a) | C{x: 'b} : c('b);
+
+type d;
+
 

--- a/meja/tests/type_declarations.meji
+++ b/meja/tests/type_declarations.meji
@@ -1,0 +1,9 @@
+type t = int;  type u = (int, bool);  type v('a) = 'a; 
+type w(_) = A(int) | B('a) : w('a);  type x('a) = {a: 'a, b: int, c: bool}; 
+type y = x(unit);  type z = x(bool);  type a = x(x(x(w(x(t))))); 
+type b('a, 'b, 'c) = First('a) : b('a, 'a, 'a) | Second('b, b('a, _, _)) :
+  b('a, 'b, 'b) | Third('c, b('a, 'b, _)) : b('a, 'b, 'c) | Rotate(
+  b('a, 'b, 'c)) : b('b, 'c, 'a);  type unit = (); 
+type polycary = A('a) : polycary; 
+type c('a) = A{x: 'a} | B('a) | C{x: 'b} : c('b);  type d; 
+

--- a/meja/tests/type_variable_scoping.meji
+++ b/meja/tests/type_variable_scoping.meji
@@ -1,4 +1,7 @@
-let f : int -> int;  let g : bool -> bool; 
+let f : int -> int;
+
+let g : bool -> bool;
+
 module X :
   {
     type t('a) = A('a) | B(int) | C(bool) : t(bool);
@@ -13,5 +16,6 @@ module X :
     
     let f : 'int -> 'int -> 'int;
     
-    }; 
+    };
+
 

--- a/meja/tests/type_variable_scoping.meji
+++ b/meja/tests/type_variable_scoping.meji
@@ -1,15 +1,15 @@
 let f : int -> int;  let g : bool -> bool; 
 module X :
   {
-    type t('a) = A('a) | B(int) | C(bool) : X.t(bool);
+    type t('a) = A('a) | B(int) | C(bool) : t(bool);
     
-    let a : X.t(int);
+    let a : t(int);
     
-    let a1 : X.t(unit);
+    let a1 : t(unit);
     
-    let b : X.t('bool);
+    let b : t('bool);
     
-    let c : X.t(bool);
+    let c : t(bool);
     
     let f : 'int -> 'int -> 'int;
     

--- a/meja/tests/type_variable_scoping.meji
+++ b/meja/tests/type_variable_scoping.meji
@@ -1,0 +1,17 @@
+let f : int -> int;  let g : bool -> bool; 
+module X :
+  {
+    type t('a) = A('a) | B(int) | C(bool) : X.t(bool);
+    
+    let a : X.t(int);
+    
+    let a1 : X.t(unit);
+    
+    let b : X.t('bool);
+    
+    let c : X.t(bool);
+    
+    let f : 'int -> 'int -> 'int;
+    
+    }; 
+

--- a/meja/tests/unify-aliases.meji
+++ b/meja/tests/unify-aliases.meji
@@ -1,0 +1,3 @@
+type t('a) = int;  let x : t(bool);  let f : {t(int)} -> t(int); 
+let g : t(int); 
+

--- a/meja/tests/unify-aliases.meji
+++ b/meja/tests/unify-aliases.meji
@@ -1,3 +1,9 @@
-type t('a) = int;  let x : t(bool);  let f : {t(int)} -> t(int); 
-let g : t(int); 
+type t('a) = int;
+
+let x : t(bool);
+
+let f : {t(int)} -> t(int);
+
+let g : t(int);
+
 


### PR DESCRIPTION
This PR
* adds signatures and module types to `Type0`
* adds pretty-printing for `Type0` signatures and module types
* generates a signature for each `Typedast.signature_item`/`structure_item`
* reimplements functors using module types and substitutions
* adds the `--meji-out` flag to emit meja interface files and enables it for tests

Currently the names for type variables aren't handled properly. Once #421 is merged, this will use the same mechanism to generate new names for the variables that need them.