### PR TITLE
Replace jbuilder with dune as builder of meja

### DIFF
--- a/meja.opam
+++ b/meja.opam
@@ -7,7 +7,7 @@ bug-reports: "https://github.com/o1labs/snarky/issues"
 dev-repo: "git+https://github.com/o1labs/snarky.git"
 license: "MIT"
 build: [
-  ["jbuilder" "build" "-p" name "-j" jobs]
+  ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
   "core_kernel" {>= "v0.12" & < "v0.13" }


### PR DESCRIPTION
This PR replaces `jbuilder` with `dune` in the build command of meja, following a suggestion in #477.