### PR TITLE
Snarky_integer.subtract_unpacking and other tweaks

### DIFF
--- a/snarky_integer/integer.ml
+++ b/snarky_integer/integer.ml
@@ -193,7 +193,7 @@ let div_mod (type f) ~m:((module M) as m : f m) a b =
     ; bits= Some q_bits }
   , {value= r; interval= b.interval; bits= Some r_bits} )
 
-let sub (type f) ~m:((module M) : f m) a b =
+let subtract_unpacking (type f) ~m:((module M) : f m) a b =
   assert (Interval.gt a.interval b.interval) ;
   let value = M.Field.(sub a.value b.value) in
   let length = Interval.bits_needed a.interval in

--- a/snarky_integer/integer.ml
+++ b/snarky_integer/integer.ml
@@ -175,8 +175,7 @@ let div_mod (type f) ~m:((module M) as m : f m) a b =
   let q_bits = Field.choose_preimage_var q ~length:q_bit_length in
   let b_bit_length = Interval.bits_needed b.interval in
   let r_bits = Field.choose_preimage_var r ~length:b_bit_length in
-  let cmp = Field.compare ~bit_length:b_bit_length r b.value in
-  Boolean.Assert.is_true cmp.less ;
+  Field.Assert.lt ~bit_length:b_bit_length r b.value ;
   (* This assertion checkes that the multiplication q * b is safe. *)
   assert (q_bit_length + b_bit_length + 1 < Field.Constant.size_in_bits) ;
   assert_r1cs q b.value Field.(a.value - r) ;

--- a/snarky_integer/integer.ml
+++ b/snarky_integer/integer.ml
@@ -231,6 +231,8 @@ let to_bits ?length (type f) ~m:((module M) : f m) t =
 
 let to_bits_exn t = Bitstring.Lsb_first.of_list (Option.value_exn t.bits)
 
+let to_bits_opt t = Option.map ~f:Bitstring.Lsb_first.of_list t.bits
+
 let min (type f) ~m:((module M) : f m) (a : f t) (b : f t) =
   let open M in
   let bit_length =

--- a/snarky_integer/integer.ml
+++ b/snarky_integer/integer.ml
@@ -34,23 +34,25 @@ module Interval = struct
 
   let succ ~m t = map ~m t ~f:B.succ
 
-  let add a b =
-    match (a, b) with
-    | Constant a, Constant b ->
-        Constant B.(a + b)
-    | Less_than a, Less_than b ->
-        Less_than B.(a + b)
-    | Constant c, Less_than bound | Less_than bound, Constant c ->
-        Less_than B.(c + one + bound)
+  let add ~m a b =
+    check ~m
+      ( match (a, b) with
+      | Constant a, Constant b ->
+          Constant B.(a + b)
+      | Less_than a, Less_than b ->
+          Less_than B.(a + b)
+      | Constant c, Less_than bound | Less_than bound, Constant c ->
+          Less_than B.(c + one + bound) )
 
-  let mul a b =
-    match (a, b) with
-    | Constant a, Constant b ->
-        Constant B.(a * b)
-    | Less_than a, Less_than b ->
-        Less_than B.(a * b)
-    | Constant c, Less_than bound | Less_than bound, Constant c ->
-        Less_than B.((c + one) * bound)
+  let mul ~m a b =
+    check ~m
+      ( match (a, b) with
+      | Constant a, Constant b ->
+          Constant B.(a * b)
+      | Less_than a, Less_than b ->
+          Less_than B.(a * b)
+      | Constant c, Less_than bound | Less_than bound, Constant c ->
+          Less_than B.((c + one) * bound) )
 
   let bits_needed = function
     | Constant x ->
@@ -183,14 +185,12 @@ let div_mod (type f) ~m:((module M) as m : f m) a b =
     ; bits= Some q_bits }
   , {value= r; interval= b.interval; bits= Some r_bits} )
 
-let add (type f) ~m:((module M) : f m) a b =
-  let interval = Interval.(add a.interval b.interval) in
-  assert (B.(of_int @@ Interval.bits_needed interval <= M.Field.size)) ;
+let add (type f) ~m:((module M) as m : f m) a b =
+  let interval = Interval.(add ~m a.interval b.interval) in
   {value= M.Field.(a.value + b.value); interval; bits= None}
 
-let mul (type f) ~m:((module M) : f m) a b =
-  let interval = Interval.(mul a.interval b.interval) in
-  assert (B.(of_int @@ Interval.bits_needed interval <= M.Field.size)) ;
+let mul (type f) ~m:((module M) as m : f m) a b =
+  let interval = Interval.(mul ~m a.interval b.interval) in
   {value= M.Field.(a.value * b.value); interval; bits= None}
 
 let to_bits ?length (type f) ~m:((module M) : f m) t =

--- a/snarky_integer/integer.mli
+++ b/snarky_integer/integer.mli
@@ -113,4 +113,6 @@ val subtract_unpacking : m:'f m -> 'f t -> 'f t -> 'f t
 
     The bit representation is calculated to ensure that [0 <= x - y], and is
     cached in the result.
+
+    NOTE: This uses approximately [log2(x)] constraints.
 *)

--- a/snarky_integer/integer.mli
+++ b/snarky_integer/integer.mli
@@ -1,3 +1,13 @@
+(** Positive integers as field elements.
+
+    These operations assert that the value of the field element does not exceed
+    the largest element in the field -- ie. that the operations do not
+    overflow.
+
+    Whenever possible, the bit representation is cached to avoid recomputing
+    it.
+*)
+
 open Snarky
 open Snark
 open Bitstring_lib
@@ -5,29 +15,71 @@ open Bitstring_lib
 type 'f t
 
 val constant : ?length:int -> m:'f m -> Bigint.t -> 'f t
+(** Create an value representing the given constant value.
+
+    The bit representation of the constant is cached, and is padded to [length]
+    when given.
+*)
 
 val shift_left : m:'f m -> 'f t -> int -> 'f t
+(** [shift_left ~m x k] is equivalent to multiplying [x] by [2^k].
+
+    The result has a cached bit representation whenever the given [x] had a
+    cached bit representation.
+*)
 
 val of_bits : m:'f m -> 'f Cvar.t Boolean.t Bitstring.Lsb_first.t -> 'f t
+(** Create a value from the given bit string.
+
+    The given bit representation is cached.
+*)
 
 val to_bits :
   ?length:int -> m:'f m -> 'f t -> 'f Cvar.t Boolean.t Bitstring.Lsb_first.t
+(** Compute the bit representation of the given integer.
+
+    If the bit representation has already been cached, it is returned and no
+    additional constraints are added. If the representation is computed, the
+    value is updated to include the cache.
+*)
 
 val to_bits_exn : 'f t -> 'f Cvar.t Boolean.t Bitstring.Lsb_first.t
+(** Return the cached bit representation, or raise an exception if the bit
+    representation has not been cached.
+*)
 
 val div_mod : m:'f m -> 'f t -> 'f t -> 'f t * 'f t
+(** [div_mod ~m a b = (q, r)] such that [a = q * b + r] and [r < b].
+
+    The bit representations of [q] and [r] are calculated and cached.
+
+    NOTE: This uses approximately [log2(a) + 2 * log2(b)] constraints.
+*)
 
 val to_field : 'f t -> 'f Cvar.t
 
 val create : value:'f Cvar.t -> upper_bound:Bigint.t -> 'f t
 
 val min : m:'f m -> 'f t -> 'f t -> 'f t
+(** [min ~m x y] returns a value equal the lesser of [x] and [y].
+
+    The result does not carry a cached bit representation.
+*)
 
 val if_ : m:'f m -> 'f Cvar.t Boolean.t -> then_:'f t -> else_:'f t -> 'f t
 
-val succ_if : m:'f m -> 'f t -> 'f Cvar.t Boolean.t -> 'f t
-
 val succ : m:'f m -> 'f t -> 'f t
+(** [succ ~m x] computes the successor [x+1] of [x].
+
+    The result does not carry a cached bit representation.
+*)
+
+val succ_if : m:'f m -> 'f t -> 'f Cvar.t Boolean.t -> 'f t
+(** [succ_if ~m x b] computes the integer [x+1] if [b] is [true], or [x]
+    otherwise.
+
+    The result does not carry a cached bit representation.
+*)
 
 val equal : m:'f m -> 'f t -> 'f t -> 'f Cvar.t Boolean.t
 
@@ -40,5 +92,13 @@ val gt : m:'f m -> 'f t -> 'f t -> 'f Cvar.t Boolean.t
 val gte : m:'f m -> 'f t -> 'f t -> 'f Cvar.t Boolean.t
 
 val add : m:'f m -> 'f t -> 'f t -> 'f t
+(** [add ~m x y] computes [x + y].
+
+    The result does not carry a cached bit representation.
+*)
 
 val mul : m:'f m -> 'f t -> 'f t -> 'f t
+(** [mul ~m x y] computes [x * y].
+
+    The result does not carry a cached bit representation.
+*)

--- a/snarky_integer/integer.mli
+++ b/snarky_integer/integer.mli
@@ -102,3 +102,10 @@ val mul : m:'f m -> 'f t -> 'f t -> 'f t
 
     The result does not carry a cached bit representation.
 *)
+
+val sub : m:'f m -> 'f t -> 'f t -> 'f t
+(** [sub ~m x y] computes [x - y].
+
+    The bit representation is calculated to ensure that [0 <= x - y], and is
+    cached in the result.
+*)

--- a/snarky_integer/integer.mli
+++ b/snarky_integer/integer.mli
@@ -48,6 +48,11 @@ val to_bits_exn : 'f t -> 'f Cvar.t Boolean.t Bitstring.Lsb_first.t
     representation has not been cached.
 *)
 
+val to_bits_opt : 'f t -> 'f Cvar.t Boolean.t Bitstring.Lsb_first.t option
+(** Returns [Some bs] for [bs] the cached bit representation, or [None] if the
+    bit representation has not been cached.
+*)
+
 val div_mod : m:'f m -> 'f t -> 'f t -> 'f t * 'f t
 (** [div_mod ~m a b = (q, r)] such that [a = q * b + r] and [r < b].
 

--- a/snarky_integer/integer.mli
+++ b/snarky_integer/integer.mli
@@ -108,8 +108,8 @@ val mul : m:'f m -> 'f t -> 'f t -> 'f t
     The result does not carry a cached bit representation.
 *)
 
-val sub : m:'f m -> 'f t -> 'f t -> 'f t
-(** [sub ~m x y] computes [x - y].
+val subtract_unpacking : m:'f m -> 'f t -> 'f t -> 'f t
+(** [subtract_unpacking ~m x y] computes [x - y].
 
     The bit representation is calculated to ensure that [0 <= x - y], and is
     cached in the result.


### PR DESCRIPTION
This PR
* fixes the bound checks on `Snarky_integer.add`/`mul`
  - previously, these were comparing `log2(upper_bound) < field_size`, giving a maximum upper bound of `2^(2^field_size_in_bits)` :sweat_smile:
* adds doc-comments
* adds `Integer.to_bits_opt` as an alternative to `to_bits_exn` that doesn't raise
* adds `Integer.subtract_unpacking`
  - we compute (and cache) `to_bits` on the result to ensure that it is `>= 0`, since it is more useful than a comparison on the arguments
  - this is called `subtract_unpacking` rather than just `sub` to draw attention to how constraint-heavy it is on large arguments
  - this feature was requested by @psteckler