### PR TITLE
Add "mod" and "ceil div" functions to snarky number (for powers of 2)

### DIFF
--- a/src/number.ml
+++ b/src/number.ml
@@ -202,6 +202,17 @@ module Make (Impl : Snark_intf.Basic) = struct
          failwithf "Number.*: Potential overflow: (%s * %s > Field.size)"
            (to_string x.upper_bound) (to_string y.upper_bound) ())
 
+  (* x mod n = x - n * floor(x / n) *)
+  let mod_pow_2 x n =
+    let%bind x_div_n = div_pow_2 x n in
+    let%map n_x_div_n = mul_pow_2 x_div_n n in
+    let res = x - n_x_div_n in
+    { res with
+      lower_bound= Bignum_bigint.zero
+    ; upper_bound=
+        (let (`Two_to_the k) = n in
+         Bignum_bigint.(pow (of_int 2) (of_int k))) }
+
   let min x y =
     let%bind less = x < y in
     if_ less ~then_:x ~else_:y
@@ -239,6 +250,8 @@ module Run = struct
     let div_pow_2 x y = run_checked (div_pow_2 x y)
 
     let mul_pow_2 x y = run_checked (mul_pow_2 x y)
+
+    let mod_pow_2 x y = run_checked (mod_pow_2 x y)
 
     let clamp_to_n_bits x y = run_checked (clamp_to_n_bits x y)
   end

--- a/src/number.ml
+++ b/src/number.ml
@@ -176,6 +176,23 @@ module Make (Impl : Snark_intf.Basic) = struct
       failwithf "Number.+: Potential overflow: (%s + %s > Field.size)"
         (to_string x.upper_bound) (to_string y.upper_bound) ()
 
+  (* Compute (n, k) -> ceil(n / 2^k) using the identity
+
+     ceil(n / m)
+     =
+        if n % m = 0
+        then floor(n / m)
+        else floor(n / m) + 1
+     =
+        if m * floor(n / m) = n
+        then floor(n / m)
+        else floor(n / m) + 1
+  *)
+  let ceil_div_pow2 n m =
+    let%bind floor_div = div_pow_2 n m in
+    let%bind m_divides_n = mul_pow_2 floor_div m >>= ( = ) n in
+    if_ m_divides_n ~then_:floor_div ~else_:(floor_div + one)
+
   let ( - ) x y =
     let open Bignum_bigint in
     (* x_upper_bound >= x >= x_lower_bound >= y_upper_bound >= y >= y_lower_bound *)
@@ -248,6 +265,8 @@ module Run = struct
     let to_bits x = run_checked (to_bits x)
 
     let div_pow_2 x y = run_checked (div_pow_2 x y)
+
+    let ceil_div_pow2 x y = run_checked (ceil_div_pow2 x y)
 
     let mul_pow_2 x y = run_checked (mul_pow_2 x y)
 

--- a/src/number.ml
+++ b/src/number.ml
@@ -188,7 +188,7 @@ module Make (Impl : Snark_intf.Basic) = struct
         then floor(n / m)
         else floor(n / m) + 1
   *)
-  let ceil_div_pow2 n m =
+  let ceil_div_pow_2 n m =
     let%bind floor_div = div_pow_2 n m in
     let%bind m_divides_n = mul_pow_2 floor_div m >>= ( = ) n in
     if_ m_divides_n ~then_:floor_div ~else_:(floor_div + one)
@@ -266,7 +266,7 @@ module Run = struct
 
     let div_pow_2 x y = run_checked (div_pow_2 x y)
 
-    let ceil_div_pow2 x y = run_checked (ceil_div_pow2 x y)
+    let ceil_div_pow_2 x y = run_checked (ceil_div_pow_2 x y)
 
     let mul_pow_2 x y = run_checked (mul_pow_2 x y)
 

--- a/src/number_intf.ml
+++ b/src/number_intf.ml
@@ -47,6 +47,8 @@ module type S = sig
 
   val mul_pow_2 : t -> [`Two_to_the of int] -> (t, _) checked
 
+  val mod_pow_2 : t -> [`Two_to_the of int] -> (t, _) checked
+
   val of_pow_2 : [`Two_to_the of int] -> t
 
   val clamp_to_n_bits : t -> int -> (t, _) checked
@@ -98,6 +100,8 @@ module type Run = sig
   val div_pow_2 : t -> [`Two_to_the of int] -> t
 
   val mul_pow_2 : t -> [`Two_to_the of int] -> t
+
+  val mod_pow_2 : t -> [`Two_to_the of int] -> t
 
   val of_pow_2 : [`Two_to_the of int] -> t
 

--- a/src/number_intf.ml
+++ b/src/number_intf.ml
@@ -45,6 +45,8 @@ module type S = sig
 
   val div_pow_2 : t -> [`Two_to_the of int] -> (t, _) checked
 
+  val ceil_div_pow_2 : t -> [`Two_to_the of int] -> (t, _) checked
+
   val mul_pow_2 : t -> [`Two_to_the of int] -> (t, _) checked
 
   val mod_pow_2 : t -> [`Two_to_the of int] -> (t, _) checked
@@ -98,6 +100,8 @@ module type Run = sig
   val to_bits : t -> bool_var list
 
   val div_pow_2 : t -> [`Two_to_the of int] -> t
+
+  val ceil_div_pow_2 : t -> [`Two_to_the of int] -> t
 
   val mul_pow_2 : t -> [`Two_to_the of int] -> t
 


### PR DESCRIPTION
This adds to the snarky number module

- a function for computing `(n, k) -> n mod 2^k`.  It computes using the identity `n mod m = n - m * floor(n / m)`
- a function for computing `(n, k) -> ceil(n / 2^k)`. It computes using the identity `ceil(n / m) = if n % m = 0 then floor(n / m) else floor(n / m) + 1`.