### PR TITLE
Remove periods from opam package synposis

### DIFF
--- a/group_map.opam
+++ b/group_map.opam
@@ -15,5 +15,5 @@ depends: [
 ]
 available: [ ocaml-version >= "4.07.0" ]
 descr: "
-Map from finite field elements to elliptic curves points over the finite field.
+Map from finite field elements to elliptic curves points over the finite field
 "

--- a/sponge.opam
+++ b/sponge.opam
@@ -18,5 +18,5 @@ depends: [
 ]
 available: [ ocaml-version >= "4.07.0" ]
 descr: "
-A library implementing the arithmetic sponge construction and several sponge-based hash functions.
+A library implementing the arithmetic sponge construction and several sponge-based hash functions
 "


### PR DESCRIPTION
Before this commit, `opam pin .` showed warnings like
```
[WARNING] Failed checks on sponge package definition from source at git+file:///home/<snip>/snarky/snarky#master:
  warning 47: Synopsis (or description first line) should start with a capital and not end with a dot
```