### PR TITLE
Build requires jbuilder for meja and snarky_bench

### DIFF
--- a/meja.opam
+++ b/meja.opam
@@ -15,6 +15,7 @@ depends: [
   "ppxlib"
   "ppx_jane"
   "dune"                {build & >= "1.6"}
+  "jbuilder"            {build}
 ]
 available: [ ocaml-version >= "4.07.1" ]
 descr: "

--- a/snarky_bench.opam
+++ b/snarky_bench.opam
@@ -15,6 +15,7 @@ depends: [
   "ppx_jane"
   "ppx_bench"
   "dune"                {build & >= "1.6"}
+  "jbuilder"            {build}
 ]
 available: [ ocaml-version >= "4.07.0" ]
 descr: "


### PR DESCRIPTION
Both changed opam files contain build commands using `jbuilder`.
It was missing from the list of dependencies.