### PR TITLE
Add gen_incl to Field

### DIFF
--- a/src/snark0.ml
+++ b/src/snark0.ml
@@ -1333,6 +1333,13 @@ struct
         Bignum_bigint.(gen_incl zero (size - one))
         ~f:(fun x -> Bigint.(to_field (of_bignum_bigint x)))
 
+    let gen_incl lo hi =
+      let lo_bigint = Bigint.(to_bignum_bigint @@ of_field lo) in
+      let hi_bigint = Bigint.(to_bignum_bigint @@ of_field hi) in
+      Quickcheck.Generator.map
+        Bignum_bigint.(gen_incl lo_bigint hi_bigint)
+        ~f:(fun x -> Bigint.(to_field (of_bignum_bigint x)))
+
     let gen_uniform =
       Quickcheck.Generator.map
         Bignum_bigint.(gen_uniform_incl zero (size - one))

--- a/src/snark_intf.ml
+++ b/src/snark_intf.ml
@@ -555,6 +555,9 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
     (** A generator for Quickcheck tests. *)
     val gen : t Core_kernel.Quickcheck.Generator.t
 
+    (** A generator for Quickcheck tests within specified inclusive bounds *)
+    val gen_incl : t -> t -> t Core_kernel.Quickcheck.Generator.t
+
     (** A uniform generator for Quickcheck tests. *)
     val gen_uniform : t Core_kernel.Quickcheck.Generator.t
 


### PR DESCRIPTION
PR #468 added `gen_incl` to snarkette fields.

In Coda, the `Field_extensions` library uses a snarkette interface in a way that `gen_incl` becomes required in snarky `Field`.

This PR adds `gen_incl` to `Field`, which now satisfies that interface.
