### PR TITLE
[Meja] Exceptions

### DIFF
--- a/meja/ocaml/of_ocaml/of_ocaml_4.08.0.ml
+++ b/meja/ocaml/of_ocaml/of_ocaml_4.08.0.ml
@@ -84,7 +84,7 @@ let to_type_decl_desc decl =
       TVariant (List.map ctors ~f:to_ctor_decl)
 
 let can_create_signature_item item =
-  match item with Sig_typext _ | Sig_class _ -> false | _ -> true
+  match item with Sig_class _ -> false | _ -> true
 
 let type_decl_of_sigi = function
   | Sig_type (ident, decl, _rec_status, _visibility) ->
@@ -96,13 +96,33 @@ let type_decl_of_sigi = function
   | _ ->
       assert false
 
+let typeext_ctor_of_sigi = function
+  | Sig_typext (ident, ext, _ext_status) ->
+      let loc = ext.ext_loc in
+      { ctor_ident= mkloc (Ident.name ident) loc
+      ; ctor_args= to_ctor_args ~loc ext.ext_args
+      ; ctor_ret= Option.map ~f:(to_type_expr ~loc) ext.ext_ret_type
+      ; ctor_loc= loc }
+  | _ ->
+      assert false
+
+let typeext_variant_of_sigi = function
+  | Sig_typext (_ident, ext, _ext_status) ->
+      let loc = ext.ext_loc in
+      { var_ident= mkloc (longident_of_path ext.ext_type_path) loc
+      ; var_params= List.map ~f:(to_type_expr ~loc) ext.ext_type_params }
+  | _ ->
+      assert false
+
 let rec group_signature_items current_group signature =
   match signature with
-  | (Sig_type (_, _, Trec_first, _visibility) as sigi) :: signature ->
+  | (Sig_type (_, _, Trec_first, _visibility) as sigi) :: signature
+  | (Sig_typext (_, _, Text_first) as sigi) :: signature ->
       (* Start of new recursive type group. *)
       if current_group = [] then group_signature_items [sigi] signature
       else List.rev current_group :: group_signature_items [sigi] signature
-  | (Sig_type (_, _, Trec_next, _visibility) as sigi) :: signature ->
+  | (Sig_type (_, _, Trec_next, _visibility) as sigi) :: signature
+  | (Sig_typext (_, _, Text_next) as sigi) :: signature ->
       (* Continuation of recursive type group. *)
       group_signature_items (sigi :: current_group) signature
   | sigi :: signature ->
@@ -137,6 +157,11 @@ let rec to_signature_item item =
             ( mkloc (Ident.name ident) decl.mtd_loc
             , to_module_sig ~loc:decl.mtd_loc decl.mtd_type )
       ; sig_loc= decl.mtd_loc }
+  | Sig_typext (_ident, ext, _) ->
+      { sig_desc=
+          Psig_typeext
+            (typeext_variant_of_sigi item, [typeext_ctor_of_sigi item])
+      ; sig_loc= ext.ext_loc }
   | _ ->
       failwith "Cannot create a signature item from this OCaml signature item."
 
@@ -149,6 +174,10 @@ and to_signature items =
     | Sig_type (_, {type_loc; _}, _, _) :: _ as items ->
         let decls = List.map ~f:type_decl_of_sigi items in
         {sig_desc= Psig_rectype decls; sig_loc= type_loc}
+    | (Sig_typext (_, {ext_loc; _}, _) as item) :: _ as items ->
+        let variant = typeext_variant_of_sigi item in
+        let ctors = List.map ~f:typeext_ctor_of_sigi items in
+        {sig_desc= Psig_typeext (variant, ctors); sig_loc= ext_loc}
     | _ ->
         assert false )
 

--- a/meja/ocaml/of_typedast.ml
+++ b/meja/ocaml/of_typedast.ml
@@ -598,6 +598,10 @@ let rec of_expression_desc ?loc = function
           ~compute:As_prover.(fun () -> [%e of_expression e])]
   | Texp_convert conv ->
       of_convert conv
+  | Texp_try (e, cases) ->
+      Exp.try_ ?loc (of_expression e)
+        (List.map cases ~f:(fun (p, e) ->
+             Exp.case (of_pattern p) (of_expression e) ))
 
 and of_handler ?(loc = Location.none) ?ctor_ident (args, body) =
   Parsetree.(

--- a/meja/ocaml/of_typedast.ml
+++ b/meja/ocaml/of_typedast.ml
@@ -684,6 +684,8 @@ let rec of_signature_desc ?loc = function
         ; pincl_attributes= [] }
   | Tsig_convert (name, typ) ->
       Sig.value ?loc (Val.mk ?loc (of_ident_loc name) (of_type_expr typ))
+  | Tsig_exception ctor ->
+      Sig.exception_ ?loc (of_ctor_decl_ext ctor)
 
 and of_signature_item sigi = of_signature_desc ~loc:sigi.sig_loc sigi.sig_desc
 
@@ -803,6 +805,8 @@ let rec of_statement_desc ?loc = function
                (Pat.var ~loc:name.loc (of_ident_loc name))
                (of_type_expr typ))
             (of_convert conv) ]
+  | Tstmt_exception ctor ->
+      Str.exception_ ?loc (of_ctor_decl_ext ctor)
 
 and of_statement stmt = of_statement_desc ~loc:stmt.stmt_loc stmt.stmt_desc
 

--- a/meja/ocaml/to_ocaml.ml
+++ b/meja/ocaml/to_ocaml.ml
@@ -289,6 +289,8 @@ let rec of_signature_desc ?loc = function
         ; pincl_attributes= [] }
   | Psig_convert (name, typ) ->
       Sig.value ?loc (Val.mk ?loc name (of_type_expr typ))
+  | Psig_exception ctor ->
+      Sig.exception_ ?loc (of_ctor_decl_ext ctor)
 
 and of_signature_item sigi = of_signature_desc ~loc:sigi.sig_loc sigi.sig_desc
 
@@ -388,6 +390,8 @@ let rec of_statement_desc ?loc = function
          generate this conversion before we can generate the code for it.
       *)
       assert false
+  | Pstmt_exception ctor ->
+      Str.exception_ ?loc (of_ctor_decl_ext ctor)
 
 and of_statement stmt = of_statement_desc ~loc:stmt.stmt_loc stmt.stmt_desc
 

--- a/meja/ocaml/to_ocaml.ml
+++ b/meja/ocaml/to_ocaml.ml
@@ -212,6 +212,10 @@ let rec of_expression_desc ?loc = function
         (Option.map ~f:of_expression e3)
   | Pexp_prover e ->
       of_expression e
+  | Pexp_try (e, cases) ->
+      Exp.try_ ?loc (of_expression e)
+        (List.map cases ~f:(fun (p, e) ->
+             Exp.case (of_pattern p) (of_expression e) ))
 
 and of_handler ?(loc = Location.none) ?ctor_ident (args, body) =
   Parsetree.(

--- a/meja/src/initial_env.ml
+++ b/meja/src/initial_env.ml
@@ -160,8 +160,7 @@ let _, env =
     { Parsetypes.tdec_ident= Location.mknoloc "exn"
     ; tdec_params= []
     ; tdec_desc=
-        Parsetypes.Pdec_extend
-          (Location.mknoloc (Path.Pident exn_ident), ctors)
+        Parsetypes.Pdec_extend (Location.mknoloc (Path.Pident exn_ident), ctors)
     ; tdec_loc= Location.none }
   in
   import ext_decl env

--- a/meja/src/initial_env.ml
+++ b/meja/src/initial_env.ml
@@ -80,7 +80,8 @@ let {Typedast.tdec_tdec= string; _}, env = import string env
 
 let {Typedast.tdec_tdec= float; _}, env = import float env
 
-let {Typedast.tdec_tdec= exn; _}, env = import exn env
+let {Typedast.tdec_tdec= exn; tdec_ident= {txt= exn_ident; _}; _}, env =
+  import exn env
 
 let {Typedast.tdec_tdec= option; _}, env = import option env
 
@@ -138,6 +139,32 @@ module Type = struct
     { (TypeDecl.mk_typ ~mode:a.Type0.type_mode list ~params:[a] env) with
       type_depth= a.type_depth }
 end
+
+(* Import OCaml built-in exceptions. *)
+let _, env =
+  let ctor = Ast_build.Type_decl.Ctor.with_args ?loc:None ?ret:None in
+  let string = Ast_build.Type.constr (Lident "string") in
+  let int = Ast_build.Type.constr (Lident "int") in
+  let ctors =
+    [ ctor "Out_of_memory" []
+    ; ctor "Sys_error" [string]
+    ; ctor "Failure" [string]
+    ; ctor "End_of_file" []
+    ; ctor "Not_found" []
+    ; ctor "Match_failure" []
+    ; ctor "Stack_overflow" []
+    ; ctor "Sys_blocked_io" []
+    ; ctor "Assert_failure" [string; int; int] ]
+  in
+  let ext_decl =
+    { Parsetypes.tdec_ident= Location.mknoloc "exn"
+    ; tdec_params= []
+    ; tdec_desc=
+        Parsetypes.Pdec_extend
+          (Location.mknoloc (Path.Pident exn_ident), ctors)
+    ; tdec_loc= Location.none }
+  in
+  import ext_decl env
 
 let env = Envi.open_module env
 

--- a/meja/src/lexer_impl.mll
+++ b/meja/src/lexer_impl.mll
@@ -67,6 +67,7 @@ rule token = parse
   | "to" { TO }
   | "as" { AS }
   | "prover" { LPROVER }
+  | "exception" { EXCEPTION }
   | "rec" { REC }
   | "true" { TRUE }
   | "false" { FALSE }

--- a/meja/src/lexer_impl.mll
+++ b/meja/src/lexer_impl.mll
@@ -72,6 +72,7 @@ rule token = parse
   | "true" { TRUE }
   | "false" { FALSE }
   | "switch" { SWITCH }
+  | "try" { TRY }
   | "type" { TYPE }
   | "module" { MODULE }
   | "open" { OPEN }

--- a/meja/src/parser_impl.mly
+++ b/meja/src/parser_impl.mly
@@ -53,6 +53,7 @@ let unitexp ~pos = mkexp ~pos (Pexp_ctor (mkloc ~pos (Lident "()"), None))
 %token TO
 %token AS
 %token LPROVER
+%token EXCEPTION
 %token REC
 %token MODULE
 %token OPEN
@@ -182,6 +183,8 @@ structure_item:
     { mkstmt ~pos:$loc (Pstmt_request (arg, x, handler)) }
   | PROVER LBRACE stmts = structure RBRACE
     { mkstmt ~pos:$loc (Pstmt_prover stmts) }
+  | EXCEPTION ctor = ctor_decl
+    { mkstmt ~pos:$loc (Pstmt_exception ctor) }
 
 signature_item:
   | LET x = as_loc(val_ident) COLON typ = type_expr
@@ -213,6 +216,8 @@ signature_item:
     { mksig ~pos:$loc (Psig_request (arg, x)) }
   | PROVER LBRACE sigs = signature RBRACE
     { mksig ~pos:$loc (Psig_prover sigs) }
+  | EXCEPTION ctor = ctor_decl
+    { mksig ~pos:$loc (Psig_exception ctor) }
 
 type_decl:
   | x = decl_type(lident) k = type_kind

--- a/meja/src/parser_impl.mly
+++ b/meja/src/parser_impl.mly
@@ -47,6 +47,7 @@ let unitexp ~pos = mkexp ~pos (Pexp_ctor (mkloc ~pos (Lident "()"), None))
 %token TRUE
 %token FALSE
 %token SWITCH
+%token TRY
 %token TYPE
 %token CONVERTIBLE
 %token BY
@@ -435,6 +436,8 @@ expr:
     { mkexp ~pos:$loc (Pexp_row_ctor (id, [])) }
   | e = if_expr
     { e }
+  | TRY LPAREN e = expr_or_bare_tuple RPAREN LBRACE rev_cases = list(match_case, {}) RBRACE
+    { mkexp ~pos:$loc (Pexp_try (e, List.rev rev_cases)) }
 
 if_expr:
   | IF e1 = expr e2 = block

--- a/meja/src/parser_impl.mly
+++ b/meja/src/parser_impl.mly
@@ -406,6 +406,12 @@ expr:
     { mkexp ~pos:$loc (Pexp_constraint (x, typ)) }
   | FUN unit = unit EQUALGT body = block
     { mkexp ~pos:$loc (Pexp_fun (Nolabel, unitpat ~pos:unit, body, Explicit)) }
+  | FUN unit = unit COLON typ = type_expr EQUALGT body = block
+    { mkexp ~pos:$loc (Pexp_fun
+        ( Nolabel
+        , unitpat ~pos:unit
+        , mkexp ~pos:$loc (Pexp_constraint (body, typ))
+        , Explicit) ) }
   | FUN LPAREN f = function_from_args
     { f }
   | FUN LBRACE f = function_from_implicit_args

--- a/meja/src/parsetypes.ml
+++ b/meja/src/parsetypes.ml
@@ -121,6 +121,7 @@ and signature_desc =
   | Psig_multiple of signature
   | Psig_prover of signature
   | Psig_convert of str * type_expr
+  | Psig_exception of ctor_decl
 
 and module_sig = {msig_desc: module_sig_desc; msig_loc: Location.t}
 
@@ -151,6 +152,7 @@ and statement_desc =
   | Pstmt_multiple of statements
   | Pstmt_prover of statements
   | Pstmt_convert of str * type_expr
+  | Pstmt_exception of ctor_decl
 
 and module_expr = {mod_desc: module_desc; mod_loc: Location.t}
 

--- a/meja/src/parsetypes.ml
+++ b/meja/src/parsetypes.ml
@@ -96,6 +96,7 @@ and expression_desc =
       ; id: int }
   | Pexp_if of expression * expression * expression option
   | Pexp_prover of expression
+  | Pexp_try of expression * (pattern * expression) list
 
 type conv_type =
   (* Other mode stitched declaration. *)

--- a/meja/src/parsetypes_iter.ml
+++ b/meja/src/parsetypes_iter.ml
@@ -237,6 +237,8 @@ let signature_desc iter = function
       iter.signature iter sigs
   | Psig_convert (name, typ) ->
       str iter name ; iter.type_expr iter typ
+  | Psig_exception ctor ->
+      iter.ctor_decl iter ctor
 
 let module_sig iter {msig_desc; msig_loc} =
   iter.location iter msig_loc ;
@@ -296,6 +298,8 @@ let statement_desc iter = function
       iter.statements iter stmts
   | Pstmt_convert (name, typ) ->
       str iter name ; iter.type_expr iter typ
+  | Pstmt_exception ctor ->
+      iter.ctor_decl iter ctor
 
 let module_expr iter {mod_desc; mod_loc} =
   iter.location iter mod_loc ;

--- a/meja/src/parsetypes_iter.ml
+++ b/meja/src/parsetypes_iter.ml
@@ -198,6 +198,10 @@ let expression_desc iter = function
       Option.iter ~f:(iter.expression iter) e3
   | Pexp_prover e ->
       iter.expression iter e
+  | Pexp_try (e, cases) ->
+      iter.expression iter e ;
+      List.iter cases ~f:(fun (p, e) ->
+          iter.pattern iter p ; iter.expression iter e )
 
 let type_conv iter = function
   | Ptconv_with (_mode, decl) ->

--- a/meja/src/parsetypes_map.ml
+++ b/meja/src/parsetypes_map.ml
@@ -219,6 +219,11 @@ let expression_desc mapper = function
         , Option.map ~f:(mapper.expression mapper) e3 )
   | Pexp_prover e ->
       Pexp_prover (mapper.expression mapper e)
+  | Pexp_try (e, cases) ->
+      Pexp_try
+        ( mapper.expression mapper e
+        , List.map cases ~f:(fun (p, e) ->
+              (mapper.pattern mapper p, mapper.expression mapper e) ) )
 
 let type_conv mapper = function
   | Ptconv_with (mode, decl) ->

--- a/meja/src/parsetypes_map.ml
+++ b/meja/src/parsetypes_map.ml
@@ -263,6 +263,8 @@ let signature_desc mapper = function
       Psig_prover (mapper.signature mapper sigs)
   | Psig_convert (name, typ) ->
       Psig_convert (str mapper name, mapper.type_expr mapper typ)
+  | Psig_exception ctor ->
+      Psig_exception (mapper.ctor_decl mapper ctor)
 
 let module_sig mapper {msig_desc; msig_loc} =
   { msig_loc= mapper.location mapper msig_loc
@@ -327,6 +329,8 @@ let statement_desc mapper = function
       Pstmt_prover (mapper.statements mapper stmts)
   | Pstmt_convert (name, typ) ->
       Pstmt_convert (str mapper name, mapper.type_expr mapper typ)
+  | Pstmt_exception ctor ->
+      Pstmt_exception (mapper.ctor_decl mapper ctor)
 
 let module_expr mapper {mod_desc; mod_loc} =
   { mod_loc= mapper.location mapper mod_loc

--- a/meja/src/pprint.ml
+++ b/meja/src/pprint.ml
@@ -380,6 +380,8 @@ let rec signature_desc fmt = function
   | Psig_convert (name, typ) ->
       (* TODO: review to make sure this is what we really want. *)
       signature_desc fmt (Psig_instance (name, typ))
+  | Psig_exception ctor ->
+      fprintf fmt "@[<hov2>exception %a;@]@;@;" ctor_decl ctor
 
 and signature_item fmt sigi = signature_desc fmt sigi.sig_desc
 

--- a/meja/src/pprint.ml
+++ b/meja/src/pprint.ml
@@ -294,6 +294,13 @@ let rec expression_desc fmt = function
         expression e1 expression e2 expression e3
   | Pexp_prover e ->
       fprintf fmt "@[<hv2>Prover {@,%a@,}@]" expression e
+  | Pexp_try (e, cases) ->
+      fprintf fmt "@[<hv2>@[<h>try@ (@[<hv1>@,%a@,@])@] {@;@[<hv>%a@]@;}@]"
+        expression e
+        (pp_print_list ~pp_sep:pp_print_space (fun fmt (p, e) ->
+             fprintf fmt "| @[<hv2>%a@] =>@;<1 4>@[<hv2>%a@]" pattern p
+               expression e ))
+        cases
 
 and expression_desc_bracket fmt exp =
   match exp with

--- a/meja/src/typechecker.ml
+++ b/meja/src/typechecker.ml
@@ -1988,6 +1988,35 @@ let rec check_signature_item env item =
       let env = Envi.add_implicit_instance name.txt typ' env in
       let env = Envi.add_implicit_instance name.txt typ'.type_alternate env in
       (env, {Typedast.sig_desc= Tsig_convert (name, typ); sig_loc= loc})
+  | Psig_exception ctor ->
+      let exn_ident =
+        match Initial_env.Type.exn.type_desc with
+        | Tctor {var_ident; _} ->
+            var_ident
+        | _ ->
+            assert false
+      in
+      let decl =
+        { Parsetypes.tdec_ident= Location.mknoloc "exn"
+        ; tdec_params= []
+        ; tdec_desc= Pdec_extend (Location.mknoloc exn_ident, [ctor])
+        ; tdec_loc= loc }
+      in
+      let decl, env =
+        match Typet.TypeDecl.import_rec [decl] env with
+        | [decl], env ->
+            (decl, env)
+        | _ ->
+            assert false
+      in
+      let ctor =
+        match decl.tdec_desc with
+        | Tdec_extend (_, [ctors]) ->
+            ctors
+        | _ ->
+            failwith "Expected a TExtend."
+      in
+      (env, {Typedast.sig_desc= Tsig_exception ctor; sig_loc= loc})
 
 and check_signature env signature =
   List.fold_map ~init:env signature ~f:check_signature_item
@@ -2381,6 +2410,35 @@ let rec check_statement env stmt =
       let env = Envi.add_implicit_instance name.txt typ' env in
       ( env
       , {Typedast.stmt_desc= Tstmt_convert (name, typ, conv); stmt_loc= loc} )
+  | Pstmt_exception ctor ->
+      let exn_ident =
+        match Initial_env.Type.exn.type_desc with
+        | Tctor {var_ident; _} ->
+            var_ident
+        | _ ->
+            assert false
+      in
+      let decl =
+        { Parsetypes.tdec_ident= Location.mknoloc "exn"
+        ; tdec_params= []
+        ; tdec_desc= Pdec_extend (Location.mknoloc exn_ident, [ctor])
+        ; tdec_loc= loc }
+      in
+      let decl, env =
+        match Typet.TypeDecl.import_rec [decl] env with
+        | [decl], env ->
+            (decl, env)
+        | _ ->
+            assert false
+      in
+      let ctor =
+        match decl.tdec_desc with
+        | Tdec_extend (_, [ctors]) ->
+            ctors
+        | _ ->
+            failwith "Expected a TExtend."
+      in
+      (env, {Typedast.stmt_desc= Tstmt_exception ctor; stmt_loc= loc})
 
 and check_module_expr env m =
   let mode = Envi.current_mode env in

--- a/meja/src/typedast.ml
+++ b/meja/src/typedast.ml
@@ -166,6 +166,7 @@ and signature_desc =
   | Tsig_multiple of signature
   | Tsig_prover of signature
   | Tsig_convert of ident * type_expr
+  | Tsig_exception of ctor_decl
 
 and module_sig = {msig_desc: module_sig_desc; msig_loc: Location.t}
 
@@ -196,6 +197,7 @@ and statement_desc =
   | Tstmt_multiple of statements
   | Tstmt_prover of statements
   | Tstmt_convert of ident * type_expr * convert
+  | Tstmt_exception of ctor_decl
 
 and module_expr = {mod_desc: module_desc; mod_loc: Location.t}
 

--- a/meja/src/typedast.ml
+++ b/meja/src/typedast.ml
@@ -141,6 +141,7 @@ and expression_desc =
       (* arguments to the conversion *)
       * expression
   | Texp_convert of convert
+  | Texp_try of expression * (pattern * expression) list
 
 type conv_type =
   (* Other mode stitched declaration. *)

--- a/meja/src/typedast_iter.ml
+++ b/meja/src/typedast_iter.ml
@@ -224,6 +224,10 @@ let expression_desc iter = function
       iter.expression iter e
   | Texp_convert conv ->
       iter.convert iter conv
+  | Texp_try (e, cases) ->
+      iter.expression iter e ;
+      List.iter cases ~f:(fun (p, e) ->
+          iter.pattern iter p ; iter.expression iter e )
 
 let convert_body iter {conv_body_desc; conv_body_loc; conv_body_type} =
   iter.location iter conv_body_loc ;

--- a/meja/src/typedast_iter.ml
+++ b/meja/src/typedast_iter.ml
@@ -296,6 +296,8 @@ let signature_desc iter = function
       iter.signature iter sigs
   | Tsig_convert (name, typ) ->
       ident iter name ; iter.type_expr iter typ
+  | Tsig_exception ctor ->
+      iter.ctor_decl iter ctor
 
 let module_sig iter {msig_desc; msig_loc} =
   iter.location iter msig_loc ;
@@ -356,6 +358,8 @@ let statement_desc iter = function
       iter.statements iter stmts
   | Tstmt_convert (name, typ, conv) ->
       ident iter name ; iter.type_expr iter typ ; iter.convert iter conv
+  | Tstmt_exception ctor ->
+      iter.ctor_decl iter ctor
 
 let module_expr iter {mod_desc; mod_loc} =
   iter.location iter mod_loc ;

--- a/meja/src/typedast_map.ml
+++ b/meja/src/typedast_map.ml
@@ -303,6 +303,11 @@ let expression_desc mapper = function
         , mapper.expression mapper e )
   | Texp_convert conv ->
       Texp_convert (mapper.convert mapper conv)
+  | Texp_try (e, cases) ->
+      Texp_try
+        ( mapper.expression mapper e
+        , List.map cases ~f:(fun (p, e) ->
+              (mapper.pattern mapper p, mapper.expression mapper e) ) )
 
 let type_conv mapper = function
   | Ttconv_with (mode, decl) ->

--- a/meja/src/typedast_map.ml
+++ b/meja/src/typedast_map.ml
@@ -348,6 +348,8 @@ let signature_desc mapper = function
       Tsig_prover (mapper.signature mapper sigs)
   | Tsig_convert (name, typ) ->
       Tsig_convert (ident mapper name, mapper.type_expr mapper typ)
+  | Tsig_exception ctor ->
+      Tsig_exception (mapper.ctor_decl mapper ctor)
 
 let module_sig mapper {msig_desc; msig_loc} =
   { msig_loc= mapper.location mapper msig_loc
@@ -416,6 +418,8 @@ let statement_desc mapper = function
         ( ident mapper name
         , mapper.type_expr mapper typ
         , mapper.convert mapper conv )
+  | Tstmt_exception ctor ->
+      Tstmt_exception (mapper.ctor_decl mapper ctor)
 
 let module_expr mapper {mod_desc; mod_loc} =
   { mod_loc= mapper.location mapper mod_loc

--- a/meja/src/untype_ast.ml
+++ b/meja/src/untype_ast.ml
@@ -307,6 +307,10 @@ let rec expression_desc = function
       Pexp_prover (expression e)
   | Texp_convert _ ->
       assert false
+  | Texp_try (e, cases) ->
+      Pexp_try
+        ( expression e
+        , List.map cases ~f:(fun (p, e) -> (pattern p, expression e)) )
 
 and expression e =
   {Parsetypes.exp_desc= expression_desc e.Typedast.exp_desc; exp_loc= e.exp_loc}

--- a/meja/src/untype_ast.ml
+++ b/meja/src/untype_ast.ml
@@ -345,6 +345,8 @@ let rec signature_desc = function
       Psig_prover (List.map ~f:signature_item sigs)
   | Tsig_convert (name, typ) ->
       Psig_convert (map_loc ~f:Ident.name name, type_expr typ)
+  | Tsig_exception ctor ->
+      Psig_exception (ctor_decl ctor)
 
 and signature_item s =
   {Parsetypes.sig_desc= signature_desc s.Typedast.sig_desc; sig_loc= s.sig_loc}
@@ -400,6 +402,8 @@ let rec statement_desc = function
       Pstmt_prover (List.map ~f:statement stmts)
   | Tstmt_convert (name, typ, _conv) ->
       Pstmt_convert (map_loc ~f:Ident.name name, type_expr typ)
+  | Tstmt_exception ctor ->
+      Pstmt_exception (ctor_decl ctor)
 
 and statement s =
   { Parsetypes.stmt_desc= statement_desc s.Typedast.stmt_desc

--- a/meja/tests/exceptions.meja
+++ b/meja/tests/exceptions.meja
@@ -1,0 +1,19 @@
+module type S = {
+  exception X;
+  exception Y(int);
+  exception Z(bool) : exn;
+};
+
+module T = {
+  exception X;
+  exception Y(int);
+  exception Z(bool) : exn;
+};
+
+open T;
+
+let x : exn = X;
+
+let y : exn = Y(15);
+
+let z : exn = Z(true);

--- a/meja/tests/exceptions.meja
+++ b/meja/tests/exceptions.meja
@@ -17,3 +17,15 @@ let x : exn = X;
 let y : exn = Y(15);
 
 let z : exn = Z(true);
+
+let raise_X = fun () : unit => {
+  raise(X);
+};
+
+let raise_Y = fun (i) : bool => {
+  raise(Y(i));
+};
+
+let raise_Z = fun (b) : int => {
+  raise(Z(b));
+};

--- a/meja/tests/exceptions.ml
+++ b/meja/tests/exceptions.ml
@@ -1,0 +1,26 @@
+module Impl = Snarky.Snark.Make (Snarky.Backends.Mnt4.Default)
+open Impl
+
+module type S = sig
+  exception X
+
+  exception Y of int
+
+  exception Z : bool -> exn
+end
+
+module T = struct
+  exception X
+
+  exception Y of int
+
+  exception Z : bool -> exn
+end
+
+open T
+
+let (x : exn) = X
+
+let (y : exn) = Y 15
+
+let (z : exn) = Z true

--- a/meja/tests/exceptions.ml
+++ b/meja/tests/exceptions.ml
@@ -24,3 +24,9 @@ let (x : exn) = X
 let (y : exn) = Y 15
 
 let (z : exn) = Z true
+
+let raise_X () : unit = raise X
+
+let raise_Y i : bool = raise (Y i)
+
+let raise_Z b : int = raise (Z b)

--- a/meja/tests/try-non-exn-constructor.meja
+++ b/meja/tests/try-non-exn-constructor.meja
@@ -1,0 +1,7 @@
+type t = A;
+
+let x = fun () => {
+  try (failwith("")) {
+    | A => 15
+  };
+};

--- a/meja/tests/try-non-exn-constructor.stderr
+++ b/meja/tests/try-non-exn-constructor.stderr
@@ -1,0 +1,3 @@
+File "tests/try-non-exn-constructor.meja", line 5, characters 6-7:
+Error: Incompatible types exn and t:
+       Cannot unify exn and t

--- a/meja/tests/try-type-mismatch.meja
+++ b/meja/tests/try-type-mismatch.meja
@@ -1,0 +1,11 @@
+let x = fun (b) => {
+  try ({
+    if (b) {
+      ();
+    } else {
+      failwith("");
+    };
+  }) {
+    | Failure(_) => b
+  };
+};

--- a/meja/tests/try-type-mismatch.stderr
+++ b/meja/tests/try-type-mismatch.stderr
@@ -1,0 +1,3 @@
+File "tests/try-type-mismatch.meja", line 9, characters 20-21:
+Error: Incompatible types unit and bool:
+       Cannot unify unit and bool

--- a/meja/tests/try.meja
+++ b/meja/tests/try.meja
@@ -1,0 +1,26 @@
+let x : unit -> int = fun () => {
+  try (failwith("oh dear")) {
+    | Failure(_) => 15
+  };
+};
+
+let y : bool -> string = fun (b) => {
+  try ({
+      if (b) {
+        "";
+      } else {
+        failwith("");
+      };
+    }) {
+    | Failure(_) => ""
+  };
+};
+
+exception Other(int, bool);
+
+let z : unit -> int = fun () => {
+  try (15) {
+    | Failure(_) => 12
+    | Other(i, _) => i
+  };
+};

--- a/meja/tests/try.meja
+++ b/meja/tests/try.meja
@@ -24,3 +24,9 @@ let z : unit -> int = fun () => {
     | Other(i, _) => i
   };
 };
+
+let a = fun () => {
+  try (raise (Other (15, true))) {
+    | Other(i, b) => (i, b)
+  };
+};

--- a/meja/tests/try.ml
+++ b/meja/tests/try.ml
@@ -1,0 +1,12 @@
+module Impl = Snarky.Snark.Make (Snarky.Backends.Mnt4.Default)
+open Impl
+
+let (x : unit -> int) = fun () -> try failwith "oh dear" with Failure _ -> 15
+
+let (y : bool -> string) =
+ fun b -> try if b then "" else failwith "" with Failure _ -> ""
+
+exception Other of int * bool
+
+let (z : unit -> int) =
+ fun () -> try 15 with Failure _ -> 12 | Other (i, _) -> i

--- a/meja/tests/try.ml
+++ b/meja/tests/try.ml
@@ -10,3 +10,5 @@ exception Other of int * bool
 
 let (z : unit -> int) =
  fun () -> try 15 with Failure _ -> 12 | Other (i, _) -> i
+
+let a () = try raise (Other (15, true)) with Other (i, b) -> (i, b)


### PR DESCRIPTION
This PR implements exceptions and a try-catch syntax.

These may be used in programs, but primarily they have been added to add a simple test point for the effects system (as opposed to `request`, which also accepts type parameters and will need additional type management to work correctly).