### PR TITLE
add squeeze_field function to sponge

### DIFF
--- a/sponge/sponge.ml
+++ b/sponge/sponge.ml
@@ -224,7 +224,7 @@ module Make_sponge (P : Intf.Permutation) = struct
 
   let capacity = 1
 
-  type sponge_state = Absorbed of int | Squeezed of int
+  type sponge_state = Absorbed of int | Squeezed of int [@@deriving sexp]
 
   type t =
     { mutable state: Field.t State.t
@@ -273,18 +273,18 @@ module Make_sponge (P : Intf.Permutation) = struct
         t.state.(0)
 end
 
-module Make_bit_sponge (Bool : sig
-  type t
-end) (Field : sig
-  type t
+module Make_bit_sponge
+    (Bool : Intf.T) (Field : sig
+        type t
 
-  val to_bits : t -> Bool.t list
-end)
-(S : Intf.Sponge
-     with module State := State
-      and module Field := Field
-      and type digest := Field.t
-      and type input := Field.t) =
+        val to_bits : t -> Bool.t list
+    end)
+    (Input : Intf.T)
+    (S : Intf.Sponge
+         with module State := State
+          and module Field := Field
+          and type digest := Field.t
+          and type input := Input.t) =
 struct
   type t =
     { underlying: S.t
@@ -315,4 +315,8 @@ struct
       t.last_squeezed
       <- t.last_squeezed @ List.take (Field.to_bits x) high_entropy_bits ;
       squeeze ~length t
+
+  let squeeze_field t =
+    t.last_squeezed <- [] ;
+    S.squeeze t.underlying
 end

--- a/sponge/sponge.mli
+++ b/sponge/sponge.mli
@@ -51,13 +51,18 @@ end) (Field : sig
 
   val to_bits : t -> Bool.t list
 end)
+(Input : Intf.T)
 (S : Intf.Sponge
      with module State := State
       and module Field := Field
       and type digest := Field.t
-      and type input := Field.t) :
-  Intf.Sponge
-  with module State := State
-   and module Field := Field
-   and type digest := length:int -> Bool.t list
-   and type input := Field.t
+      and type input := Input.t) : sig
+  include
+    Intf.Sponge
+    with module State := State
+     and module Field := Field
+     and type digest := length:int -> Bool.t list
+     and type input := Input.t
+
+  val squeeze_field : t -> Field.t
+end


### PR DESCRIPTION
This PR adds a squeze_field function to the bit sponge that squeezes a full field element.