### PR TITLE
Extensible constraint type

### DIFF
--- a/src/backend_extended.ml
+++ b/src/backend_extended.ml
@@ -310,20 +310,11 @@ struct
 
     type t = Cvar.t Constraint.t [@@deriving sexp]
 
-    let eval_basic t get_value =
-      match t with
-      | Constraint.Boolean v ->
-          let x = get_value v in
-          Field.(equal x zero || equal x one)
-      | Equal (v1, v2) ->
-          Field.equal (get_value v1) (get_value v2)
-      | R1CS (v1, v2, v3) ->
-          Field.(equal (mul (get_value v1) (get_value v2)) (get_value v3))
-      | Square (a, c) ->
-          Field.equal (Field.square (get_value a)) (get_value c)
+    let m = (module Field : Field_intf.S with type t = Field.t)
 
     let eval t get_value =
-      List.for_all t ~f:(fun {basic; _} -> eval_basic basic get_value)
+      List.for_all t ~f:(fun {basic; _} ->
+          Constraint.Basic.eval m get_value basic )
   end
 
   module R1CS_constraint_system = R1CS_constraint_system

--- a/src/checked_runner.ml
+++ b/src/checked_runner.ml
@@ -1,4 +1,5 @@
 open Core_kernel
+module Constraint0 = Constraint
 
 exception Runtime_error of string * string list * exn * string
 
@@ -161,7 +162,11 @@ struct
                  asprintf "R1CS %s %s %s"
                    (Field.to_string (get_value s var1))
                    (Field.to_string (get_value s var2))
-                   (Field.to_string (get_value s var3))) ))
+                   (Field.to_string (get_value s var3)))
+           | _ ->
+               Format.asprintf
+                 !"%{sexp:Field.t Constraint0.basic}"
+                 (Constraint0.Basic.map basic ~f:(get_value s)) ))
 
   let stack_to_string = String.concat ~sep:"\n"
 

--- a/src/constraint.ml
+++ b/src/constraint.ml
@@ -1,11 +1,156 @@
 open Base
 
-type 'var basic =
+type _ basic = ..
+
+module Conv (F : sig
+  type _ t
+end) =
+struct
+  type t = {to_basic: 'v. 'v F.t -> 'v basic; of_basic: 'v. 'v basic -> 'v F.t}
+end
+
+module type S = sig
+  type _ t [@@deriving sexp]
+
+  val map : 'a t -> f:('a -> 'b) -> 'b t
+
+  (* TODO: Try making this a functor and seeing how it affects performance *)
+  val eval :
+    (module Field_intf.S with type t = 'f) -> ('v -> 'f) -> 'v t -> bool
+end
+
+module Basic = struct
+  type 'v t = 'v basic
+
+  module type S_with_conv = sig
+    include S
+
+    val to_basic : 'v t -> 'v basic
+
+    val of_basic : 'v basic -> 'v t
+  end
+
+  module Entry = struct
+    type t = (module S_with_conv)
+  end
+
+  let cases : Entry.t list ref = ref []
+
+  let add_case m = cases := m :: !cases
+
+  let case f =
+    List.find_map_exn !cases ~f:(fun m -> Option.try_with (fun () -> f m))
+
+  let sexp_of_t f t = case (fun (module M) -> M.sexp_of_t f (M.of_basic t))
+
+  let t_of_sexp f s = case (fun (module M) -> M.to_basic (M.t_of_sexp f s))
+
+  let eval (type f) (fm : (module Field_intf.S with type t = f)) (f : 'v -> f)
+      (t : 'v basic) : bool =
+    case (fun (module M) -> M.eval fm f (M.of_basic t))
+
+  let map t ~f = case (fun (module M) -> M.to_basic (M.map (M.of_basic t) ~f))
+end
+
+module Add_kind (C : S) : sig
+  type 'v basic += T of 'v C.t
+end = struct
+  type 'v basic += T of 'v C.t
+
+  module M = struct
+    include C
+
+    let to_basic x = T x
+
+    let of_basic = function T x -> x | _ -> failwith "different constructor"
+  end
+
+  let () = Basic.add_case (module M)
+end
+
+(* We special case these for compatibility with existing code. *)
+type 'var basic +=
   | Boolean of 'var
   | Equal of 'var * 'var
   | Square of 'var * 'var
   | R1CS of 'var * 'var * 'var
-[@@deriving sexp]
+
+let basic_of_sexp = Basic.t_of_sexp
+
+let sexp_of_basic = Basic.sexp_of_t
+
+let () =
+  let unhandled s = Core_kernel.failwithf "%s: non-basic constraint" s () in
+  let module Essential = struct
+    type 'var t =
+      | Boolean of 'var
+      | Equal of 'var * 'var
+      | Square of 'var * 'var
+      | R1CS of 'var * 'var * 'var
+    [@@deriving sexp]
+
+    let to_basic : 'v t -> 'v basic = function
+      | Boolean x ->
+          Boolean x
+      | Equal (x, y) ->
+          Equal (x, y)
+      | Square (x, y) ->
+          Square (x, y)
+      | R1CS (x, y, z) ->
+          R1CS (x, y, z)
+
+    let of_basic : 'v basic -> 'v t = function
+      | Boolean x ->
+          Boolean x
+      | Equal (x, y) ->
+          Equal (x, y)
+      | Square (x, y) ->
+          Square (x, y)
+      | R1CS (x, y, z) ->
+          R1CS (x, y, z)
+      | _ ->
+          unhandled "of_basic"
+  end in
+  let module M = struct
+    type 'v t = 'v basic
+
+    let sexp_of_t f t = Essential.(sexp_of_t f (of_basic t))
+
+    let t_of_sexp f s = Essential.(to_basic (t_of_sexp f s))
+
+    let of_basic = Fn.id
+
+    let to_basic = Fn.id
+
+    let map t ~f =
+      match t with
+      | Boolean v ->
+          Boolean (f v)
+      | Equal (v1, v2) ->
+          Equal (f v1, f v2)
+      | R1CS (v1, v2, v3) ->
+          R1CS (f v1, f v2, f v3)
+      | Square (a, c) ->
+          Square (f a, f c)
+      | _ ->
+          unhandled "map"
+
+    let eval (type f v) (module Field : Field_intf.S with type t = f)
+        (get_value : v -> f) (t : v basic) : bool =
+      match t with
+      | Boolean v ->
+          let x = get_value v in
+          Field.(equal x zero || equal x one)
+      | Equal (v1, v2) ->
+          Field.equal (get_value v1) (get_value v2)
+      | R1CS (v1, v2, v3) ->
+          Field.(equal (mul (get_value v1) (get_value v2)) (get_value v3))
+      | Square (a, c) ->
+          Field.equal (Field.square (get_value a)) (get_value c)
+      | _ ->
+          unhandled "eval"
+  end in
+  Basic.add_case (module M)
 
 type 'v basic_with_annotation = {basic: 'v basic; annotation: string option}
 [@@deriving sexp]

--- a/src/libsnark_r1cs_constraint_system.ml
+++ b/src/libsnark_r1cs_constraint_system.ml
@@ -143,6 +143,7 @@ module Make (Inputs : Inputs_intf) :
 
   let basic_to_r1cs_constraint : Cvar.t Constraint.basic -> R1CS_constraint.t =
     let of_var = Linear_combination.of_var in
+    let open Constraint in
     function
     | Boolean v ->
         let lc = of_var v in
@@ -167,6 +168,8 @@ module Make (Inputs : Inputs_intf) :
         let constr = R1CS_constraint.create (of_var a) (of_var b) (of_var c) in
         R1CS_constraint.set_is_square constr false ;
         constr
+    | _ ->
+        failwith "Unhandled constraint type"
 
   let add_constraint ?label t c =
     let c = basic_to_r1cs_constraint c in
@@ -176,8 +179,10 @@ module Make (Inputs : Inputs_intf) :
     | Some label ->
         add_constraint_with_annotation t c label
 
-  let basic_to_json = function
-    | Constraint.Boolean x ->
+  let basic_to_json =
+    let open Constraint in
+    function
+    | Boolean x ->
         let fx = Cvar.to_json x in
         `Assoc [("A", fx); ("B", fx); ("C", fx)]
     | Equal (x, y) ->
@@ -191,6 +196,8 @@ module Make (Inputs : Inputs_intf) :
     | R1CS (a, b, c) ->
         `Assoc
           [("A", Cvar.to_json a); ("B", Cvar.to_json b); ("C", Cvar.to_json c)]
+    | _ ->
+        `String "unhandled constraint type"
 
   let constraint_to_json x =
     `List (List.map x ~f:(fun {Constraint.basic; _} -> basic_to_json basic))
@@ -201,7 +208,7 @@ module Make (Inputs : Inputs_intf) :
           let a = Linear_combination.to_var (R1CS_constraint.a constr) in
           let b = Linear_combination.to_var (R1CS_constraint.b constr) in
           let c = Linear_combination.to_var (R1CS_constraint.c constr) in
-          Constraint.create_basic (R1CS (a, b, c)) :: acc )
+          Constraint.create_basic (Constraint.R1CS (a, b, c)) :: acc )
     in
     let open Base in
     let inputs =


### PR DESCRIPTION
This makes the constraint type extensible. A backend will implement a subset of the variants. This is to permit adding PLONK-type constraints in upcoming work.