### PR TITLE
add gen_uniform_incl; snarkette bin_io matches snarky

### DIFF
--- a/snarkette/dune
+++ b/snarkette/dune
@@ -2,6 +2,6 @@
  (inline_tests)
   (name snarkette)
   (public_name snarkette)
-  (libraries tuple_lib fold_lib num core_kernel )
+  (libraries tuple_lib fold_lib num core_kernel bignum)
   (preprocess (pps ppx_jane ppx_deriving.eq ppx_deriving_yojson))
   (js_of_ocaml (flags +nat.js)))

--- a/snarkette/nat.ml
+++ b/snarkette/nat.ml
@@ -74,6 +74,7 @@ let of_yojson = function
   | _ ->
       Error "Nat.of_yojson: Expected string"
 
+(** this serialization is not used for fields *)
 include Binable.Of_stringable (struct
   type nonrec t = t
 

--- a/snarkette/nat_intf.ml
+++ b/snarkette/nat_intf.ml
@@ -32,4 +32,8 @@ module type S = sig
   val test_bit : t -> int -> bool
 
   val num_bits : t -> int
+
+  val of_bytes : string -> t
+
+  val to_bytes : t -> string
 end

--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -1280,6 +1280,13 @@ struct
         Bignum_bigint.(gen_uniform_incl zero (size - one))
         ~f:(fun x -> Bigint.(to_field (of_bignum_bigint x)))
 
+    let gen_uniform_incl lo hi =
+      let lo_bigint = Bigint.(to_bignum_bigint @@ of_field lo) in
+      let hi_bigint = Bigint.(to_bignum_bigint @@ of_field hi) in
+      Quickcheck.Generator.map
+        Bignum_bigint.(gen_uniform_incl lo_bigint hi_bigint)
+        ~f:(fun x -> Bigint.(to_field (of_bignum_bigint x)))
+
     let typ = Typ.field
 
     type var' = Var.t

--- a/src/snark_intf.ml
+++ b/src/snark_intf.ml
@@ -583,6 +583,9 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
     val gen_uniform : t Core_kernel.Quickcheck.Generator.t
     (** A uniform generator for Quickcheck tests. *)
 
+    val gen_uniform_incl : t -> t -> t Core_kernel.Quickcheck.Generator.t
+    (** A uniform Quickcheck generator within specified inclusive bounds *)
+
     include Field_intf.Extended with type t := t
 
     include Stringable.S with type t := t


### PR DESCRIPTION
Two changes:

- add `gen_uniform_incl` to the snarky interface, so we can generate values within specified bounds (in Coda, `Private_key` generated numbers within bounds, then coerced them to a field value; seems better to do this "natively")

- change the `snarkette` `bin_io` serialization of fields to match the `snarky` serialization, which is to stuff bytes in a `Bigstring.t`; that seems to require right 0-padding to a word boundary (determined by comparing serializations from Coda nonconsensus code, which relies on snarkette, with the consensus code)