### PR TITLE
Take high_entropy_bits as a parameter for Bit_sponge

### DIFF
--- a/sponge/sponge.ml
+++ b/sponge/sponge.ml
@@ -299,6 +299,8 @@ module Bit_sponge = struct
           type t
 
           val to_bits : t -> Bool.t list
+
+          val high_entropy_bits : int
       end)
       (Input : Intf.T)
       (S : Intf.Sponge
@@ -311,7 +313,7 @@ module Bit_sponge = struct
 
     let state t = S.state t.underlying
 
-    let high_entropy_bits = 128
+    let high_entropy_bits = Field.high_entropy_bits
 
     let create ?init params =
       {underlying= S.create ?init params; last_squeezed= []}

--- a/sponge/sponge.mli
+++ b/sponge/sponge.mli
@@ -78,6 +78,8 @@ module Bit_sponge : sig
     type t
 
     val to_bits : t -> Bool.t list
+
+    val high_entropy_bits : int
   end)
   (Input : Intf.T)
   (S : Intf.Sponge


### PR DESCRIPTION
This allows us to use 256 for the current large curves, but 128 for the
tweedle curves.

Most importantly, this allows us to bump snarky in current coda develop.