### PR TITLE
[Meja] Fix tri-stitching

### DIFF
--- a/meja/src/envi.ml
+++ b/meja/src/envi.ml
@@ -925,9 +925,17 @@ module Type = struct
             *)
             ()
         | Tvar _ -> (
-          match (repr var.type_alternate.type_alternate).type_desc with
+          match (repr var.type_alternate).type_desc with
           | Tvar _ ->
               set_replacement var (mkvar ~mode:var.type_mode None env)
+          | Treplace alt_var ->
+              (* Tri-stitched type variable, where the stitched part has
+                 already been substituted. Tri-stitch to the substitution.
+              *)
+              assert (equal_mode Checked var.type_mode) ;
+              let new_var = mk' ~mode:Checked env.depth (Tvar None) in
+              unsafe_set_single_replacement var new_var ;
+              new_var.type_alternate <- alt_var
           | _ ->
               (* Tri-stitched type variable where the stitched types have been
                instantiated.

--- a/meja/src/typechecker.ml
+++ b/meja/src/typechecker.ml
@@ -1842,7 +1842,9 @@ let rec check_statement env stmt =
         let decl = decl.tdec_tdec in
         let snap = Snapshot.create () in
         Envi.Type.refresh_vars decl.tdec_params env ;
-        let typ_params = List.map ~f:repr decl.tdec_params in
+        let typ_params =
+          List.map decl.tdec_params ~f:(fun typ -> Envi.Type.copy typ env)
+        in
         let typ = Envi.Type.copy decl.tdec_ret env in
         backtrack snap ; (typ, typ_params)
       in

--- a/meja/tests/prover-test.ml
+++ b/meja/tests/prover-test.ml
@@ -92,8 +92,8 @@ let j __implicit12__ __implicit13__ __implicit14__ __implicit10__ b x =
   in
   i
 
-let k __implicit15__ __implicit16__ (f : field) =
-  j __implicit15__ __implicit16__ Typ.field
+let k (f : field) =
+  j Typ.field Typ.field Typ.field
     { Snarky.Types.Typ.store= (fun x -> Snarky.Typ_monads.Store.return x)
     ; Snarky.Types.Typ.read= (fun x -> Snarky.Typ_monads.Read.return x)
     ; Snarky.Types.Typ.alloc=
@@ -102,5 +102,5 @@ let k __implicit15__ __implicit16__ (f : field) =
     ; Snarky.Types.Typ.check= (fun _ -> Snarky.Checked.return ()) }
     true f
 
-let l __implicit19__ __implicit20__ (b : boolean) (b' : boolean) =
-  j __implicit19__ __implicit20__ Typ.boolean Typ.boolean b b'
+let l (b : boolean) (b' : boolean) =
+  j Typ.boolean Typ.boolean Typ.boolean Typ.boolean b b'

--- a/meja/tests/tri-stitching.meja
+++ b/meja/tests/tri-stitching.meja
@@ -1,0 +1,9 @@
+let f = fun (x : ('x, 'y), y: 'b, b) => {
+  let y = Prover { y; };
+  if (b) { x; } else { y; };
+};
+
+let g = fun (b: boolean, x: field) => {
+  ignore(f((b, b), (true, false), true));
+  f((x, x), (x, x), false);
+};

--- a/meja/tests/tri-stitching.ml
+++ b/meja/tests/tri-stitching.ml
@@ -1,0 +1,94 @@
+module Impl = Snarky.Snark.Make (Snarky.Backends.Mnt4.Default)
+open Impl
+
+let f __implicit2__ __implicit1__ (x : 'x * 'y) (y : 'b) b =
+  let y =
+    let typ x___2 = x___2 in
+    Snarky.exists (typ __implicit2__)
+      ~compute:
+        (let open As_prover in
+        fun () ->
+          let typ x___1 = x___1 in
+          As_prover.read (typ __implicit1__) y)
+  in
+  if b then x else y
+
+let g __implicit4__ (b : boolean) (x : field) =
+  ignore
+    (f
+       { Snarky.Types.Typ.store=
+           (fun (x0, x1) ->
+             Snarky.Typ_monads.Store.bind
+               (Typ.boolean.Snarky.Types.Typ.store x0) ~f:(fun x0 ->
+                 Snarky.Typ_monads.Store.bind
+                   (Typ.boolean.Snarky.Types.Typ.store x1) ~f:(fun x1 ->
+                     Snarky.Typ_monads.Store.return (x0, x1) ) ) )
+       ; Snarky.Types.Typ.read=
+           (fun (x0, x1) ->
+             Snarky.Typ_monads.Read.bind (Typ.boolean.Snarky.Types.Typ.read x0)
+               ~f:(fun x0 ->
+                 Snarky.Typ_monads.Read.bind
+                   (Typ.boolean.Snarky.Types.Typ.read x1) ~f:(fun x1 ->
+                     Snarky.Typ_monads.Read.return (x0, x1) ) ) )
+       ; Snarky.Types.Typ.alloc=
+           Snarky.Typ_monads.Alloc.bind Typ.boolean.Snarky.Types.Typ.alloc
+             ~f:(fun x0 ->
+               Snarky.Typ_monads.Alloc.bind Typ.boolean.Snarky.Types.Typ.alloc
+                 ~f:(fun x1 -> Snarky.Typ_monads.Alloc.return (x0, x1)) )
+       ; Snarky.Types.Typ.check=
+           (fun (x0, x1) ->
+             Snarky.Checked.bind (Typ.boolean.Snarky.Types.Typ.check x0)
+               ~f:(fun () ->
+                 Snarky.Checked.bind (Typ.boolean.Snarky.Types.Typ.check x1)
+                   ~f:(fun () -> Snarky.Checked.return ()) ) ) }
+       __implicit4__ (b, b) (true, false) true) ;
+  f
+    { Snarky.Types.Typ.store=
+        (fun (x0, x1) ->
+          Snarky.Typ_monads.Store.bind (Typ.field.Snarky.Types.Typ.store x0)
+            ~f:(fun x0 ->
+              Snarky.Typ_monads.Store.bind
+                (Typ.field.Snarky.Types.Typ.store x1) ~f:(fun x1 ->
+                  Snarky.Typ_monads.Store.return (x0, x1) ) ) )
+    ; Snarky.Types.Typ.read=
+        (fun (x0, x1) ->
+          Snarky.Typ_monads.Read.bind (Typ.field.Snarky.Types.Typ.read x0)
+            ~f:(fun x0 ->
+              Snarky.Typ_monads.Read.bind (Typ.field.Snarky.Types.Typ.read x1)
+                ~f:(fun x1 -> Snarky.Typ_monads.Read.return (x0, x1)) ) )
+    ; Snarky.Types.Typ.alloc=
+        Snarky.Typ_monads.Alloc.bind Typ.field.Snarky.Types.Typ.alloc
+          ~f:(fun x0 ->
+            Snarky.Typ_monads.Alloc.bind Typ.field.Snarky.Types.Typ.alloc
+              ~f:(fun x1 -> Snarky.Typ_monads.Alloc.return (x0, x1)) )
+    ; Snarky.Types.Typ.check=
+        (fun (x0, x1) ->
+          Snarky.Checked.bind (Typ.field.Snarky.Types.Typ.check x0)
+            ~f:(fun () ->
+              Snarky.Checked.bind (Typ.field.Snarky.Types.Typ.check x1)
+                ~f:(fun () -> Snarky.Checked.return ()) ) ) }
+    { Snarky.Types.Typ.store=
+        (fun (x0, x1) ->
+          Snarky.Typ_monads.Store.bind (Typ.field.Snarky.Types.Typ.store x0)
+            ~f:(fun x0 ->
+              Snarky.Typ_monads.Store.bind
+                (Typ.field.Snarky.Types.Typ.store x1) ~f:(fun x1 ->
+                  Snarky.Typ_monads.Store.return (x0, x1) ) ) )
+    ; Snarky.Types.Typ.read=
+        (fun (x0, x1) ->
+          Snarky.Typ_monads.Read.bind (Typ.field.Snarky.Types.Typ.read x0)
+            ~f:(fun x0 ->
+              Snarky.Typ_monads.Read.bind (Typ.field.Snarky.Types.Typ.read x1)
+                ~f:(fun x1 -> Snarky.Typ_monads.Read.return (x0, x1)) ) )
+    ; Snarky.Types.Typ.alloc=
+        Snarky.Typ_monads.Alloc.bind Typ.field.Snarky.Types.Typ.alloc
+          ~f:(fun x0 ->
+            Snarky.Typ_monads.Alloc.bind Typ.field.Snarky.Types.Typ.alloc
+              ~f:(fun x1 -> Snarky.Typ_monads.Alloc.return (x0, x1)) )
+    ; Snarky.Types.Typ.check=
+        (fun (x0, x1) ->
+          Snarky.Checked.bind (Typ.field.Snarky.Types.Typ.check x0)
+            ~f:(fun () ->
+              Snarky.Checked.bind (Typ.field.Snarky.Types.Typ.check x1)
+                ~f:(fun () -> Snarky.Checked.return ()) ) ) }
+    (x, x) (x, x) false


### PR DESCRIPTION
This PR
* switches to using `Treplace` for instantiating type variables for copying
  - we already do this for all other copies, it's better to have a unified mechanism
  - this also fixed a bug where slight behavioural differences between `Tref` and `Treplace` were causing instances not to be found (see `meja/tests/prover-test.ml`)
* changes the tri-stitching copying algorithm to handle cases of `'variable -> type1 <-> type2` stitching properly
  - the new test checks this; previously, this test would crash the typechecker with an `AssertionError`
  - there are also new stronger checks that ensure we meet these invariants everywhere