### PR TITLE
Remove fast project

### DIFF
--- a/src/backend_extended.ml
+++ b/src/backend_extended.ml
@@ -233,7 +233,7 @@ struct
       fun bs -> go Field.one Field.zero bs
 
     (* Unused for now as it is incompatible with the zexe backends. *)
-    let project_fast bs =
+    let _project_fast bs =
       (* todo: 32-bit and ARM support. basically this code needs to always match the loop in the C++ of_data implementation. *)
       assert (Sys.word_size = 64 && not Sys.big_endian) ;
       let module R = Backend.Bigint.R in

--- a/src/backend_extended.ml
+++ b/src/backend_extended.ml
@@ -232,7 +232,8 @@ struct
       in
       fun bs -> go Field.one Field.zero bs
 
-    let project bs =
+    (* Unused for now as it is incompatible with the zexe backends. *)
+    let project_fast bs =
       (* todo: 32-bit and ARM support. basically this code needs to always match the loop in the C++ of_data implementation. *)
       assert (Sys.word_size = 64 && not Sys.big_endian) ;
       let module R = Backend.Bigint.R in
@@ -253,6 +254,8 @@ struct
         chunks64 ;
       Backend.Bigint.R.(of_data arr ~bitcount:(List.length bs) |> to_field)
 
+    let project = project_reference
+
     let compare t1 t2 = Bigint.(compare (of_field t1) (of_field t2))
 
     let hash_fold_t s x =
@@ -272,15 +275,18 @@ struct
 
     let of_string = Fn.compose of_bignum_bigint Bignum_bigint.of_string
 
+    (*
+    (* Unused for now as it is incompatible with the zexe backends. *)
     let%test_unit "project correctness" =
       Quickcheck.test
         Quickcheck.Generator.(
           small_positive_int >>= fun x -> list_with_length x bool)
         ~f:(fun bs ->
           [%test_eq: string]
-            (project bs |> to_string)
+            (project_fast bs |> to_string)
             (project_reference bs |> to_string) )
 
+*)
     let ( + ) = add
 
     let ( * ) = mul


### PR DESCRIPTION
This stops using the fast project function as it was incompatible with the zexe backends. @mrmr1993 do you think I should just remove the commented out unit test or is it worth keeping it in the file?