### PR TITLE
Make Checked.t abstract

### DIFF
--- a/snarky_curve/snarky_curve.ml
+++ b/snarky_curve/snarky_curve.ml
@@ -225,7 +225,7 @@ module Make_checked (Inputs : Inputs_intf) = struct
     let (Typ typ_unchecked) = typ_unchecked in
     Typ
       { typ_unchecked with
-        check = (fun t -> make_checked (fun () -> assert_on_curve t))
+        check = (fun t -> make_checked_ast (fun () -> assert_on_curve t))
       }
 
   let if_ c ~then_:(tx, ty) ~else_:(ex, ey) =

--- a/src/base/enumerable.ml
+++ b/src/base/enumerable.ml
@@ -42,7 +42,7 @@ struct
           (Field.Var.constant (Field.of_int M.max))
     in
     let (Typ typ) = Typ.transport Field.typ ~there:to_field ~back:of_field in
-    Typ { typ with check }
+    Typ { typ with check = (fun x -> make_checked_ast (check x)) }
 
   let var_to_bits : var -> Boolean.var list Checked.t =
     Field.Checked.unpack ~length:bit_length

--- a/src/base/snark0.ml
+++ b/src/base/snark0.ml
@@ -1416,6 +1416,8 @@ struct
 
   let make_checked_ast x = x
 
+  let run_checked_ast x = x
+
   module Test = struct
     let checked_to_unchecked typ1 typ2 checked input =
       let checked_result =
@@ -2199,6 +2201,8 @@ module Run = struct
     module Internal_Basic = Snark
 
     let run_checked = run
+
+    let run_checked_ast x = run_checked x
   end
 
   module Make (Backend : Backend_intf.S) = struct

--- a/src/base/snark0.ml
+++ b/src/base/snark0.ml
@@ -1414,6 +1414,8 @@ struct
     in
     typ.var_of_fields (res, res_aux)
 
+  let make_checked_ast x = x
+
   module Test = struct
     let checked_to_unchecked typ1 typ2 checked input =
       let checked_result =
@@ -1560,6 +1562,8 @@ module Run = struct
       (!state, a)
 
     let make_checked x = Checked_ast.Direct (as_stateful x, fun x -> Pure x)
+
+    let make_checked_ast = make_checked
 
     module R1CS_constraint_system = Snark.R1CS_constraint_system
     module Var = Snark.Var

--- a/src/base/snark_intf.ml
+++ b/src/base/snark_intf.ml
@@ -980,6 +980,8 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
 
   val make_checked_ast : 'a Checked.t -> ('a, field) Checked_ast.t
 
+  val run_checked_ast : ('a, field) Checked_ast.t -> 'a Checked.t
+
   (** Generate the R1CS for the checked computation. *)
   val constraint_system :
        input_typ:('input_var, 'input_value) Typ.t
@@ -1382,6 +1384,8 @@ module type Run_basic = sig
   val make_checked : (unit -> 'a) -> 'a Internal_Basic.Checked.t
 
   val make_checked_ast : (unit -> 'a) -> ('a, field) Checked_ast.t
+
+  val run_checked_ast : ('a, field) Checked_ast.t -> 'a
 
   val constraint_system :
        input_typ:('input_var, 'input_value) Typ.t

--- a/src/base/snark_intf.ml
+++ b/src/base/snark_intf.ml
@@ -1159,7 +1159,7 @@ module type Run_basic = sig
     (Typ_intf
       with type field := Field.Constant.t
        and type field_var := Field.t
-       and type checked_unit := (unit, field) Checked_ast.t
+       and type checked_unit := unit Internal_Basic.Checked.t
        and type _ checked := unit
        and type ('a, 'b, 'c, 'd) data_spec :=
         ('a, 'b, 'c, 'd, field) Typ0.Data_spec.t
@@ -1277,6 +1277,11 @@ module type Run_basic = sig
       }
   end
 
+  and Internal_Basic :
+    (Basic
+      with type field = field
+       and type 'a As_prover.Ref.t = 'a As_prover.Ref.t)
+
   module Bitstring_checked : sig
     type t = Boolean.var list
 
@@ -1372,7 +1377,7 @@ module type Run_basic = sig
 
   val with_label : string -> (unit -> 'a) -> 'a
 
-  val make_checked : (unit -> 'a) -> ('a, field) Checked_ast.t
+  val make_checked : (unit -> 'a) -> 'a Internal_Basic.Checked.t
 
   val constraint_system :
        input_typ:('input_var, 'input_value) Typ.t
@@ -1433,11 +1438,6 @@ module type Run_basic = sig
   val in_prover : unit -> bool
 
   val in_checked_computation : unit -> bool
-
-  module Internal_Basic :
-    Basic
-      with type field = field
-       and type 'a As_prover.Ref.t = 'a As_prover.Ref.t
 
   val run_checked : 'a Internal_Basic.Checked.t -> 'a
 end

--- a/src/base/snark_intf.ml
+++ b/src/base/snark_intf.ml
@@ -604,7 +604,7 @@ module type Basic = sig
       Typ_intf
         with type field := Field.t
          and type field_var := Field.Var.t
-         and type checked_unit := unit Checked.t
+         and type checked_unit := (unit, field) Checked_ast.t
          and type _ checked := unit Checked.t
          and type ('a, 'b, 'c, 'd) data_spec :=
           ('a, 'b, 'c, 'd, field) Typ0.Data_spec.t
@@ -648,7 +648,7 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
 
     type run_state = Field.t Run_state.t
 
-    include Monad_let.S with type 'a t = ('a, Field.t) Checked_ast.t
+    include Monad_let.S
 
     module List :
       Monad_sequence.S
@@ -978,6 +978,8 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
   *)
   val with_label : string -> 'a Checked.t -> 'a Checked.t
 
+  val make_checked_ast : 'a Checked.t -> ('a, field) Checked_ast.t
+
   (** Generate the R1CS for the checked computation. *)
   val constraint_system :
        input_typ:('input_var, 'input_value) Typ.t
@@ -1159,7 +1161,7 @@ module type Run_basic = sig
     (Typ_intf
       with type field := Field.Constant.t
        and type field_var := Field.t
-       and type checked_unit := unit Internal_Basic.Checked.t
+       and type checked_unit := (unit, field) Checked_ast.t
        and type _ checked := unit
        and type ('a, 'b, 'c, 'd) data_spec :=
         ('a, 'b, 'c, 'd, field) Typ0.Data_spec.t
@@ -1378,6 +1380,8 @@ module type Run_basic = sig
   val with_label : string -> (unit -> 'a) -> 'a
 
   val make_checked : (unit -> 'a) -> 'a Internal_Basic.Checked.t
+
+  val make_checked_ast : (unit -> 'a) -> ('a, field) Checked_ast.t
 
   val constraint_system :
        input_typ:('input_var, 'input_value) Typ.t


### PR DESCRIPTION
This PR makes the `Checked.t` type abstract in `Snark_intf`.

This will allow us to swap out the implementation of `Checked.t` for some other one (e.g. snarky.rs) without any changes on the Mina side.

This PR also updates ppx_snarky, adding the ability to expose paths on the `%snarkydef` and `%with_label` annotations, to direct them at the appropriate module if required.

Note that this leaves the type of `check` in the `Typ.t` as `Checked_ast.t`, because it was surprisingly annoying to make it work on the Mina side. Instead, this PR introduces `make_checked_ast` and `run_checked_ast` functions, which allow converting between the types and the AST type.