### PR TITLE
Add support for public outputs

### DIFF
--- a/src/base/snark_intf.ml
+++ b/src/base/snark_intf.ml
@@ -841,13 +841,15 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
     val generate_witness :
          run:('a, 't) t
       -> ('t, Proof_inputs.t, 'k_var, 'k_value) Data_spec.t
+      -> return_typ:('a, _) Typ.t
       -> 'k_var
       -> 'k_value
 
     val generate_witness_conv :
          run:('a, 't) t
-      -> f:(Proof_inputs.t -> 'out)
+      -> f:(Proof_inputs.t -> 'public_output -> 'out)
       -> ('t, 'out, 'k_var, 'k_value) Data_spec.t
+      -> return_typ:('a, 'public_output) Typ.t
       -> 'k_var
       -> 'k_value
 
@@ -997,6 +999,7 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
   val conv :
        ('r_var -> 'r_value)
     -> ('r_var, 'r_value, 'k_var, 'k_value) Data_spec.t
+    -> _ Typ.t
     -> 'k_var
     -> 'k_value
 
@@ -1026,7 +1029,8 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
       corresponding to the given public input and generated auxiliary input.
   *)
   val generate_witness :
-       (unit Checked.t, Proof_inputs.t, 'k_var, 'k_value) Data_spec.t
+       ('r_var Checked.t, Proof_inputs.t, 'k_var, 'k_value) Data_spec.t
+    -> return_typ:('r_var, _) Typ.t
     -> 'k_var
     -> 'k_value
 
@@ -1038,8 +1042,9 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
       input and generated auxiliary input.
   *)
   val generate_witness_conv :
-       f:(Proof_inputs.t -> 'out)
-    -> (unit Checked.t, 'out, 'k_var, 'k_value) Data_spec.t
+       f:(Proof_inputs.t -> 'r_value -> 'out)
+    -> ('r_var Checked.t, 'out, 'k_var, 'k_value) Data_spec.t
+    -> return_typ:('r_var, 'r_value) Typ.t
     -> 'k_var
     -> 'k_value
 
@@ -1060,7 +1065,10 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
       Returns [unit]; this is for testing only.
   *)
   val generate_auxiliary_input :
-    ('a Checked.t, unit, 'k_var, 'k_value) Data_spec.t -> 'k_var -> 'k_value
+       ('a Checked.t, unit, 'k_var, 'k_value) Data_spec.t
+    -> return_typ:('a, _) Typ.t
+    -> 'k_var
+    -> 'k_value
 
   (** Returns the number of constraints in the constraint system.
 
@@ -1686,6 +1694,7 @@ module type Run_basic = sig
 
   val generate_witness :
        (unit -> 'a, Proof_inputs.t, 'k_var, 'k_value) Data_spec.t
+    -> return_typ:('a, _) Typ.t
     -> 'k_var
     -> 'k_value
 
@@ -1694,8 +1703,9 @@ module type Run_basic = sig
     (_, Field.Constant.Vector.t, _, 'k_value) Data_spec.t -> 'k_value
 
   val generate_witness_conv :
-       f:(Proof_inputs.t -> 'out)
-    -> (unit -> 'a, 'out, 'k_var, 'k_value) Data_spec.t
+       f:(Proof_inputs.t -> 'r_value -> 'out)
+    -> (unit -> 'r_var, 'out, 'k_var, 'k_value) Data_spec.t
+    -> return_typ:('r_var, 'r_value) Typ.t
     -> 'k_var
     -> 'k_value
 

--- a/src/base/snark_intf.ml
+++ b/src/base/snark_intf.ml
@@ -834,6 +834,7 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
     val constraint_system :
          run:('a, 't) t
       -> exposing:('t, _, 'k_var, _) Data_spec.t
+      -> return_typ:('a, _) Typ.t
       -> 'k_var
       -> R1CS_constraint_system.t
 
@@ -985,7 +986,8 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
 
   (** Generate the R1CS for the checked computation. *)
   val constraint_system :
-       exposing:(unit Checked.t, _, 'k_var, _) Data_spec.t
+       exposing:('a Checked.t, _, 'k_var, _) Data_spec.t
+    -> return_typ:('a, _) Typ.t
     -> 'k_var
     -> R1CS_constraint_system.t
 
@@ -1678,6 +1680,7 @@ module type Run_basic = sig
 
   val constraint_system :
        exposing:(unit -> 'a, _, 'k_var, _) Data_spec.t
+    -> return_typ:('a, _) Typ.t
     -> 'k_var
     -> R1CS_constraint_system.t
 


### PR DESCRIPTION
This PR adds support for 'public outputs' from circuits, allowing circuits to return a value that will be exposed as part of the public input to the proof, and exposing that returned value to the caller.

This enables the more natural modelling of circuits as functions that take and return some data, and enable us to remove duplicate code where we construct the 'input' both inside and outside of the circuit. Importantly, this will allow SnarkyJS circuits to return the constructed `Parties.t` without needing to run the logic twice.