### PR TITLE
More string equality instead of poly equality

### DIFF
--- a/sponge/test_vectors/main.ml
+++ b/sponge/test_vectors/main.ml
@@ -25,7 +25,7 @@ let () =
   assert (String.equal test_vectors.name "three_wire") ;
   let check_test_vector test_vector =
     let digest = Hash_function.ThreeWire.hash_field_elems test_vector.input in
-    assert (digest = test_vector.output)
+    assert (String.equal digest test_vector.output)
   in
   List.iter test_vectors.test_vectors ~f:check_test_vector
 
@@ -37,6 +37,6 @@ let () =
   assert (String.equal test_vectors.name "fp_3") ;
   let check_test_vector test_vector =
     let digest = Hash_function.Fp3.hash_field_elems test_vector.input in
-    assert (digest = test_vector.output)
+    assert (String.equal digest test_vector.output)
   in
   List.iter test_vectors.test_vectors ~f:check_test_vector


### PR DESCRIPTION
More replacements of polymorphic equality with string equality.

Verified that unit tests for `snarky` fully run with OCaml 4.11.2 with these changes (which, regrettably, I didn't do with #591).
