### PR TITLE
Revert "Use monomorphic comparison for tests"

### DIFF
--- a/sponge/intf.ml
+++ b/sponge/intf.ml
@@ -1,5 +1,5 @@
 module type Field = sig
-  type t [@@deriving sexp, equal, compare]
+  type t
 
   val zero : t
 
@@ -38,7 +38,7 @@ end
 module Inputs = struct
   module type Common = sig
     module Field : sig
-      type t [@@deriving sexp, equal, compare]
+      type t
 
       val zero : t
     end
@@ -69,7 +69,7 @@ end
 
 module type Permutation = sig
   module Field : sig
-    type t [@@deriving sexp, equal, compare]
+    type t
 
     val zero : t
   end

--- a/sponge/sponge.ml
+++ b/sponge/sponge.ml
@@ -225,8 +225,9 @@ module Make_hash (P : Intf.Permutation) = struct
   let%test_unit "empty field_elems to_blocks" =
     let blocks = to_blocks 2 [||] in
     assert (Array.length blocks = 1) ;
-    [%test_eq: Field.t] blocks.(0).(0) Field.zero ;
-    [%test_eq: Field.t] blocks.(0).(1) Field.zero
+    [%test_eq: unit array array]
+      (Array.map blocks ~f:(Array.map ~f:ignore))
+      [|[|(); ()|]|]
 
   let%test_unit "block" =
     let z = Field.zero in


### PR DESCRIPTION
This reverts commit 9dddcca58c02835109d0341f08cf1157c22cd427.

After discussion with @imeckler it looks like this won't work with some of the more abstract circuit fields.