### PR TITLE
String equality for test vector names

### DIFF
--- a/sponge/test_vectors/main.ml
+++ b/sponge/test_vectors/main.ml
@@ -22,7 +22,7 @@ let () =
   let cur_dir = Sys.getcwd () in
   let test_vector_file = Filename.concat cur_dir "three_wire.json" in
   let test_vectors = parse_test_vectors test_vector_file in
-  assert (test_vectors.name = "three_wire") ;
+  assert (String.equal test_vectors.name "three_wire") ;
   let check_test_vector test_vector =
     let digest = Hash_function.ThreeWire.hash_field_elems test_vector.input in
     assert (digest = test_vector.output)
@@ -34,7 +34,7 @@ let () =
   let cur_dir = Sys.getcwd () in
   let test_vector_file = Filename.concat cur_dir "fp_3.json" in
   let test_vectors = parse_test_vectors test_vector_file in
-  assert (test_vectors.name = "fp_3") ;
+  assert (String.equal test_vectors.name "fp_3") ;
   let check_test_vector test_vector =
     let digest = Hash_function.Fp3.hash_field_elems test_vector.input in
     assert (digest = test_vector.output)


### PR DESCRIPTION
Use string equality instead of polymorphic equality to compare test vector names, to allow compilation with recent Jane Street libraries.