### PR TITLE
Use `npm ci` to test website builds

### DIFF
--- a/scripts/test-website-build.sh
+++ b/scripts/test-website-build.sh
@@ -3,5 +3,6 @@
 set -e
 
 cd website/website
-npm install docusaurus
+# Restore packages to the state in package-lock.json
+npm ci
 npm run-script build


### PR DESCRIPTION
A package update has broken the website test in CI. This PR changes the way docusaurus is initialised so that it pulls in the 'locked' versions set in `package-lock.json`, so that CI starts passing again.