### PR TITLE
change the sponge operations interface, add a proper sponge, add a sp…

### DIFF
--- a/snarky_universe/hash.ml
+++ b/snarky_universe/hash.ml
@@ -113,7 +113,7 @@ struct
     module Operations = Sponge.Make_operations (Field)
   end
 
-  include Sponge.Make (Sponge.Poseidon (Inputs))
+  include Sponge.Make_hash (Sponge.Poseidon (Inputs))
 
   type t = Field.t
 
@@ -141,11 +141,14 @@ struct
                      res *= x ; res
 
       module Operations = struct
-        let apply_matrix rows v =
-          Array.map rows ~f:(fun row ->
+        let add_assign ~state i x = Field.(state.(i) += x)
+
+        let apply_affine_map (rows, constants) v =
+          Array.mapi rows ~f:(fun i row ->
               let open Field in
               let res = zero + zero in
               Array.iteri row ~f:(fun i r -> res += (r * v.(i))) ;
+              res += constants.(i) ;
               res )
 
         let add_block ~state block =
@@ -157,7 +160,7 @@ struct
       end
     end
 
-    include Sponge.Make (Sponge.Poseidon (Inputs))
+    include Sponge.Make_hash (Sponge.Poseidon (Inputs))
 
     let hash xs = hash params_constant xs
   end

--- a/sponge/intf.ml
+++ b/sponge/intf.ml
@@ -13,9 +13,10 @@ module type Operations = sig
     type t
   end
 
-  val add_block : state:Field.t array -> Field.t array -> unit
+  val add_assign : state:Field.t array -> int -> Field.t -> unit
 
-  val apply_matrix : Field.t array array -> Field.t array -> Field.t array
+  val apply_affine_map :
+    Field.t array array * Field.t array -> Field.t array -> Field.t array
 
   val copy : Field.t array -> Field.t array
 end
@@ -57,21 +58,25 @@ module type Permutation = sig
     val zero : t
   end
 
-  val add_block : state:Field.t array -> Field.t array -> unit
+  val add_assign : state:Field.t array -> int -> Field.t -> unit
 
   val copy : Field.t array -> Field.t array
 
   val block_cipher : Field.t Params.t -> Field.t array -> Field.t array
 end
 
-module type Hash = sig
-  module Field : sig
-    type t
-  end
+module type T = sig
+  type t
+end
 
-  module State : sig
-    type _ t
-  end
+module type T1 = sig
+  type _ t
+end
+
+module type Hash = sig
+  module Field : T
+
+  module State : T1
 
   val update :
        Field.t Params.t
@@ -85,4 +90,22 @@ module type Hash = sig
 
   val hash :
     ?init:Field.t State.t -> Field.t Params.t -> Field.t array -> Field.t
+end
+
+module type Sponge = sig
+  module Field : T
+
+  module State : T1
+
+  type input
+
+  type digest
+
+  type t
+
+  val create : ?init:Field.t State.t -> Field.t Params.t -> t
+
+  val absorb : t -> input -> unit
+
+  val squeeze : t -> digest
 end

--- a/sponge/sponge.mli
+++ b/sponge/sponge.mli
@@ -27,5 +27,30 @@ module Poseidon (Inputs : Intf.Inputs.Poseidon) :
 module Make_operations (Field : Intf.Field) :
   Intf.Operations with module Field := Field
 
-module Make (P : Intf.Permutation) :
+module Make_hash (P : Intf.Permutation) :
   Intf.Hash with module State := State and module Field := P.Field
+
+module Make_sponge (P : Intf.Permutation) :
+  Intf.Sponge
+  with module State := State
+   and module Field := P.Field
+   and type digest := P.Field.t
+   and type input := P.Field.t
+
+module Make_bit_sponge (Bool : sig
+  type t
+end) (Field : sig
+  type t
+
+  val to_bits : t -> Bool.t list
+end)
+(S : Intf.Sponge
+     with module State := State
+      and module Field := Field
+      and type digest := Field.t
+      and type input := Field.t) :
+  Intf.Sponge
+  with module State := State
+   and module Field := Field
+   and type digest := length:int -> Bool.t list
+   and type input := Field.t


### PR DESCRIPTION
This PR

- makes a proper "sponge" interface for the block ciphers in the sponge library.
- makes a version of the sponge that lets you squeeze out bits
- changes the "operations interface" to allow users of the library to have more control over how some operations are implemented
- modifies the way that poseidon is implemented, essentially changing the "parenthesization" of things in the pipeline from

add-round-constants -> apply sbox -> apply mds matrix 
-> add-round-constants -> apply sbox -> apply mds matrix 
-> ..

to

add-round-constants 
-> apply sbox -> (apply mds matrix  -> add-round-constants)
-> apply sbox -> (apply mds matrix -> add-round-constants)
-> ..