### PR TITLE
put embedded xbyak in sync with o1-labs/xbyak repo

### DIFF
--- a/src/camlsnark_c/libsnark-caml/depends/xbyak/.bazelrc
+++ b/src/camlsnark_c/libsnark-caml/depends/xbyak/.bazelrc
@@ -1,0 +1,4 @@
+# enable platform-based toolchain resolution:
+build --incompatible_enable_cc_toolchain_resolution
+
+try-import user.bazelrc

--- a/src/camlsnark_c/libsnark-caml/depends/xbyak/.gitignore
+++ b/src/camlsnark_c/libsnark-caml/depends/xbyak/.gitignore
@@ -1,0 +1,5 @@
+.bazel
+bazel-*
+user.bazelrc
+
+*~

--- a/src/camlsnark_c/libsnark-caml/depends/xbyak/bzl/tools/aliaslog
+++ b/src/camlsnark_c/libsnark-caml/depends/xbyak/bzl/tools/aliaslog
@@ -1,0 +1,3 @@
+# source me
+
+alias "bl=less `bazel info command_log`"

--- a/src/camlsnark_c/libsnark-caml/depends/xbyak/bzl/tools/user.bazelrc.template
+++ b/src/camlsnark_c/libsnark-caml/depends/xbyak/bzl/tools/user.bazelrc.template
@@ -1,0 +1,29 @@
+## Copy this file to 'user.bazelrc' in the root directory and edit to
+## taste. Do NOT check it into version control. The root .bazelrc file
+## contains a line that loads user.bazelrc if it exists.
+
+## See https://docs.bazel.build/versions/master/guide.html#bazelrc-the-bazel-configuration-file
+## Best practices: https://docs.bazel.build/versions/master/best-practices.html#bazelrc
+## Command line ref: https://docs.bazel.build/versions/master/command-line-reference.html
+
+################################################################
+# do not use on macos if you are building shared libs:
+build --symlink_prefix=.bazel/   # use hidden dir .bazel/ instead of top-level symlinks bazel-*
+# When enabled, the `bazel-out` symlink won’t be created if a different name is given to `--symlink_prefix`.
+build --experimental_no_product_name_out_symlink
+
+build --color=yes
+
+# build --subcommands  # print commands Bazel constructs, no pretty-print
+build --subcommands=pretty_print
+build --verbose_failures
+build --sandbox_debug
+
+# build --show_timestamps
+# build --keep_going  # Continue as much as possible after an error
+# build --jobs 600 # default is "auto" = calculates a reasonable default based on host resources
+
+# query --noimplicit_deps
+# query --notool_deps
+# query --keep_going
+

--- a/src/camlsnark_c/libsnark-caml/depends/xbyak/doc/bazel.md
+++ b/src/camlsnark_c/libsnark-caml/depends/xbyak/doc/bazel.md
@@ -1,0 +1,70 @@
+# xbyak: working with bazel
+
+## using xbyak as dependency
+
+To use `xbyak` in a non-bazel project, follow the instructions in the main readme file.
+
+To use `xbyak` in a Bazel project, add the following to the WORKSPACE file:
+
+```
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+http_archive(
+    name = "xbyak",
+    urls = ["https://github.com/o1-labs/xbyak.git"]
+    # or use a url for a commit or release
+    # strip_prefix = ...
+    # sha256 = ...
+)
+```
+
+The dependency label is `@xbyak//xbyak`, e.g. `deps =
+["@xbyak//xbyak"]`. If the header files are not found, add
+`"-Iexternal/xbyak"` to `copts`.
+
+For an example, see [ate-pairing](https://github.com/o1-labs/ate-pairing/blob/snarky/BUILD.bazel)
+
+## build configuration options
+
+* `--//:snark` - use CurveSNARK (see main readme file for
+  explanation). Default: False, use CurveFp254BNb.
+
+* `--/:with_libgmp` - compile libzm with libgmp support.  Default: True.
+
+When using `xbyak` as a dependency in a Bazelized project, you may
+copy the `bool_flag` and `config_setting` definitions from the `xbyak`
+root `BUILD.bazel` file to your project's root `BUILD.bazel` file.
+This will allow the user to configure builds using e.g.
+`--//:with_libgmp` instead of `--@xbyak//:with_libgmp`. It also allows
+you to override the defaults. See
+[ate-pairing](https://github.com/o1-labs/ate-pairing/blob/snarky/BUILD.bazel)
+and [libff](https://github.com/o1-labs/libff/blob/snarky/BUILD.bazel)
+for examples. The latter overrides `enable_snark` to default True.
+
+## tests
+
+Clone the repo, then:
+
+```
+$ bazel test test
+```
+
+All tests succeed on linux, test:jmp fails on MacOS.
+
+You can also run the samples:
+
+```
+$ bazel run sample:<target>
+```
+
+where <target> = bf | calc | jmp_table | memfunc | quantize | static_buf | test | test_util | toyvm
+
+## queries
+
+List all test targets:
+
+* ` bazel query "kind(.*_test, //...:*)"`
+
+List all rules in package `sample`:
+
+* ` bazel query "sample:all"`
+

--- a/src/camlsnark_c/libsnark-caml/depends/xbyak/readme.md
+++ b/src/camlsnark_c/libsnark-caml/depends/xbyak/readme.md
@@ -37,6 +37,12 @@ and_(), or_(), xor_(), not_() are always available.
 Install
 -------------
 
+#### Bazel
+
+See [doc/bazel.md](doc/bazel.md) for instructions.
+
+#### Legacy
+
 The following files are necessary. Please add the path to your compile directories.
 
 * xbyak.h

--- a/src/camlsnark_c/libsnark-caml/depends/xbyak/sample/BUILD.bazel
+++ b/src/camlsnark_c/libsnark-caml/depends/xbyak/sample/BUILD.bazel
@@ -12,7 +12,12 @@ CFLAGS = ["-g", "-O2",
           "-I.",
           "-Wall"] + CFLAGS_WARN
 
-cc_binary( name = "test",
+config_setting(
+    name = "is_32bit",
+    constraint_values = ["@platforms//cpu:arm"],
+)
+
+cc_binary( name = "test0",
            visibility = ["//visibility:public"],
            srcs = ["test0.cpp"],
            copts = CFLAGS,
@@ -30,11 +35,6 @@ cc_binary( name = "bf",
            srcs = ["bf.cpp"],
            copts = CFLAGS,
            deps = ["//xbyak"] )
-
-config_setting(
-    name = "is_32bit",
-    constraint_values = ["@platforms//cpu:arm"],
-)
 
 # generate a dummy file as input to :toyvm on 64-bit platforms
 genrule(
@@ -92,3 +92,18 @@ cc_binary( name = "calc",
                    "@boost//:spirit",
                    "@boost//:bind"]
 )
+
+## error: call to 'ref' is ambiguous
+# cc_binary( name = "calc2",
+#            visibility = ["//visibility:public"],
+#            srcs = ["calc2.cpp"],
+#            copts = ["-Iboost"] + CFLAGS,
+#            deps = ["//xbyak",
+#                    "@boost//:bind",
+#                    "@boost//:foreach",
+#                    "@boost//:function",
+#                    "@boost//:spirit",
+#                    "@boost//:phoenix",
+#                    "@boost//:iostreams",
+#                    "@boost//:variant"]
+# )

--- a/src/camlsnark_c/libsnark-caml/depends/xbyak/test/BUILD.bazel
+++ b/src/camlsnark_c/libsnark-caml/depends/xbyak/test/BUILD.bazel
@@ -11,23 +11,34 @@ CFLAGS = ["-O2", "-fomit-frame-pointer",
           "-Wall", "-fno-operator-names",
           "-I.", "-Itest", "-Iexternal/xbyak"] + CFLAGS_WARN #-std=c++0x
 
+config_setting(
+    name = "is_64bit",
+    constraint_values = ["@platforms//cpu:x86_64"]
+)
+
+config_setting(
+    name = "is_32bit",
+    constraint_values = ["@platforms//cpu:x86_32"]
+)
+
 test_suite(
     name = "test",
     tests = [
-        ":make_nm",
-        ":normalize_prefix",
-        ":jmp",
         ":address",
         ":bad_address",
-        ":misc",
         ":cvt_test",
-        ":cvt_test32"
+        ":cvt_test32",
+        ":jmp",
+        ":make_nm",
+        ":misc",
+        ":normalize_prefix"
     ]
 )
 
 cc_test(
     name = "make_nm",
     visibility = ["//visibility:public"],
+    size = "small",
     copts = CFLAGS,
     srcs = ["make_nm.cpp"],
     deps = ["//xbyak", "//test/cybozu"]
@@ -36,6 +47,7 @@ cc_test(
 cc_test(
     name = "normalize_prefix",
     visibility = ["//visibility:public"],
+    size = "small",
     copts = CFLAGS,
     srcs = ["normalize_prefix.cpp"],
     deps = ["//xbyak"]
@@ -53,7 +65,13 @@ cc_test(
 cc_test(
     name = "jmp",
     visibility = ["//visibility:public"],
-    copts = CFLAGS + ["-Iexternal/xbyak/test"],
+    size = "small",
+    copts = CFLAGS
+    + select({
+        ":is_64bit": ["-m64"],
+        ":is_32bit": ["-m32"],
+        "//conditions:default"   : []
+    }),
     srcs = ["jmp.cpp"],
     deps = ["//xbyak", "//test/cybozu"]
 )
@@ -61,7 +79,13 @@ cc_test(
 cc_test(
     name = "address",
     visibility = ["//visibility:public"],
-    copts = CFLAGS,
+    size = "small",
+    copts = CFLAGS
+    + select({
+        ":is_64bit": ["-m64"],
+        ":is_32bit": ["-m32"],
+        "//conditions:default"   : []
+    }),
     srcs = ["address.cpp"],
     deps = ["//xbyak"]
 )
@@ -69,6 +93,7 @@ cc_test(
 cc_test(
     name = "bad_address",
     visibility = ["//visibility:public"],
+    size = "small",
     copts = CFLAGS,
     srcs = ["bad_address.cpp"],
     deps = ["//xbyak", "//test/cybozu"]
@@ -77,7 +102,8 @@ cc_test(
 cc_test(
     name = "misc",
     visibility = ["//visibility:public"],
-    copts = CFLAGS + ["-Iexternal/xbyak/test"],
+    size = "small",
+    copts = CFLAGS,
     srcs = ["misc.cpp"],
     deps = ["//xbyak", "//test/cybozu"]
 )
@@ -85,21 +111,28 @@ cc_test(
 cc_test(
     name = "cvt_test",
     visibility = ["//visibility:public"],
+    size = "small",
     copts = CFLAGS,
-    srcs = ["cvt_test.cpp",
-    ],
+    defines = select({
+        ":is_32bit": ["XBYAK32"],
+        "//conditions:default"   : []
+    }),
+    srcs = ["cvt_test.cpp"],
     deps = ["//xbyak", "//test/cybozu"]
 )
 
 cc_test(
     name = "cvt_test32",
     visibility = ["//visibility:public"],
+    size = "small",
     copts = CFLAGS + ["-DXBYAK32"],
-    srcs = ["cvt_test.cpp",
-    ],
+    srcs = ["cvt_test.cpp"],
     deps = ["//xbyak", "//test/cybozu"]
 )
 
+## not implemented: test_nm, test_avx, test_avx512
+## these involve shell scripts, see Makefile
+## leaving these here in case we decide to support in future:
 # genrule(
 #     name="test_nm",
 #     tools = [":jmp",
@@ -110,3 +143,11 @@ cc_test(
 #     data = ["test_nm.sh",
 #             "test_address.sh"],
 # )
+
+# sh_test(
+#     name = "nm",
+#     srcs = ["test_nm.sh"],
+#     deps = [":foo_sh_lib"],
+#     data = glob(["testdata/*.txt"]),
+# )
+

--- a/src/camlsnark_c/libsnark-caml/depends/xbyak/test/misc.cpp
+++ b/src/camlsnark_c/libsnark-caml/depends/xbyak/test/misc.cpp
@@ -1,9 +1,9 @@
 #include <stdio.h>
 #include <string.h>
 #include <string>
-#include <xbyak/xbyak.h>
-#include <cybozu/inttype.hpp>
-#include <cybozu/test.hpp>
+#include "xbyak/xbyak.h"
+#include "cybozu/inttype.hpp"
+#include "cybozu/test.hpp"
 
 using namespace Xbyak;
 


### PR DESCRIPTION
This makes the xbyak code embedded in snarky match the snarky branch of [o1-labs/xbyak](https://github.com/o1-labs/xbyak/tree/snarky).  The next step will be to replace this code with a submodule.