### PR TITLE
Remove `Data_spec.t`

### DIFF
--- a/src/base/snark0.ml
+++ b/src/base/snark0.ml
@@ -289,29 +289,18 @@ struct
       r1cs_h ~run (ref 1) ~input_typ ~return_typ k
 
     let generate_public_input :
-           ( 'r_var
-           , Field.Vector.t
-           , 'input_var -> 'r_var
-           , 'input_value -> Field.Vector.t )
-           Data_spec.t
+           ('input_var, 'input_value, _, _) Types.Typ.typ
         -> 'input_value
         -> Field.Vector.t =
      fun t0 ->
       let primary_input = Field.Vector.create () in
       let next_input = ref 1 in
       let store_field_elt = store_field_elt primary_input next_input in
-      let go :
-          type r_var k_var k_value.
-          (r_var, Field.Vector.t, k_var, k_value) Data_spec.t -> k_value =
-       fun t ->
-        match t with
-        | Data_spec (Typ { value_to_fields; _ }) ->
-            fun value ->
-              let fields, _aux = value_to_fields value in
-              let _fields = Array.map ~f:store_field_elt fields in
-              primary_input
-      in
-      go t0
+      let (Typ { value_to_fields; _ }) = t0 in
+      fun value ->
+        let fields, _aux = value_to_fields value in
+        let _fields = Array.map ~f:store_field_elt fields in
+        primary_input
 
     let conv :
         type r_var r_value.

--- a/src/base/snark0.ml
+++ b/src/base/snark0.ml
@@ -55,6 +55,32 @@ struct
 
   module Runner = Runner
 
+  module Data_spec = struct
+    include Typ.Data_spec0
+
+    type ('r_var, 'r_value, 'k_var, 'k_value) t =
+      ( 'r_var
+      , 'r_value
+      , 'k_var
+      , 'k_value
+      , field
+      , (unit, field) Checked.Types.Checked.t )
+      data_spec
+
+    let size t =
+      let rec go :
+          type r_var r_value k_var k_value.
+          int -> (r_var, r_value, k_var, k_value) t -> int =
+       fun acc t ->
+        match t with
+        | [] ->
+            acc
+        | Typ { size_in_field_elements; _ } :: t' ->
+            go (acc + size_in_field_elements) t'
+      in
+      go 0 t
+  end
+
   (* TODO-someday: Add pass to unify variables which have an Equal constraint *)
   let constraint_system ~run ~num_inputs ~return_typ:(Types.Typ.Typ return_typ)
       output t : R1CS_constraint_system.t =
@@ -460,31 +486,7 @@ struct
 
     type ('var, 'value) t = ('var, 'value, Field.t) T.t
 
-    module Data_spec = struct
-      include Typ.Data_spec0
-
-      type ('r_var, 'r_value, 'k_var, 'k_value) t =
-        ( 'r_var
-        , 'r_value
-        , 'k_var
-        , 'k_value
-        , field
-        , (unit, field) Checked_S.t )
-        data_spec
-
-      let size t =
-        let rec go :
-            type r_var r_value k_var k_value.
-            int -> (r_var, r_value, k_var, k_value) t -> int =
-         fun acc t ->
-          match t with
-          | [] ->
-              acc
-          | Typ { size_in_field_elements; _ } :: t' ->
-              go (acc + size_in_field_elements) t'
-        in
-        go 0 t
-    end
+    module Data_spec = Data_spec
 
     let unit : (unit, unit) t = unit ()
 

--- a/src/base/snark0.ml
+++ b/src/base/snark0.ml
@@ -198,11 +198,11 @@ struct
       v
 
     let collect_input_constraints :
-        type checked r2 k1 k2.
+        type checked r2 input_var input_value.
            int ref
-        -> (checked, r2, k1, k2) Data_spec.t
+        -> (checked, r2, input_var -> checked, input_value -> r2) Data_spec.t
         -> return_typ:_ Typ.t
-        -> (unit -> k1)
+        -> (unit -> input_var -> checked)
         -> _ * (unit -> checked) Checked.t =
      fun next_input t ~return_typ k ->
       let open Checked in
@@ -250,12 +250,12 @@ struct
           (retval, checked)
 
     let r1cs_h :
-        type a checked r2 k1 k2 retval.
+        type a checked r2 input_var input_value retval.
            run:(a, checked) Runner.run
         -> int ref
-        -> (checked, r2, k1, k2) Data_spec.t
+        -> (checked, r2, input_var -> checked, input_value -> r2) Data_spec.t
         -> return_typ:(a, retval, _) Typ.t
-        -> k1
+        -> (input_var -> checked)
         -> R1CS_constraint_system.t =
      fun ~run next_input t ~return_typ k ->
       let retval, r =
@@ -269,11 +269,11 @@ struct
         ~return_typ retval
         (Checked.map ~f:(fun r -> r ()) r)
 
-    let constraint_system (type a checked k_var) :
+    let constraint_system (type a checked input_var) :
            run:(a, checked) Runner.run
-        -> exposing:(checked, _, k_var, _) Data_spec.t
+        -> exposing:(checked, _, input_var -> checked, _) Data_spec.t
         -> return_typ:_
-        -> k_var
+        -> (input_var -> checked)
         -> R1CS_constraint_system.t =
      fun ~run ~exposing ~return_typ k ->
       r1cs_h ~run (ref 1) exposing ~return_typ k

--- a/src/base/snark0.ml
+++ b/src/base/snark0.ml
@@ -466,7 +466,18 @@ struct
       type ('r_var, 'r_value, 'k_var, 'k_value) t =
         ('r_var, 'r_value, 'k_var, 'k_value, field) T.Data_spec.t
 
-      let size t = T.Data_spec.size t
+      let size t =
+        let rec go :
+            type r_var r_value k_var k_value.
+            int -> (r_var, r_value, k_var, k_value) t -> int =
+         fun acc t ->
+          match t with
+          | [] ->
+              acc
+          | Typ { size_in_field_elements; _ } :: t' ->
+              go (acc + size_in_field_elements) t'
+        in
+        go 0 t
     end
 
     let unit : (unit, unit) t = unit ()

--- a/src/base/snark0.ml
+++ b/src/base/snark0.ml
@@ -306,10 +306,15 @@ struct
     let conv :
         type r_var r_value.
            (int -> _ -> r_var -> Field.Vector.t -> r_value)
-        -> (r_var, r_value, 'k_var, 'k_value) Data_spec.t
+        -> ( r_var
+           , r_value
+           , 'input_var -> r_var
+           , 'input_value -> r_value )
+           Data_spec.t
         -> _ Typ.t
-        -> (unit -> 'k_var)
-        -> 'k_value =
+        -> (unit -> 'input_var -> r_var)
+        -> 'input_value
+        -> r_value =
      fun cont0 t0 (Typ return_typ) k0 ->
       let primary_input = Field.Vector.create () in
       let next_input = ref 1 in

--- a/src/base/snark0.ml
+++ b/src/base/snark0.ml
@@ -56,8 +56,6 @@ struct
   module Runner = Runner
 
   module Data_spec = struct
-    include Typ.Data_spec0
-
     type ('r_var, 'r_value, 'k_var, 'k_value) t =
       ( 'r_var
       , 'r_value
@@ -65,7 +63,7 @@ struct
       , 'k_value
       , field
       , (unit, field) Checked.Types.Checked.t )
-      data_spec
+      Typ.Data_spec0.data_spec
 
     let size t =
       let rec go :

--- a/src/base/snark0.ml
+++ b/src/base/snark0.ml
@@ -464,7 +464,13 @@ struct
       include Typ.Data_spec0
 
       type ('r_var, 'r_value, 'k_var, 'k_value) t =
-        ('r_var, 'r_value, 'k_var, 'k_value, field) T.Data_spec.t
+        ( 'r_var
+        , 'r_value
+        , 'k_var
+        , 'k_value
+        , field
+        , (unit, field) Checked_S.t )
+        data_spec
 
       let size t =
         let rec go :

--- a/src/base/snark0.ml
+++ b/src/base/snark0.ml
@@ -279,7 +279,13 @@ struct
       r1cs_h ~run (ref 1) exposing ~return_typ k
 
     let generate_public_input :
-        ('r_var, Field.Vector.t, 'k_var, 'k_value) Data_spec.t -> 'k_value =
+           ( 'r_var
+           , Field.Vector.t
+           , 'input_var -> 'r_var
+           , 'input_value -> Field.Vector.t )
+           Data_spec.t
+        -> 'input_value
+        -> Field.Vector.t =
      fun t0 ->
       let primary_input = Field.Vector.create () in
       let next_input = ref 1 in

--- a/src/base/snark0.ml
+++ b/src/base/snark0.ml
@@ -55,28 +55,6 @@ struct
 
   module Runner = Runner
 
-  module Data_spec = struct
-    type ('r_var, 'r_value, 'k_var, 'k_value) t =
-      | Data_spec :
-          ( 'var
-          , 'value
-          , field
-          , (unit, field) Checked.Types.Checked.t )
-          Types.Typ.typ
-          -> ('r_var, 'r_value, 'var -> 'r_var, 'value -> 'r_value) t
-
-    let size t =
-      let go :
-          type r_var r_value k_var k_value.
-          int -> (r_var, r_value, k_var, k_value) t -> int =
-       fun acc t ->
-        match t with
-        | Data_spec (Typ { size_in_field_elements; _ }) ->
-            acc + size_in_field_elements
-      in
-      go 0 t
-  end
-
   (* TODO-someday: Add pass to unify variables which have an Equal constraint *)
   let constraint_system ~run ~num_inputs ~return_typ:(Types.Typ.Typ return_typ)
       output t : R1CS_constraint_system.t =
@@ -465,8 +443,6 @@ struct
     include T.T
 
     type ('var, 'value) t = ('var, 'value, Field.t) T.t
-
-    module Data_spec = Data_spec
 
     let unit : (unit, unit) t = unit ()
 
@@ -990,8 +966,6 @@ struct
           let all = Boolean.Array.all
         end)
   end
-
-  module Data_spec = Typ.Data_spec
 
   module Cvar1 = struct
     include Cvar
@@ -1594,7 +1568,6 @@ module Run = struct
 
     module Bigint = Snark.Bigint
     module Constraint = Snark.Constraint
-    module Data_spec = Snark.Data_spec
 
     module Typ = struct
       open Snark.Typ

--- a/src/base/snark_intf.ml
+++ b/src/base/snark_intf.ml
@@ -1035,13 +1035,7 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
 
   (** Generate the public input vector for a given statement. *)
   val generate_public_input :
-       ( 'r_var
-       , Field.Vector.t
-       , 'input_var -> 'r_var
-       , 'input_value -> Field.Vector.t )
-       Data_spec.t
-    -> 'input_value
-    -> Field.Vector.t
+    ('input_var, 'input_value) Typ.t -> 'input_value -> Field.Vector.t
 
   (** Generate a witness (auxiliary input) for the given public input.
 
@@ -1481,13 +1475,7 @@ module type Run_basic = sig
 
   (** Generate the public input vector for a given statement. *)
   val generate_public_input :
-       ( 'r_var
-       , Field.Constant.Vector.t
-       , 'input_var -> 'r_var
-       , 'input_value -> Field.Constant.Vector.t )
-       Data_spec.t
-    -> 'input_value
-    -> Field.Constant.Vector.t
+    ('input_var, 'input_value) Typ.t -> 'input_value -> Field.Constant.Vector.t
 
   val generate_witness_conv :
        f:(Proof_inputs.t -> 'r_value -> 'out)

--- a/src/base/snark_intf.ml
+++ b/src/base/snark_intf.ml
@@ -1013,12 +1013,7 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
 
   (** Generate the R1CS for the checked computation. *)
   val constraint_system :
-       exposing:
-         ( 'a Checked.t
-         , 'res
-         , 'input_var -> 'a Checked.t
-         , 'input_value -> 'res )
-         Data_spec.t
+       input_typ:('input_var, 'input_value) Typ.t
     -> return_typ:('a, _) Typ.t
     -> ('input_var -> 'a Checked.t)
     -> R1CS_constraint_system.t
@@ -1468,12 +1463,7 @@ module type Run_basic = sig
   val make_checked : (unit -> 'a) -> ('a, field) Types.Checked.t
 
   val constraint_system :
-       exposing:
-         ( unit -> 'a
-         , 'res
-         , 'input_var -> unit -> 'a
-         , 'input_value -> 'res )
-         Data_spec.t
+       input_typ:('input_var, 'input_value) Typ.t
     -> return_typ:('a, _) Typ.t
     -> ('input_var -> unit -> 'a)
     -> R1CS_constraint_system.t

--- a/src/base/snark_intf.ml
+++ b/src/base/snark_intf.ml
@@ -597,39 +597,6 @@ module type Basic = sig
        and type field_var := Field.Var.t)
 
   (** The data specification for checked computations. *)
-  and Data_spec : sig
-    (** A list of {!type:Typ.t} values, describing the inputs to a checked
-        computation. The type [('r_var, 'r_value, 'k_var, 'k_value) t]
-        represents
-        - ['k_value] is the OCaml type of the computation
-        - ['r_value] is the OCaml type of the result
-        - ['k_var] is the type of the computation within the R1CS
-        - ['k_value] is the type of the result within the R1CS.
-
-        This functions the same as OCaml's default list type:
-{[
-  Data_spec.[typ1; typ2; typ3]
-
-  Data_spec.(typ1 :: typs)
-
-  let open Data_spec in
-  [typ1; typ2; typ3; typ4; typ5]
-
-  let open Data_spec in
-  typ1 :: typ2 :: typs
-
-]}
-        all function as you would expect.
-    *)
-    type ('r_var, 'r_value, 'k_var, 'k_value) t =
-      | Data_spec :
-          ('var, 'value, field, (unit, field) Types.Checked.t) Typ.typ
-          -> ('r_var, 'r_value, 'var -> 'r_var, 'value -> 'r_value) t
-
-    (** [size [typ1; ...; typn]] returns the number of {!type:Var.t} variables
-        allocated by allocating [typ1], followed by [typ2], etc. *)
-    val size : _ t -> int
-  end
 
   (** Mappings from OCaml types to R1CS variables and constraints. *)
   and Typ : sig
@@ -1184,41 +1151,6 @@ module type Run_basic = sig
     (Constraint_intf
       with type field := Field.Constant.t
        and type field_var := Field.t)
-
-  (** The data specification for checked computations. *)
-  and Data_spec : sig
-    (** A list of {!type:Typ.t} values, describing the inputs to a checked
-        computation. The type [('r_var, 'r_value, 'k_var, 'k_value) t]
-        represents
-        - ['k_value] is the OCaml type of the computation
-        - ['r_value] is the OCaml type of the result
-        - ['k_var] is the type of the computation within the R1CS
-        - ['k_value] is the type of the result within the R1CS.
-
-        This functions the same as OCaml's default list type:
-{[
-  Data_spec.[typ1; typ2; typ3]
-
-  Data_spec.(typ1 :: typs)
-
-  let open Data_spec in
-  [typ1; typ2; typ3; typ4; typ5]
-
-  let open Data_spec in
-  typ1 :: typ2 :: typs
-
-]}
-        all function as you would expect.
-    *)
-    type ('r_var, 'r_value, 'k_var, 'k_value) t =
-      | Data_spec :
-          ('var, 'value, field, (unit, field) Checked.t) Types.Typ.typ
-          -> ('r_var, 'r_value, 'var -> 'r_var, 'value -> 'r_value) t
-
-    (** [size [typ1; ...; typn]] returns the number of {!type:Var.t} variables
-        allocated by allocating [typ1], followed by [typ2], etc. *)
-    val size : (_, _, _, _) t -> int
-  end
 
   (** Mappings from OCaml types to R1CS variables and constraints. *)
   and Typ :

--- a/src/base/snark_intf.ml
+++ b/src/base/snark_intf.ml
@@ -1035,7 +1035,13 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
 
   (** Generate the public input vector for a given statement. *)
   val generate_public_input :
-    (_, Field.Vector.t, _, 'k_value) Data_spec.t -> 'k_value
+       ( 'r_var
+       , Field.Vector.t
+       , 'input_var -> 'r_var
+       , 'input_value -> Field.Vector.t )
+       Data_spec.t
+    -> 'input_value
+    -> Field.Vector.t
 
   (** Generate a witness (auxiliary input) for the given public input.
 
@@ -1460,7 +1466,13 @@ module type Run_basic = sig
 
   (** Generate the public input vector for a given statement. *)
   val generate_public_input :
-    (_, Field.Constant.Vector.t, _, 'k_value) Data_spec.t -> 'k_value
+       ( 'r_var
+       , Field.Constant.Vector.t
+       , 'input_var -> 'r_var
+       , 'input_value -> Field.Constant.Vector.t )
+       Data_spec.t
+    -> 'input_value
+    -> Field.Constant.Vector.t
 
   val generate_witness_conv :
        f:(Proof_inputs.t -> 'r_value -> 'out)

--- a/src/base/snark_intf.ml
+++ b/src/base/snark_intf.ml
@@ -627,8 +627,6 @@ module type Basic = sig
     (** [size [typ1; ...; typn]] returns the number of {!type:Var.t} variables
         allocated by allocating [typ1], followed by [typ2], etc. *)
     val size : _ t -> int
-
-    include module type of Typ0.Data_spec0
   end
 
   (** Mappings from OCaml types to R1CS variables and constraints. *)
@@ -1211,8 +1209,6 @@ module type Run_basic = sig
     (** [size [typ1; ...; typn]] returns the number of {!type:Var.t} variables
         allocated by allocating [typ1], followed by [typ2], etc. *)
     val size : (_, _, _, _) t -> int
-
-    include module type of Typ0.Data_spec0
   end
 
   (** Mappings from OCaml types to R1CS variables and constraints. *)

--- a/src/base/snark_intf.ml
+++ b/src/base/snark_intf.ml
@@ -622,11 +622,9 @@ module type Basic = sig
         all function as you would expect.
     *)
     type ('r_var, 'r_value, 'k_var, 'k_value) t =
-      | ( :: ) :
+      | Data_spec :
           ('var, 'value, field, (unit, field) Types.Checked.t) Typ.typ
-          * ('r_var, 'r_value, 'k_var, 'k_value) t
-          -> ('r_var, 'r_value, 'var -> 'k_var, 'value -> 'k_value) t
-      | [] : ('r_var, 'r_value, 'r_var, 'r_value) t
+          -> ('r_var, 'r_value, 'var -> 'r_var, 'value -> 'r_value) t
 
     (** [size [typ1; ...; typn]] returns the number of {!type:Var.t} variables
         allocated by allocating [typ1], followed by [typ2], etc. *)
@@ -1209,11 +1207,9 @@ module type Run_basic = sig
         all function as you would expect.
     *)
     type ('r_var, 'r_value, 'k_var, 'k_value) t =
-      | ( :: ) :
+      | Data_spec :
           ('var, 'value, field, (unit, field) Checked.t) Types.Typ.typ
-          * ('r_var, 'r_value, 'k_var, 'k_value) t
-          -> ('r_var, 'r_value, 'var -> 'k_var, 'value -> 'k_value) t
-      | [] : ('r_var, 'r_value, 'r_var, 'r_value) t
+          -> ('r_var, 'r_value, 'var -> 'r_var, 'value -> 'r_value) t
 
     (** [size [typ1; ...; typn]] returns the number of {!type:Var.t} variables
         allocated by allocating [typ1], followed by [typ2], etc. *)

--- a/src/base/snark_intf.ml
+++ b/src/base/snark_intf.ml
@@ -1023,11 +1023,7 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
   *)
   val conv :
        ('r_var -> 'r_value)
-    -> ( 'r_var
-       , 'r_value
-       , 'input_var -> 'r_var
-       , 'input_value -> 'r_value )
-       Data_spec.t
+    -> ('input_var, 'input_value) Typ.t
     -> _ Typ.t
     -> ('input_var -> 'r_var)
     -> 'input_value
@@ -1043,11 +1039,7 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
       corresponding to the given public input and generated auxiliary input.
   *)
   val generate_witness :
-       ( 'r_var Checked.t
-       , Proof_inputs.t
-       , 'input_var -> 'r_var Checked.t
-       , 'input_value -> Proof_inputs.t )
-       Data_spec.t
+       input_typ:('input_var, 'input_value) Typ.t
     -> return_typ:('r_var, _) Typ.t
     -> ('input_var -> 'r_var Checked.t)
     -> 'input_value
@@ -1062,11 +1054,7 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
   *)
   val generate_witness_conv :
        f:(Proof_inputs.t -> 'r_value -> 'out)
-    -> ( 'r_var Checked.t
-       , 'out
-       , 'input_var -> 'r_var Checked.t
-       , 'input_value -> 'out )
-       Data_spec.t
+    -> input_typ:('input_var, 'input_value) Typ.t
     -> return_typ:('r_var, 'r_value) Typ.t
     -> ('input_var -> 'r_var Checked.t)
     -> 'input_value
@@ -1089,11 +1077,7 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
       Returns [unit]; this is for testing only.
   *)
   val generate_auxiliary_input :
-       ( 'a Checked.t
-       , unit
-       , 'input_var -> 'a Checked.t
-       , 'input_value -> unit )
-       Data_spec.t
+       input_typ:('input_var, 'input_value) Typ.t
     -> return_typ:('a, _) Typ.t
     -> ('input_var -> 'a Checked.t)
     -> 'input_value
@@ -1463,11 +1447,7 @@ module type Run_basic = sig
     -> R1CS_constraint_system.t
 
   val generate_witness :
-       ( unit -> 'a
-       , Proof_inputs.t
-       , 'input_var -> unit -> 'a
-       , 'input_value -> Proof_inputs.t )
-       Data_spec.t
+       input_typ:('input_var, 'input_value) Typ.t
     -> return_typ:('a, _) Typ.t
     -> ('input_var -> unit -> 'a)
     -> 'input_value
@@ -1479,11 +1459,7 @@ module type Run_basic = sig
 
   val generate_witness_conv :
        f:(Proof_inputs.t -> 'r_value -> 'out)
-    -> ( unit -> 'r_var
-       , 'out
-       , 'input_var -> unit -> 'r_var
-       , 'input_value -> 'out )
-       Data_spec.t
+    -> input_typ:('input_var, 'input_value) Typ.t
     -> return_typ:('r_var, 'r_value) Typ.t
     -> ('input_var -> unit -> 'r_var)
     -> 'input_value

--- a/src/base/snark_intf.ml
+++ b/src/base/snark_intf.ml
@@ -1028,10 +1028,15 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
   *)
   val conv :
        ('r_var -> 'r_value)
-    -> ('r_var, 'r_value, 'k_var, 'k_value) Data_spec.t
+    -> ( 'r_var
+       , 'r_value
+       , 'input_var -> 'r_var
+       , 'input_value -> 'r_value )
+       Data_spec.t
     -> _ Typ.t
-    -> 'k_var
-    -> 'k_value
+    -> ('input_var -> 'r_var)
+    -> 'input_value
+    -> 'r_value
 
   (** Generate the public input vector for a given statement. *)
   val generate_public_input :
@@ -1049,10 +1054,15 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
       corresponding to the given public input and generated auxiliary input.
   *)
   val generate_witness :
-       ('r_var Checked.t, Proof_inputs.t, 'k_var, 'k_value) Data_spec.t
+       ( 'r_var Checked.t
+       , Proof_inputs.t
+       , 'input_var -> 'r_var Checked.t
+       , 'input_value -> Proof_inputs.t )
+       Data_spec.t
     -> return_typ:('r_var, _) Typ.t
-    -> 'k_var
-    -> 'k_value
+    -> ('input_var -> 'r_var Checked.t)
+    -> 'input_value
+    -> Proof_inputs.t
 
   (** Generate a witness (auxiliary input) for the given public input and pass
       the result to a function.
@@ -1063,10 +1073,15 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
   *)
   val generate_witness_conv :
        f:(Proof_inputs.t -> 'r_value -> 'out)
-    -> ('r_var Checked.t, 'out, 'k_var, 'k_value) Data_spec.t
+    -> ( 'r_var Checked.t
+       , 'out
+       , 'input_var -> 'r_var Checked.t
+       , 'input_value -> 'out )
+       Data_spec.t
     -> return_typ:('r_var, 'r_value) Typ.t
-    -> 'k_var
-    -> 'k_value
+    -> ('input_var -> 'r_var Checked.t)
+    -> 'input_value
+    -> 'out
 
   (** Run a checked computation as the prover, without checking the
       constraints. *)
@@ -1085,10 +1100,15 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
       Returns [unit]; this is for testing only.
   *)
   val generate_auxiliary_input :
-       ('a Checked.t, unit, 'k_var, 'k_value) Data_spec.t
+       ( 'a Checked.t
+       , unit
+       , 'input_var -> 'a Checked.t
+       , 'input_value -> unit )
+       Data_spec.t
     -> return_typ:('a, _) Typ.t
-    -> 'k_var
-    -> 'k_value
+    -> ('input_var -> 'a Checked.t)
+    -> 'input_value
+    -> unit
 
   (** Returns the number of constraints in the constraint system.
 
@@ -1459,10 +1479,15 @@ module type Run_basic = sig
     -> R1CS_constraint_system.t
 
   val generate_witness :
-       (unit -> 'a, Proof_inputs.t, 'k_var, 'k_value) Data_spec.t
+       ( unit -> 'a
+       , Proof_inputs.t
+       , 'input_var -> unit -> 'a
+       , 'input_value -> Proof_inputs.t )
+       Data_spec.t
     -> return_typ:('a, _) Typ.t
-    -> 'k_var
-    -> 'k_value
+    -> ('input_var -> unit -> 'a)
+    -> 'input_value
+    -> Proof_inputs.t
 
   (** Generate the public input vector for a given statement. *)
   val generate_public_input :
@@ -1476,10 +1501,15 @@ module type Run_basic = sig
 
   val generate_witness_conv :
        f:(Proof_inputs.t -> 'r_value -> 'out)
-    -> (unit -> 'r_var, 'out, 'k_var, 'k_value) Data_spec.t
+    -> ( unit -> 'r_var
+       , 'out
+       , 'input_var -> unit -> 'r_var
+       , 'input_value -> 'out )
+       Data_spec.t
     -> return_typ:('r_var, 'r_value) Typ.t
-    -> 'k_var
-    -> 'k_value
+    -> ('input_var -> unit -> 'r_var)
+    -> 'input_value
+    -> 'out
 
   val run_unchecked : (unit -> 'a) -> 'a
 

--- a/src/base/snark_intf.ml
+++ b/src/base/snark_intf.ml
@@ -1013,9 +1013,14 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
 
   (** Generate the R1CS for the checked computation. *)
   val constraint_system :
-       exposing:('a Checked.t, _, 'k_var, _) Data_spec.t
+       exposing:
+         ( 'a Checked.t
+         , 'res
+         , 'input_var -> 'a Checked.t
+         , 'input_value -> 'res )
+         Data_spec.t
     -> return_typ:('a, _) Typ.t
-    -> 'k_var
+    -> ('input_var -> 'a Checked.t)
     -> R1CS_constraint_system.t
 
   (** Internal: supplies arguments to a checked computation by storing them
@@ -1437,9 +1442,14 @@ module type Run_basic = sig
   val make_checked : (unit -> 'a) -> ('a, field) Types.Checked.t
 
   val constraint_system :
-       exposing:(unit -> 'a, _, 'k_var, _) Data_spec.t
+       exposing:
+         ( unit -> 'a
+         , 'res
+         , 'input_var -> unit -> 'a
+         , 'input_value -> 'res )
+         Data_spec.t
     -> return_typ:('a, _) Typ.t
-    -> 'k_var
+    -> ('input_var -> unit -> 'a)
     -> R1CS_constraint_system.t
 
   val generate_witness :

--- a/src/base/snark_intf.ml
+++ b/src/base/snark_intf.ml
@@ -622,7 +622,11 @@ module type Basic = sig
         all function as you would expect.
     *)
     type ('r_var, 'r_value, 'k_var, 'k_value) t =
-      ('r_var, 'r_value, 'k_var, 'k_value, field) Typ0.Data_spec.t
+      | ( :: ) :
+          ('var, 'value, field, (unit, field) Types.Checked.t) Typ.typ
+          * ('r_var, 'r_value, 'k_var, 'k_value) t
+          -> ('r_var, 'r_value, 'var -> 'k_var, 'value -> 'k_value) t
+      | [] : ('r_var, 'r_value, 'r_var, 'r_value) t
 
     (** [size [typ1; ...; typn]] returns the number of {!type:Var.t} variables
         allocated by allocating [typ1], followed by [typ2], etc. *)
@@ -637,7 +641,8 @@ module type Basic = sig
          and type field_var := Field.Var.t
          and type checked_unit := unit Checked.t
          and type _ checked := unit Checked.t
-         and type ('a, 'b, 'c, 'd) data_spec := ('a, 'b, 'c, 'd) Data_spec.t
+         and type ('a, 'b, 'c, 'd) data_spec :=
+          ('a, 'b, 'c, 'd, field) Typ0.Data_spec.t
          and type 'a prover_ref := 'a As_prover.Ref.t
 
     include module type of Types.Typ.T
@@ -1204,7 +1209,11 @@ module type Run_basic = sig
         all function as you would expect.
     *)
     type ('r_var, 'r_value, 'k_var, 'k_value) t =
-      ('r_var, 'r_value, 'k_var, 'k_value, field) Typ0.Data_spec.t
+      | ( :: ) :
+          ('var, 'value, field, (unit, field) Checked.t) Types.Typ.typ
+          * ('r_var, 'r_value, 'k_var, 'k_value) t
+          -> ('r_var, 'r_value, 'var -> 'k_var, 'value -> 'k_value) t
+      | [] : ('r_var, 'r_value, 'r_var, 'r_value) t
 
     (** [size [typ1; ...; typn]] returns the number of {!type:Var.t} variables
         allocated by allocating [typ1], followed by [typ2], etc. *)
@@ -1218,7 +1227,8 @@ module type Run_basic = sig
        and type field_var := Field.t
        and type checked_unit := (unit, field) Checked.t
        and type _ checked := unit
-       and type ('a, 'b, 'c, 'd) data_spec := ('a, 'b, 'c, 'd) Data_spec.t
+       and type ('a, 'b, 'c, 'd) data_spec :=
+        ('a, 'b, 'c, 'd, field) Typ0.Data_spec.t
        and type 'a prover_ref := 'a As_prover.Ref.t)
 
   (** Representation of booleans within a field.


### PR DESCRIPTION
This PR removes `Data_spec.t` from the snarky interface, and replaces all uses with a single `input_typ:_ Typ.t` argument.

The commits in this PR are structured so as to do the minimum amount of work at each step, while still achieving compilation. Interested reviewers can follow the process of applying the conversion step-by-step.