### PR TITLE
Statically link libsodium

### DIFF
--- a/src/camlsnark_c/camlsnark_linker_flags_gen.ml
+++ b/src/camlsnark_c/camlsnark_linker_flags_gen.ml
@@ -22,7 +22,9 @@ let () =
         ; "-lgomp"
         ; "-lssl"
         ; "-lcrypto"
-        ; "-lsodium"
+        ; "-Wl,--push-state,-Bstatic"
+        ;  "-lsodium"
+        ; "-Wl,--pop-state"
         ; "-lprocps"
         ; "-lgmp"
         ; "-lstdc++" ]

--- a/src/camlsnark_c/camlsnark_linker_flags_gen.ml
+++ b/src/camlsnark_c/camlsnark_linker_flags_gen.ml
@@ -23,7 +23,7 @@ let () =
         ; "-lssl"
         ; "-lcrypto"
         ; "-Wl,--push-state,-Bstatic"
-        ;  "-lsodium"
+        ; "-lsodium"
         ; "-Wl,--pop-state"
         ; "-lprocps"
         ; "-lgmp"


### PR DESCRIPTION
Coda already statically links `libsodium`, so this change prevents executables from the coda repo built with snarky trying to dynamically load a `libsodium.so`.