### PR TITLE
Change snarky curve back to using digestif.ocaml explicitly

### DIFF
--- a/snarky_curve/dune
+++ b/snarky_curve/dune
@@ -5,6 +5,6 @@
   (inline_tests)
   (libraries
     snarky
-    digestif.c
+    digestif.ocaml
     group_map
     core_kernel ))

--- a/snarky_curve/dune
+++ b/snarky_curve/dune
@@ -5,6 +5,6 @@
   (inline_tests)
   (libraries
     snarky
-    digestif
+    digestif.c
     group_map
     core_kernel ))


### PR DESCRIPTION
I had trouble getting https://github.com/o1-labs/snarky/pull/504 to work in the context of coda due to the inline tests runner not knowing which implementation of digestif to link in. I tried adding

```dune
(inline-tests (libraries digestif.c))
```

to the dune file, and this seemed to get dune to provide the right implementation as it included

```
/home/izzy/.opam/4.07.1/lib/digestif/rakia/rakia.cmxa -I /home/izzy/.opam/4.07.1/lib/digestif/rakia /home/izzy/.opam/4.07.1/lib/digestif/c/digestif_c.cmxa
```

in the call to ocamlopt, but it still failed with the same error.

## Why ocaml and not c backend
In the context of coda, using digestif.c here instead of digestif.ocaml failed with
```
File "_none_", line 1:   
Error: Files src/lib/crs/crs.cmxa
       and /home/izzy/.opam/4.07.1/lib/digestif/c/digestif_c.cmxa
       make inconsistent assumptions over implementation Digestif
Makefile:86: recipe for target 'build' failed
make: *** [build] Error 1
```

The branch name is such because I had originally tried using digestif.c