### PR TITLE
[TRIVIAL] Don't ocamlformat files under website/

### DIFF
--- a/app/reformat-snarky/reformat.ml
+++ b/app/reformat-snarky/reformat.ml
@@ -29,7 +29,8 @@ let main dry_run check path =
             && (not (String.is_suffix ~suffix:".un~" path))
             && (not (String.is_suffix ~suffix:"external" path))
             && (not (String.is_suffix ~suffix:"ocamlformat" path))
-            && not (String.is_suffix ~suffix:"node_modules" path)
+            && (not (String.is_suffix ~suffix:"node_modules" path))
+            && not (String.is_suffix ~suffix:"website" path)
         | `File ->
             (not
                (List.exists whitelist ~f:(fun s ->


### PR DESCRIPTION
This speeds up `make format`/`make check-format` by ignoring all of the generated website files.