### PR TITLE
Use libsodium for randomness

### DIFF
--- a/src/camlsnark_c/camlsnark_linker_flags_gen.ml
+++ b/src/camlsnark_c/camlsnark_linker_flags_gen.ml
@@ -11,6 +11,7 @@ let () =
         ; "-L/usr/local/opt/openssl/lib"
         ; "-lssl"
         ; "-lcrypto"
+        ; "-lsodium"
         ; "-lgmp"
         ; "-lomp"
         ; "-lstdc++" ]
@@ -21,6 +22,7 @@ let () =
         ; "-lgomp"
         ; "-lssl"
         ; "-lcrypto"
+        ; "-lsodium"
         ; "-lprocps"
         ; "-lgmp"
         ; "-lstdc++" ]

--- a/src/camlsnark_c/libsnark-caml/CMakeLists.txt
+++ b/src/camlsnark_c/libsnark-caml/CMakeLists.txt
@@ -132,6 +132,8 @@ find_path(GMP_INCLUDE_DIR NAMES gmp.h)
 find_library(GMP_LIBRARIES NAMES gmp libgmp)
 find_library(GMPXX_LIBRARIES NAMES gmpxx libgmpxx)
 
+find_library(SODIUM_LIBRARIES NAMES sodium libsodium)
+
 include(FindPkgConfig)
 pkg_check_modules(
   CRYPTO

--- a/src/camlsnark_c/libsnark-caml/depends/libff/CMakeLists.txt
+++ b/src/camlsnark_c/libsnark-caml/depends/libff/CMakeLists.txt
@@ -120,6 +120,8 @@ find_path(GMP_INCLUDE_DIR NAMES gmp.h)
 find_library(GMP_LIBRARIES NAMES gmp libgmp)
 find_library(GMPXX_LIBRARIES NAMES gmpxx libgmpxx)
 
+find_library(SODIUM_LIBRARIES NAMES sodium libsodium)
+
 include(FindPkgConfig)
 pkg_check_modules(
   CRYPTO

--- a/src/camlsnark_c/libsnark-caml/depends/libff/libff/CMakeLists.txt
+++ b/src/camlsnark_c/libsnark-caml/depends/libff/libff/CMakeLists.txt
@@ -66,6 +66,7 @@ target_link_libraries(
   ff
 
   ${GMP_LIBRARIES}
+  ${SODIUM_LIBRARIES}
   ${GMPXX_LIBRARIES}
   ${CRYPTO_LIBRARIES}
   ${PROCPS_LIBRARIES}

--- a/src/camlsnark_c/libsnark-caml/depends/libff/libff/algebra/fields/bigint.tcc
+++ b/src/camlsnark_c/libsnark-caml/depends/libff/libff/algebra/fields/bigint.tcc
@@ -11,6 +11,7 @@
 #define BIGINT_TCC_
 #include <cassert>
 #include <cstring>
+#include <sodium.h>
 
 namespace libff {
 
@@ -166,10 +167,8 @@ template<mp_size_t n>
 bigint<n>& bigint<n>::randomize()
 {
     assert(GMP_NUMB_BITS == sizeof(mp_limb_t) * 8);
-    FILE *fp = fopen("/dev/urandom", "r");  //TODO Remove hard-coded use of /dev/urandom.
-    size_t bytes_read = fread(this->data, 1, sizeof(mp_limb_t) * n, fp);
-    assert(bytes_read == sizeof(mp_limb_t) * n);
-    fclose(fp);
+    assert(sodium_init() != -1);
+    randombytes_buf(this->data, sizeof(mp_limb_t) * n);
 
     return (*this);
 }

--- a/src/camlsnark_c/libsnark-caml/libsnark/CMakeLists.txt
+++ b/src/camlsnark_c/libsnark-caml/libsnark/CMakeLists.txt
@@ -36,6 +36,7 @@ target_link_libraries(
   
   ff
   ${GMP_LIBRARIES}
+  ${SODIUM_LIBRARIES}
   ${GMPXX_LIBRARIES}
   ${CRYPTO_LIBRARIES}
   ${PROCPS_LIBRARIES}


### PR DESCRIPTION
This PR modifies libff to use sodium for generating random field elements. This fixes a potential vulnerability on certain old platforms