### PR TITLE
[sponge] fix bugs + test vectors

### DIFF
--- a/sponge/dune
+++ b/sponge/dune
@@ -1,7 +1,7 @@
 (library
-  (name sponge)
-  (public_name sponge)
-  (preprocess (pps ppx_jane ppx_deriving.eq))
-  (inline_tests)
-  (libraries
-    core_kernel ))
+ (name sponge)
+ (public_name sponge)
+ (preprocess
+  (pps ppx_jane ppx_deriving.eq))
+ (inline_tests)
+ (libraries core_kernel))

--- a/sponge/sponge.ml
+++ b/sponge/sponge.ml
@@ -192,7 +192,8 @@ module Poseidon (Inputs : Intf.Inputs.Poseidon) = struct
       !state.(0) <- sbox !state.(0) ;
       state := apply_affine_map (mds, round_constants.(i)) !state
     done ;
-    let range = (snd range + 1, rounds_full + rounds_partial - 1) in
+    let second_half_rounds_full = rounds_full - first_half_rounds_full in
+    let range = (snd range + 1, snd range + second_half_rounds_full) in
     for i = fst range to snd range do
       Array.map_inplace !state ~f:sbox ;
       state := apply_affine_map (mds, round_constants.(i)) !state

--- a/sponge/test_vectors/dune
+++ b/sponge/test_vectors/dune
@@ -1,0 +1,3 @@
+(executable
+ (name main)
+ (libraries sponge snarkette core_kernel))

--- a/sponge/test_vectors/dune
+++ b/sponge/test_vectors/dune
@@ -1,3 +1,11 @@
 (executable
  (name main)
  (libraries sponge snarkette core_kernel))
+
+; run test vectors with `dune runtest`
+
+(rule
+ (alias runtest)
+ (deps three_wire.json fp_3.json)
+ (action
+  (run ./main.exe)))

--- a/sponge/test_vectors/fp_3.json
+++ b/sponge/test_vectors/fp_3.json
@@ -1,0 +1,49 @@
+{
+    "name": "fp_3",
+    "test_vectors": [
+        {
+            "input": [],
+            "output": "87b24ed3fe1f35af6497c504acd6de35f06bd9c2e2490a1b5012715719de8d05"
+        },
+        {
+            "input": [
+                "df698e389c6f1987ffe186d806f8163738f5bf22e8be02572cce99dc6a4ab030"
+            ],
+            "output": "d2f75185842484ba5a1a4e0ba5f3870ed48782cc4f89a8228f5eaf75e1833906"
+        },
+        {
+            "input": [
+                "56b648a5a85619814900a6b40375676803fe16fb1ad2d1fb79115eb1b52ac026",
+                "f26a8a03d9c9bbd9c6b2a1324d2a3f4d894bafe25a7e4ad1a498705f4026ff2f"
+            ],
+            "output": "922d4e7f5802aee157ae13afb8c7a4aadca06913b9d36a9d1f20f5edb70e2c30"
+        },
+        {
+            "input": [
+                "075c41fa23e4690694df5ded43624fd60ab7ee6ec6dd48f44dc71bc206cecb26",
+                "a4e2beebb09bd02ad42bbccc11051e8262b6ef50445d8382b253e91ab1557a0d",
+                "7dfc23a1242d9c0d6eb16e924cfba342bb2fccf36b8cbaf296851f2e6c469639"
+            ],
+            "output": "1879e13397b27ddec5fcdfb50183d106744368525494afcb256c8207129a103d"
+        },
+        {
+            "input": [
+                "a1a659b14e80d47318c6fcdbbd388de4272d5c2815eb458cf4f196d52403b639",
+                "5e33065d1801131b64d13038ff9693a7ef6283f24ec8c19438d112ff59d50f04",
+                "38a8f4d0a9b6d0facdc4e825f6a2ba2b85401d5de119bf9f2bcb908235683e06",
+                "3456d0313a30d7ccb23bd71ed6aa70ab234dad683d8187b677aef73f42f4f52e"
+            ],
+            "output": "415aab36a9011fa8218bd67be746c7a8fd9ba83d01d1ca669574c60caef12d30"
+        },
+        {
+            "input": [
+                "bccfee48dc76bb991c97bd531cf489f4ee37a66a15f5cfac31bdd4f159d4a905",
+                "2d106fb21a262f85fd400a995c6d74bad48d8adab2554046871c215e585b072b",
+                "8300e93ee8587956534d0756bb2aa575e5878c670cff5c8e3e55c62632333c06",
+                "879c32da31566f6d16afdefff94cba5260fec1057e97f19fc9a61dc2c54a6417",
+                "9c0aa6e5501cfb2d08aeaea5b3cddac2c9bee85d13324118b44bafb63a59611e"
+            ],
+            "output": "9d69ee732cfe073cc9417aef734293002c8db0c69b1e814cfa7a858e7c995d33"
+        }
+    ]
+}

--- a/sponge/test_vectors/hash_function.ml
+++ b/sponge/test_vectors/hash_function.ml
@@ -8,7 +8,7 @@ module Field = struct
   include Snarkette.Pasta.Fp
 
   (* Converts a byterray into a [Field.t], raises an exception if the number obtained is larger than the order *)
-  let of_bytes (bytearray: string) : t =
+  let of_bytes (bytearray : string) : t =
     let aux i acc c =
       let big = Nat.of_int @@ int_of_char c in
       let offset = Nat.shift_left big (Int.( * ) i 8) in
@@ -22,12 +22,12 @@ module Field = struct
     of_bigint big
 
   (* Converts an hexadecimal string into a [Field.t], raises an exception if the number obtained is larger than the order *)
-  let of_hex (hexstring: string) : t =
+  let of_hex (hexstring : string) : t =
     let bytearray : string = Hex.decode hexstring |> Bytes.to_string in
     of_bytes bytearray
 
   (* Converts a field element into a bytearray (encoding the field element in little-endian) *)
-  let to_bytes (field: t) : bytes =
+  let to_bytes (field : t) : bytes =
     (* taken from src/lib/pickles *)
     let bits_to_bytes bits =
       let byte_of_bits bs =
@@ -44,7 +44,7 @@ module Field = struct
     bytearray
 
   (* Converts a field element into an hexadecimal string (encoding the field element in little-endian) *)
-  let to_hex (field: t) : string =
+  let to_hex (field : t) : string =
     let bytearray : bytes = to_bytes field in
     Hex.encode bytearray
 end
@@ -127,12 +127,12 @@ module ThreeWire = struct
     Sponge.Params.(map pasta_p ~f:Field.of_string)
 
   let hash ?init = hash ?init params
-  
+
   (* input is an array of field elements encoded as hexstrings *)
   let hash_field_elems (field_elems : string list) : string =
     let input : Field.t array =
-      if List.length field_elems = 0 then [||] else
-      Array.of_list @@ List.map field_elems ~f:Field.of_hex
+      if List.length field_elems = 0 then [||]
+      else Array.of_list @@ List.map field_elems ~f:Field.of_hex
     in
     let digest = hash ~init:initial_state input in
     Field.to_hex digest
@@ -145,12 +145,12 @@ module Fp3 = struct
     Sponge.Params.(map pasta_p_3 ~f:Field.of_string)
 
   let hash ?init = hash ?init params
-  
+
   (* input is an array of field elements encoded as hexstrings *)
   let hash_field_elems (field_elems : string list) : string =
     let input : Field.t array =
-      if List.length field_elems = 0 then [||] else
-      Array.of_list @@ List.map field_elems ~f:Field.of_hex
+      if List.length field_elems = 0 then [||]
+      else Array.of_list @@ List.map field_elems ~f:Field.of_hex
     in
     let digest = hash ~init:initial_state input in
     Field.to_hex digest

--- a/sponge/test_vectors/hash_function.ml
+++ b/sponge/test_vectors/hash_function.ml
@@ -1,0 +1,106 @@
+open Core_kernel
+
+(* *************** *
+ *    our field    *
+ * *************** *)
+
+module Field = struct
+  include Snarkette.Pasta.Fp
+
+  (* Converts a byterray into a [Field.t], raises an exception if the number obtained is larger than the order *)
+  let of_bytes (bytearray: string) : t =
+    let aux i acc c =
+      let big = Nat.of_int @@ int_of_char c in
+      let offset = Nat.shift_left big (Int.( * ) i 8) in
+      Nat.(acc + offset)
+    in
+    let zero = Nat.of_int 0 in
+    let big = String.foldi bytearray ~init:zero ~f:aux in
+    let one = Nat.of_int 1 in
+    if Nat.(order - one < big) then
+      failwith "the given field is larger than the order" ;
+    of_bigint big
+
+  (* Converts an hexadecimal string into a [Field.t], raises an exception if the number obtained is larger than the order *)
+  let of_hex (hexstring: string) : t =
+    let bytearray : string = Hex.decode hexstring |> Bytes.to_string in
+    of_bytes bytearray
+
+  (* Converts a field element into a bytearray (encoding the field element in little-endian) *)
+  let to_bytes (field: t) : bytes =
+    (* taken from src/lib/pickles *)
+    let bits_to_bytes bits =
+      let byte_of_bits bs =
+        List.foldi bs ~init:0 ~f:(fun i acc b ->
+            if b then acc lor (1 lsl i) else acc )
+        |> Char.of_int_exn
+      in
+      List.map
+        (List.groupi bits ~break:(fun i _ _ -> i mod 8 = 0))
+        ~f:byte_of_bits
+      |> Bytes.of_char_list
+    in
+    let bytearray = to_bits field |> bits_to_bytes in
+    bytearray
+
+  (* Converts a field element into an hexadecimal string (encoding the field element in little-endian) *)
+  let to_hex (field: t) : string =
+    let bytearray : bytes = to_bytes field in
+    Hex.encode bytearray
+end
+
+(* ********************** *
+ * our permutation Config *
+ * ********************** *)
+
+module Config = struct
+  module Field = Field
+
+  let rounds_full = 63
+
+  let initial_ark = true
+
+  let rounds_partial = 0
+
+  let to_the_alpha x =
+    let open Field in
+    let x_2 = x * x in
+    let x_4 = x_2 * x_2 in
+    let x_5 = x_4 * x in
+    x_5
+
+  module Operations = struct
+    let add_assign ~state i x = Field.(state.(i) <- state.(i) + x)
+
+    let apply_affine_map (matrix, constants) v =
+      let dotv row =
+        Array.reduce_exn (Array.map2_exn row v ~f:Field.( * )) ~f:Field.( + )
+      in
+      let res = Array.map matrix ~f:dotv in
+      Array.map2_exn res constants ~f:Field.( + )
+
+    let copy a = Array.map a ~f:Fn.id
+  end
+end
+
+(* ***************** *
+ *   hash function   *
+ * ***************** *)
+
+module Hash = struct
+  include Sponge.Make_hash (Sponge.Poseidon (Config))
+
+  let params : Field.t Sponge.Params.t =
+    Sponge.Params.(map pasta_p ~f:Field.of_string)
+
+  let hash ?init = hash ?init params
+  
+  (* input is an array of field elements encoded as hexstrings *)
+  let hash_field_elems (field_elems : string list) : string =
+    let input : Field.t array =
+      if List.length field_elems = 0 then [||] else
+      Array.of_list @@ List.map field_elems ~f:Field.of_hex
+    in
+    let digest = hash ~init:initial_state input in
+    Field.to_hex digest
+end

--- a/sponge/test_vectors/hex.ml
+++ b/sponge/test_vectors/hex.ml
@@ -3,45 +3,61 @@ let encode (bytearray : bytes) : string =
   let start_of_digit_0_in_ascii_table = 0x30 in
   let start_of_lower_case_a_in_ascii_table = 0x61 in
   let hex_digit_of_int (x : int) : char =
-    assert (x >= 0);
-    assert (x < 16);
+    assert (x >= 0) ;
+    assert (x < 16) ;
     char_of_int
-      (if x < 10 then x + start_of_digit_0_in_ascii_table
-      else x - 10 + start_of_lower_case_a_in_ascii_table)
+      ( if x < 10 then x + start_of_digit_0_in_ascii_table
+      else x - 10 + start_of_lower_case_a_in_ascii_table )
   in
   let rec aux bytearray len cur_pos buf =
     if cur_pos < len then (
       let x = int_of_char @@ Bytes.get bytearray cur_pos in
       let c1 = hex_digit_of_int (x lsr 4) in
       let c2 = hex_digit_of_int (x land 0x0F) in
-      Bytes.set buf (cur_pos * 2) c1;
-      Bytes.set buf ((cur_pos * 2) + 1) c2;
-      aux bytearray len (succ cur_pos) buf)
+      Bytes.set buf (cur_pos * 2) c1 ;
+      Bytes.set buf ((cur_pos * 2) + 1) c2 ;
+      aux bytearray len (succ cur_pos) buf )
   in
   let len = Bytes.length bytearray in
   let buf_len = 2 * len in
   let buf = Bytes.make buf_len dummy_char in
-  aux bytearray len 0 buf;
-  Bytes.to_string buf
+  aux bytearray len 0 buf ; Bytes.to_string buf
 
 let decode_1char = function
-  | '0' -> 0
-  | '1' -> 1
-  | '2' -> 2
-  | '3' -> 3
-  | '4' -> 4
-  | '5' -> 5
-  | '6' -> 6
-  | '7' -> 7
-  | '8' -> 8
-  | '9' -> 9
-  | 'a' -> 10
-  | 'b' -> 11
-  | 'c' -> 12
-  | 'd' -> 13
-  | 'e' -> 14
-  | 'f' -> 15
-  | _ -> failwith "invalid character"
+  | '0' ->
+      0
+  | '1' ->
+      1
+  | '2' ->
+      2
+  | '3' ->
+      3
+  | '4' ->
+      4
+  | '5' ->
+      5
+  | '6' ->
+      6
+  | '7' ->
+      7
+  | '8' ->
+      8
+  | '9' ->
+      9
+  | 'a' ->
+      10
+  | 'b' ->
+      11
+  | 'c' ->
+      12
+  | 'd' ->
+      13
+  | 'e' ->
+      14
+  | 'f' ->
+      15
+  | _ ->
+      failwith "invalid character"
 
 let decode_2chars c1 c2 : char =
   let fst = decode_1char c1 in
@@ -56,8 +72,8 @@ let decode hexstring =
       let c1 = ss.[pos] in
       let c2 = ss.[pos + 1] in
       let b = decode_2chars c1 c2 in
-      Bytes.set res res_cur_pos b;
-      aux (succ res_cur_pos) res_len ss res)
+      Bytes.set res res_cur_pos b ;
+      aux (succ res_cur_pos) res_len ss res )
     else res
   in
   let len = String.length hexstring in
@@ -67,4 +83,3 @@ let decode hexstring =
     let buf_len = len / 2 in
     let buf = Bytes.make buf_len '\x00' in
     aux 0 buf_len hexstring buf
-      

--- a/sponge/test_vectors/hex.ml
+++ b/sponge/test_vectors/hex.ml
@@ -1,0 +1,70 @@
+let encode (bytearray : bytes) : string =
+  let dummy_char = '_' in
+  let start_of_digit_0_in_ascii_table = 0x30 in
+  let start_of_lower_case_a_in_ascii_table = 0x61 in
+  let hex_digit_of_int (x : int) : char =
+    assert (x >= 0);
+    assert (x < 16);
+    char_of_int
+      (if x < 10 then x + start_of_digit_0_in_ascii_table
+      else x - 10 + start_of_lower_case_a_in_ascii_table)
+  in
+  let rec aux bytearray len cur_pos buf =
+    if cur_pos < len then (
+      let x = int_of_char @@ Bytes.get bytearray cur_pos in
+      let c1 = hex_digit_of_int (x lsr 4) in
+      let c2 = hex_digit_of_int (x land 0x0F) in
+      Bytes.set buf (cur_pos * 2) c1;
+      Bytes.set buf ((cur_pos * 2) + 1) c2;
+      aux bytearray len (succ cur_pos) buf)
+  in
+  let len = Bytes.length bytearray in
+  let buf_len = 2 * len in
+  let buf = Bytes.make buf_len dummy_char in
+  aux bytearray len 0 buf;
+  Bytes.to_string buf
+
+let decode_1char = function
+  | '0' -> 0
+  | '1' -> 1
+  | '2' -> 2
+  | '3' -> 3
+  | '4' -> 4
+  | '5' -> 5
+  | '6' -> 6
+  | '7' -> 7
+  | '8' -> 8
+  | '9' -> 9
+  | 'a' -> 10
+  | 'b' -> 11
+  | 'c' -> 12
+  | 'd' -> 13
+  | 'e' -> 14
+  | 'f' -> 15
+  | _ -> failwith "invalid character"
+
+let decode_2chars c1 c2 : char =
+  let fst = decode_1char c1 in
+  let snd = decode_1char c2 in
+  let res = (fst lsl 4) lxor snd in
+  char_of_int res
+
+let decode hexstring =
+  let rec aux res_cur_pos res_len ss res : bytes =
+    if res_cur_pos < res_len then (
+      let pos = 2 * res_cur_pos in
+      let c1 = ss.[pos] in
+      let c2 = ss.[pos + 1] in
+      let b = decode_2chars c1 c2 in
+      Bytes.set res res_cur_pos b;
+      aux (succ res_cur_pos) res_len ss res)
+    else res
+  in
+  let len = String.length hexstring in
+  if len mod 2 <> 0 then failwith "wrong hexstring length"
+  else if len = 0 then Bytes.empty
+  else
+    let buf_len = len / 2 in
+    let buf = Bytes.make buf_len '\x00' in
+    aux 0 buf_len hexstring buf
+      

--- a/sponge/test_vectors/main.ml
+++ b/sponge/test_vectors/main.ml
@@ -25,7 +25,7 @@ let parse_test_vectors filepath =
 
 (* three_wire test vectors *)
 let () = 
-  let cur_dir = Sys.argv.(0) |> Filename.dirname in 
+  let cur_dir = Sys.getcwd () in 
   let test_vector_file = Filename.concat cur_dir "three_wire.json" in
   let test_vectors = parse_test_vectors test_vector_file in 
   assert (test_vectors.name = "three_wire");
@@ -37,7 +37,7 @@ let () =
 
 (* fp_3 test vectors *)
 let () = 
-  let cur_dir = Sys.argv.(0) |> Filename.dirname in 
+let cur_dir = Sys.getcwd () in 
   let test_vector_file = Filename.concat cur_dir "fp_3.json" in
   let test_vectors = parse_test_vectors test_vector_file in 
   assert (test_vectors.name = "fp_3");

--- a/sponge/test_vectors/main.ml
+++ b/sponge/test_vectors/main.ml
@@ -1,0 +1,35 @@
+open Core_kernel
+
+type test_vector = {
+  input: string list;
+  output: string;
+}
+
+type test_vectors = {
+  name: string;
+  test_vectors: test_vector list;
+}
+
+let parse_test_vectors filepath =
+  let json = Yojson.Basic.from_file filepath in
+  let open Yojson.Basic.Util in
+  let name = json |> member "name" |> to_string in 
+  let test_vectors = json |> member "test_vectors" |> to_list in
+  let json_to_test_vector test_vector = 
+    let input = test_vector |> member "input" |> to_list |> filter_string in
+    let output = test_vector |> member "output" |> to_string in
+    {input; output}
+  in
+  let test_vectors = List.map test_vectors ~f:json_to_test_vector in
+  {name; test_vectors}
+
+let () = 
+  let cur_dir = Sys.argv.(0) |> Filename.dirname in 
+  let test_vector_file = Filename.concat cur_dir "three_wire.json" in
+  let test_vectors = parse_test_vectors test_vector_file in 
+  assert (test_vectors.name = "three_wire");
+  let check_test_vector test_vector = 
+    let digest = Hash_function.Hash.hash_field_elems test_vector.input in 
+    assert (digest = test_vector.output)
+  in
+  List.iter test_vectors.test_vectors ~f:check_test_vector

--- a/sponge/test_vectors/main.ml
+++ b/sponge/test_vectors/main.ml
@@ -1,21 +1,15 @@
 open Core_kernel
 
-type test_vector = {
-  input: string list;
-  output: string;
-}
+type test_vector = {input: string list; output: string}
 
-type test_vectors = {
-  name: string;
-  test_vectors: test_vector list;
-}
+type test_vectors = {name: string; test_vectors: test_vector list}
 
 let parse_test_vectors filepath =
   let json = Yojson.Basic.from_file filepath in
   let open Yojson.Basic.Util in
-  let name = json |> member "name" |> to_string in 
+  let name = json |> member "name" |> to_string in
   let test_vectors = json |> member "test_vectors" |> to_list in
-  let json_to_test_vector test_vector = 
+  let json_to_test_vector test_vector =
     let input = test_vector |> member "input" |> to_list |> filter_string in
     let output = test_vector |> member "output" |> to_string in
     {input; output}
@@ -24,25 +18,25 @@ let parse_test_vectors filepath =
   {name; test_vectors}
 
 (* three_wire test vectors *)
-let () = 
-  let cur_dir = Sys.getcwd () in 
+let () =
+  let cur_dir = Sys.getcwd () in
   let test_vector_file = Filename.concat cur_dir "three_wire.json" in
-  let test_vectors = parse_test_vectors test_vector_file in 
-  assert (test_vectors.name = "three_wire");
-  let check_test_vector test_vector = 
-    let digest = Hash_function.ThreeWire.hash_field_elems test_vector.input in 
+  let test_vectors = parse_test_vectors test_vector_file in
+  assert (test_vectors.name = "three_wire") ;
+  let check_test_vector test_vector =
+    let digest = Hash_function.ThreeWire.hash_field_elems test_vector.input in
     assert (digest = test_vector.output)
   in
   List.iter test_vectors.test_vectors ~f:check_test_vector
 
 (* fp_3 test vectors *)
-let () = 
-let cur_dir = Sys.getcwd () in 
+let () =
+  let cur_dir = Sys.getcwd () in
   let test_vector_file = Filename.concat cur_dir "fp_3.json" in
-  let test_vectors = parse_test_vectors test_vector_file in 
-  assert (test_vectors.name = "fp_3");
-  let check_test_vector test_vector = 
-    let digest = Hash_function.Fp3.hash_field_elems test_vector.input in 
+  let test_vectors = parse_test_vectors test_vector_file in
+  assert (test_vectors.name = "fp_3") ;
+  let check_test_vector test_vector =
+    let digest = Hash_function.Fp3.hash_field_elems test_vector.input in
     assert (digest = test_vector.output)
   in
   List.iter test_vectors.test_vectors ~f:check_test_vector

--- a/sponge/test_vectors/main.ml
+++ b/sponge/test_vectors/main.ml
@@ -23,13 +23,26 @@ let parse_test_vectors filepath =
   let test_vectors = List.map test_vectors ~f:json_to_test_vector in
   {name; test_vectors}
 
+(* three_wire test vectors *)
 let () = 
   let cur_dir = Sys.argv.(0) |> Filename.dirname in 
   let test_vector_file = Filename.concat cur_dir "three_wire.json" in
   let test_vectors = parse_test_vectors test_vector_file in 
   assert (test_vectors.name = "three_wire");
   let check_test_vector test_vector = 
-    let digest = Hash_function.Hash.hash_field_elems test_vector.input in 
+    let digest = Hash_function.ThreeWire.hash_field_elems test_vector.input in 
+    assert (digest = test_vector.output)
+  in
+  List.iter test_vectors.test_vectors ~f:check_test_vector
+
+(* fp_3 test vectors *)
+let () = 
+  let cur_dir = Sys.argv.(0) |> Filename.dirname in 
+  let test_vector_file = Filename.concat cur_dir "fp_3.json" in
+  let test_vectors = parse_test_vectors test_vector_file in 
+  assert (test_vectors.name = "fp_3");
+  let check_test_vector test_vector = 
+    let digest = Hash_function.Fp3.hash_field_elems test_vector.input in 
     assert (digest = test_vector.output)
   in
   List.iter test_vectors.test_vectors ~f:check_test_vector

--- a/sponge/test_vectors/three_wire.json
+++ b/sponge/test_vectors/three_wire.json
@@ -1,0 +1,49 @@
+{
+    "name": "three_wire",
+    "test_vectors": [
+        {
+            "input": [],
+            "output": "1b3251b6912d82edc78bbb0a5c88f0c6fde1781bc3e654123fa6862a4c63e617"
+        },
+        {
+            "input": [
+                "df698e389c6f1987ffe186d806f8163738f5bf22e8be02572cce99dc6a4ab030"
+            ],
+            "output": "f9b1b6c5f8c98017c6b35ac74bc689b6533d6dbbee1fd868831b637a43ea720c"
+        },
+        {
+            "input": [
+                "56b648a5a85619814900a6b40375676803fe16fb1ad2d1fb79115eb1b52ac026",
+                "f26a8a03d9c9bbd9c6b2a1324d2a3f4d894bafe25a7e4ad1a498705f4026ff2f"
+            ],
+            "output": "7a556e93bcfbd27b55867f533cd1df293a7def60dd929a086fdd4e70393b0918"
+        },
+        {
+            "input": [
+                "075c41fa23e4690694df5ded43624fd60ab7ee6ec6dd48f44dc71bc206cecb26",
+                "a4e2beebb09bd02ad42bbccc11051e8262b6ef50445d8382b253e91ab1557a0d",
+                "7dfc23a1242d9c0d6eb16e924cfba342bb2fccf36b8cbaf296851f2e6c469639"
+            ],
+            "output": "f94b39a919aab06f43f4a4b5a3e965b719a4dbd2b9cd26d2bba4197b10286b35"
+        },
+        {
+            "input": [
+                "a1a659b14e80d47318c6fcdbbd388de4272d5c2815eb458cf4f196d52403b639",
+                "5e33065d1801131b64d13038ff9693a7ef6283f24ec8c19438d112ff59d50f04",
+                "38a8f4d0a9b6d0facdc4e825f6a2ba2b85401d5de119bf9f2bcb908235683e06",
+                "3456d0313a30d7ccb23bd71ed6aa70ab234dad683d8187b677aef73f42f4f52e"
+            ],
+            "output": "cc1ccfa964fd6ef9ff1994beb53cfce9ebe1212847ce30e4c64f0777875aec34"
+        },
+        {
+            "input": [
+                "bccfee48dc76bb991c97bd531cf489f4ee37a66a15f5cfac31bdd4f159d4a905",
+                "2d106fb21a262f85fd400a995c6d74bad48d8adab2554046871c215e585b072b",
+                "8300e93ee8587956534d0756bb2aa575e5878c670cff5c8e3e55c62632333c06",
+                "879c32da31566f6d16afdefff94cba5260fec1057e97f19fc9a61dc2c54a6417",
+                "9c0aa6e5501cfb2d08aeaea5b3cddac2c9bee85d13324118b44bafb63a59611e"
+            ],
+            "output": "cf7b9c2128f0e2c0fed4e1eca8d5954b629640c2458d24ba238c1bd3ccbc8e12"
+        }
+    ]
+}


### PR DESCRIPTION
## What's wrong?

I introduced an off-by-one error here: https://github.com/o1-labs/snarky/pull/585/commits/120fcdae5b697a46b481bd84d435b825dcc4e699#diff-6ece204f52dc5d5f99d41c96cb239b21e8968325f0e6e937aa1eea2be1b1dc57L187

Interestingly, I was thinking about that change these days and the fact that without test vectors I had potentially introduced a bug. Well, looks like I did it. 

## What's in this PR?

So this PR fixes the bug and introduces test vectors (generated by this PR in the marlin repo: https://github.com/o1-labs/marlin/pull/103)

## Does it work?

Yeah, you can run `dune runtest` to run these.

## Potential issues with this PR:

- we're copy/pasting code from the hexstring lib: https://github.com/mimoo/hexstring because hexstring is not compatible with 4.07.1. As we move to a higher version of OCaml I should be able to remove this (cc @psteckler )
- we're also copy/pasting code from Mina's [random_oracle](https://github.com/MinaProtocol/mina/blob/develop/src/lib/random_oracle/random_oracle.ml) as well as the [poseidon.js](https://github.com/MinaProtocol/mina/pull/8913/). I think there's an argument somewhere that the hash part of that code could live here as we're already defining a field and the params in this repo. At the same time, if I understand correctly, we have an OCaml implementation of the field here VS a Rust implementation on the mina repo. Since the latter is more efficient it doesn't make sense to move the code here atm.

