### PR TITLE
making new params available to users of sponge lib

### DIFF
--- a/sponge/sponge.ml
+++ b/sponge/sponge.ml
@@ -21,6 +21,8 @@ module Params = struct
   let pasta_p = Constants.params_Pasta_p
 
   let pasta_q = Constants.params_Pasta_q
+
+  let pasta_p_3 = Constants.params_Pasta_p_3
 end
 
 module State = Array

--- a/sponge/sponge.mli
+++ b/sponge/sponge.mli
@@ -22,6 +22,8 @@ module Params : sig
   val pasta_p : string t
 
   val pasta_q : string t
+
+  val pasta_p_3 : string t
 end
 
 module State : sig


### PR DESCRIPTION
Without this, the new parameters (pasta_p_3) cannot be accessed from outside the sponge library.