### PR TITLE
make bigint dependency explicit

### DIFF
--- a/src/base/dune
+++ b/src/base/dune
@@ -2,5 +2,24 @@
  (name snarky_backendless)
  (public_name snarky.backendless)
  (inline_tests)
- (libraries bitstring_lib core_kernel h_list interval_union snarky_intf)
- (preprocess (pps ppx_sexp_conv ppx_bin_prot ppx_let ppx_hash ppx_compare ppx_deriving.enum ppx_assert ppx_deriving.eq ppx_snarky ppx_fields_conv ppx_inline_test ppx_custom_printf)))
+ (libraries
+  bitstring_lib
+  core_kernel
+  h_list
+  interval_union
+  snarky_intf
+  bignum.bigint)
+ (preprocess
+  (pps
+   ppx_sexp_conv
+   ppx_bin_prot
+   ppx_let
+   ppx_hash
+   ppx_compare
+   ppx_deriving.enum
+   ppx_assert
+   ppx_deriving.eq
+   ppx_snarky
+   ppx_fields_conv
+   ppx_inline_test
+   ppx_custom_printf)))


### PR DESCRIPTION
Help the poor OCaml reader who is trying to figure where dependencies are coming from :)