### PR TITLE
Monad let simplifications

### DIFF
--- a/src/monad_let.ml
+++ b/src/monad_let.ml
@@ -46,22 +46,6 @@ module type S = sig
   end
 end
 
-module Make (X : Monad.Basic) : S with type 'a t := 'a X.t = struct
-  include X
-  module M = Monad.Make (X)
-  module Let = M.Let_syntax.Let_syntax
-
-  include (M : S_without_syntax with type 'a t := 'a t)
-
-  module Let_syntax = struct
-    include (M.Let_syntax : Base_syntax with type 'a t := 'a t)
-
-    include (Let : Let_syntax with type 'a t := 'a t)
-
-    module Let_syntax = Let
-  end
-end
-
 module type Let_syntax2 = sig
   type ('a, 'e) t
 
@@ -219,4 +203,10 @@ Make3 (struct
   type ('a, 'd, 'e) t = ('a, 'e) X.t
 
   include (X : Monad.Basic3 with type ('a, 'd, 'e) t := ('a, 'e) X.t)
+end)
+
+module Make (X : Monad.Basic) : S with type 'a t := 'a X.t = Make2 (struct
+  type ('a, 'e) t = 'a X.t
+
+  include (X : Monad.Basic2 with type ('a, 'e) t := 'a X.t)
 end)

--- a/src/monad_let.ml
+++ b/src/monad_let.ml
@@ -129,23 +129,6 @@ module type S2 = sig
   end
 end
 
-module Make2 (X : Monad.Basic2) : S2 with type ('a, 'e) t := ('a, 'e) X.t =
-struct
-  include X
-  module M = Monad.Make2 (X)
-  module Let = M.Let_syntax.Let_syntax
-
-  include (M : S_without_syntax2 with type ('a, 'e) t := ('a, 'e) t)
-
-  module Let_syntax = struct
-    include (M.Let_syntax : Base_syntax2 with type ('a, 'e) t := ('a, 'e) t)
-
-    include (Let : Let_syntax2 with type ('a, 'e) t := ('a, 'e) t)
-
-    module Let_syntax = Let
-  end
-end
-
 module type Let_syntax3 = sig
   type ('a, 'd, 'e) t
 
@@ -230,3 +213,10 @@ module Make3 (X : Monad.Basic3) :
     module Let_syntax = Let
   end
 end
+
+module Make2 (X : Monad.Basic2) : S2 with type ('a, 'e) t := ('a, 'e) X.t =
+Make3 (struct
+  type ('a, 'd, 'e) t = ('a, 'e) X.t
+
+  include (X : Monad.Basic3 with type ('a, 'd, 'e) t := ('a, 'e) X.t)
+end)


### PR DESCRIPTION
monad_let.ml contained similar definitions of `Make`, `Make2` and `Make3` functors. Actually, `Make` is a special case of `Make2`, which in turn is a special case of `Make3`.

This PR uses `Make3` to define the other two.