### PR TITLE
camlsnark_c: fix bash build cmds on macos

### DIFF
--- a/src/camlsnark_c/snark_caml_bn128/dune
+++ b/src/camlsnark_c/snark_caml_bn128/dune
@@ -42,7 +42,7 @@
      pushd _stubs_build/libsnark_caml_bn128/; ar -xv ../../caml/libsnark_caml_bn128.a; popd
 
      libtool -static -o libsnark_caml_bn128_stubs.a \\
-       _stubs_build/libsnark_caml_bn128/*.o \\
+       _stubs_build/libsnark_caml_bn128/*.o
    popd
    mv ../libsnark-caml/build/libsnark_caml_bn128_stubs.a .
 

--- a/src/camlsnark_c/snark_caml_mnt298/dune
+++ b/src/camlsnark_c/snark_caml_mnt298/dune
@@ -42,7 +42,7 @@
      pushd _stubs_build/libsnark_caml_mnt298/; ar -xv ../../caml/libsnark_caml_mnt298.a; popd
 
      libtool -static -o libsnark_caml_mnt298_stubs.a \\
-       _stubs_build/libsnark_caml_mnt298/*.o \\
+       _stubs_build/libsnark_caml_mnt298/*.o
    popd
    mv ../libsnark-caml/build/libsnark_caml_mnt298_stubs.a .
 

--- a/src/camlsnark_c/snark_caml_mnt753/dune
+++ b/src/camlsnark_c/snark_caml_mnt753/dune
@@ -42,7 +42,7 @@
      pushd _stubs_build/libsnark_caml_mnt753/; ar -xv ../../caml/libsnark_caml_mnt753.a; popd
 
      libtool -static -o libsnark_caml_mnt753_stubs.a \\
-       _stubs_build/libsnark_caml_mnt753/*.o \\
+       _stubs_build/libsnark_caml_mnt753/*.o
    popd
    mv ../libsnark-caml/build/libsnark_caml_mnt753_stubs.a .
 


### PR DESCRIPTION
Fixes a bug in the embedded bash build scripts in `snarky/src/camlsnark_c/snark_caml_*/dune` that prevents compile on MacOS - causes libtool to choke on popd because the prev line ends with \\ (continuation)