### PR TITLE
Add unit arguments to functions

### DIFF
--- a/ppx/snarkydef.ml
+++ b/ppx/snarkydef.ml
@@ -49,7 +49,9 @@ let rec snarkydef_inject ~local ~loc ~arg ~name expr =
         "%%snarkydef currently doesn't support 'function'"
   | _ ->
       with_label ~local ~loc ~arg
-        [ (Nolabel, located_label_string ~loc name); (Nolabel, expr) ]
+        [ (Nolabel, located_label_string ~loc name)
+        ; (Nolabel, [%expr fun () -> [%e expr]])
+        ]
 
 let snarkydef ~local ~loc ~path:_ ~arg name expr =
   [%stri

--- a/src/base/checked_ast.ml
+++ b/src/base/checked_ast.ml
@@ -123,15 +123,15 @@ module Basic :
 
   let as_prover x = As_prover (x, return ())
 
-  let mk_lazy x = Lazy (x, return)
+  let mk_lazy x = Lazy (x (), return)
 
-  let with_label lbl x = With_label (lbl, x, return)
+  let with_label lbl x = With_label (lbl, x (), return)
 
-  let with_handler h x = With_handler (h, x, return)
+  let with_handler h x = With_handler (h, x (), return)
 
   let exists typ p = Exists (typ, p, return)
 
-  let next_auxiliary = Next_auxiliary return
+  let next_auxiliary () = Next_auxiliary return
 
   (** Count the constraints generated in the circuit definition.
 
@@ -229,10 +229,11 @@ module Basic :
 
   let constraint_count (type f)
       ?(weight : ((f field Cvar.t, f field) Constraint.t -> int) option)
-      ?(log = fun ?start:_ _ _ -> ()) (t : (_, f field) Types.Checked.t) : int =
+      ?(log = fun ?start:_ _ _ -> ()) (t : unit -> (_, f field) Types.Checked.t)
+      : int =
     let next_auxiliary = ref 1 in
     let weight = match weight with None -> Fn.const 1 | Some w -> w in
-    fst (constraint_count_aux ~weight ~log ~auxc:next_auxiliary 0 t)
+    fst (constraint_count_aux ~weight ~log ~auxc:next_auxiliary 0 (t ()))
 end
 
 module T = struct

--- a/src/base/checked_intf.ml
+++ b/src/base/checked_intf.ml
@@ -12,24 +12,24 @@ module type Basic = sig
 
   val as_prover : (unit, 'f field) Types.As_prover.t -> (unit, 'f field) t
 
-  val mk_lazy : ('a, 'f) t -> ('a Lazy.t, 'f) t
+  val mk_lazy : (unit -> ('a, 'f) t) -> ('a Lazy.t, 'f) t
 
-  val with_label : string -> ('a, 'f field) t -> ('a, 'f field) t
+  val with_label : string -> (unit -> ('a, 'f field) t) -> ('a, 'f field) t
 
   val with_handler :
-    Request.Handler.single -> ('a, 'f field) t -> ('a, 'f field) t
+    Request.Handler.single -> (unit -> ('a, 'f field) t) -> ('a, 'f field) t
 
   val exists :
        ('var, 'value, 'f field) Types.Typ.t
     -> ('value, 'f field) Types.Provider.t
     -> (('var, 'value) Handle.t, 'f field) t
 
-  val next_auxiliary : (int, 'f field) t
+  val next_auxiliary : unit -> (int, 'f field) t
 
   val constraint_count :
        ?weight:(('f field Cvar.t, 'f field) Constraint.t -> int)
     -> ?log:(?start:bool -> string -> int -> unit)
-    -> ('a, 'f field) t
+    -> (unit -> ('a, 'f field) t)
     -> int
 end
 
@@ -44,7 +44,7 @@ module type S = sig
 
   val as_prover : (unit, 'f field) Types.As_prover.t -> (unit, 'f field) t
 
-  val mk_lazy : ('a, 'f) t -> ('a Lazy.t, 'f) t
+  val mk_lazy : (unit -> ('a, 'f) t) -> ('a Lazy.t, 'f) t
 
   val request_witness :
        ('var, 'value, 'f field) Types.Typ.t
@@ -78,16 +78,17 @@ module type S = sig
         { request : 'a Request.t; respond : 'a Request.Response.t -> response }
         -> request
 
-  val handle : ('a, 'f field) t -> (request -> response) -> ('a, 'f field) t
+  val handle :
+    (unit -> ('a, 'f field) t) -> (request -> response) -> ('a, 'f field) t
 
   val handle_as_prover :
-       ('a, 'f field) t
+       (unit -> ('a, 'f field) t)
     -> (request -> response, 'f field) Types.As_prover.t
     -> ('a, 'f field) t
 
-  val next_auxiliary : (int, 'f field) t
+  val next_auxiliary : unit -> (int, 'f field) t
 
-  val with_label : string -> ('a, 'f field) t -> ('a, 'f field) t
+  val with_label : string -> (unit -> ('a, 'f field) t) -> ('a, 'f field) t
 
   val assert_ :
        ?label:Base.string
@@ -121,7 +122,7 @@ module type S = sig
   val constraint_count :
        ?weight:(('f field Cvar.t, 'f field) Constraint.t -> int)
     -> ?log:(?start:bool -> string -> int -> unit)
-    -> ('a, 'f field) t
+    -> (unit -> ('a, 'f field) t)
     -> int
 end
 

--- a/src/base/knapsack.ml
+++ b/src/base/knapsack.ml
@@ -52,14 +52,14 @@ module Make (Impl : Snark_intf.Basic) = struct
     let hash_to_bits (t : t) (vs : Boolean.var list) :
         Boolean.var list Checked.t =
       let%bind xs = hash_to_field t vs in
-      with_label "hash_to_bits"
-        (let%map bss =
-           Checked.all
-             (List.map xs
-                ~f:
-                  (Field.Checked.choose_preimage_var ~length:Field.size_in_bits) )
-         in
-         List.concat bss )
+      with_label "hash_to_bits" (fun () ->
+          let%map bss =
+            Checked.all
+              (List.map xs
+                 ~f:
+                   (Field.Checked.choose_preimage_var ~length:Field.size_in_bits) )
+          in
+          List.concat bss )
   end
 
   module Hash (M : sig
@@ -108,7 +108,8 @@ module Make (Impl : Snark_intf.Basic) = struct
       res
 
     let hash (h1 : var) (h2 : var) =
-      with_label "Knapsack.hash" (Checked.hash_to_bits knapsack (h1 @ h2))
+      with_label "Knapsack.hash" (fun () ->
+          Checked.hash_to_bits knapsack (h1 @ h2) )
 
     let assert_equal = Impl.Bitstring_checked.Assert.equal
   end

--- a/src/base/number.ml
+++ b/src/base/number.ml
@@ -27,12 +27,12 @@ module Make (Impl : Snark_intf.Basic) = struct
 
   let to_bits { var; bits; upper_bound; lower_bound = _ } =
     let length = bigint_num_bits upper_bound in
-    with_label "Number.to_bits"
-      ( match bits with
-      | Some bs ->
-          return (List.take bs length)
-      | None ->
-          Field.Checked.unpack var ~length )
+    with_label "Number.to_bits" (fun () ->
+        match bits with
+        | Some bs ->
+            return (List.take bs length)
+        | None ->
+            Field.Checked.unpack var ~length )
 
   let of_bits bs =
     let n = List.length bs in
@@ -70,23 +70,23 @@ module Make (Impl : Snark_intf.Basic) = struct
 
   let clamp_to_n_bits t n =
     assert (n < Field.size_in_bits) ;
-    with_label "Number.clamp_to_n_bits"
-      (let k = pow2 n in
-       if Bignum_bigint.(t.upper_bound < k) then return t
-       else
-         let%bind bs = to_bits t in
-         let bs' = List.take bs n in
-         let g = Field.Var.project bs' in
-         let%bind fits = Field.Checked.equal t.var g in
-         let%map r =
-           Field.Checked.if_ fits ~then_:g
-             ~else_:(Field.Var.constant Field.(sub (two_to_the n) one))
-         in
-         { upper_bound = Bignum_bigint.(k - one)
-         ; lower_bound = t.lower_bound
-         ; var = r
-         ; bits = None
-         } )
+    with_label "Number.clamp_to_n_bits" (fun () ->
+        let k = pow2 n in
+        if Bignum_bigint.(t.upper_bound < k) then return t
+        else
+          let%bind bs = to_bits t in
+          let bs' = List.take bs n in
+          let g = Field.Var.project bs' in
+          let%bind fits = Field.Checked.equal t.var g in
+          let%map r =
+            Field.Checked.if_ fits ~then_:g
+              ~else_:(Field.Var.constant Field.(sub (two_to_the n) one))
+          in
+          { upper_bound = Bignum_bigint.(k - one)
+          ; lower_bound = t.lower_bound
+          ; var = r
+          ; bits = None
+          } )
 
   let ( < ) x y =
     let open Bignum_bigint in
@@ -97,17 +97,17 @@ module Make (Impl : Snark_intf.Basic) = struct
       x     [ ]
       y [ ]
     *)
-    with_label "Number.(<)"
-      ( if x.upper_bound < y.lower_bound then return Boolean.true_
-      else if x.lower_bound >= y.upper_bound then return Boolean.false_
-      else
-        let bit_length =
-          Int.max
-            (bigint_num_bits x.upper_bound)
-            (bigint_num_bits y.upper_bound)
-        in
-        let%map { less; _ } = Field.Checked.compare ~bit_length x.var y.var in
-        less )
+    with_label "Number.(<)" (fun () ->
+        if x.upper_bound < y.lower_bound then return Boolean.true_
+        else if x.lower_bound >= y.upper_bound then return Boolean.false_
+        else
+          let bit_length =
+            Int.max
+              (bigint_num_bits x.upper_bound)
+              (bigint_num_bits y.upper_bound)
+          in
+          let%map { less; _ } = Field.Checked.compare ~bit_length x.var y.var in
+          less )
 
   let ( <= ) x y =
     let open Bignum_bigint in
@@ -118,19 +118,19 @@ module Make (Impl : Snark_intf.Basic) = struct
       x     [ ]
       y [ ]
     *)
-    with_label "Number.(<=)"
-      ( if x.upper_bound <= y.lower_bound then return Boolean.true_
-      else if x.lower_bound > y.upper_bound then return Boolean.false_
-      else
-        let bit_length =
-          Int.max
-            (bigint_num_bits x.upper_bound)
-            (bigint_num_bits y.upper_bound)
-        in
-        let%map { less_or_equal; _ } =
-          Field.Checked.compare ~bit_length x.var y.var
-        in
-        less_or_equal )
+    with_label "Number.(<=)" (fun () ->
+        if x.upper_bound <= y.lower_bound then return Boolean.true_
+        else if x.lower_bound > y.upper_bound then return Boolean.false_
+        else
+          let bit_length =
+            Int.max
+              (bigint_num_bits x.upper_bound)
+              (bigint_num_bits y.upper_bound)
+          in
+          let%map { less_or_equal; _ } =
+            Field.Checked.compare ~bit_length x.var y.var
+          in
+          less_or_equal )
 
   let ( > ) x y = y < x
 
@@ -214,18 +214,18 @@ module Make (Impl : Snark_intf.Basic) = struct
 
   let ( * ) x y =
     let open Bignum_bigint in
-    with_label "Number.(*)"
-      (let upper_bound = x.upper_bound * y.upper_bound in
-       if upper_bound < Field.size then
-         let%map var = Field.Checked.mul x.var y.var in
-         { upper_bound
-         ; lower_bound = x.lower_bound * y.lower_bound
-         ; var
-         ; bits = None
-         }
-       else
-         failwithf "Number.*: Potential overflow: (%s * %s > Field.size)"
-           (to_string x.upper_bound) (to_string y.upper_bound) () )
+    with_label "Number.(*)" (fun () ->
+        let upper_bound = x.upper_bound * y.upper_bound in
+        if upper_bound < Field.size then
+          let%map var = Field.Checked.mul x.var y.var in
+          { upper_bound
+          ; lower_bound = x.lower_bound * y.lower_bound
+          ; var
+          ; bits = None
+          }
+        else
+          failwithf "Number.*: Potential overflow: (%s * %s > Field.size)"
+            (to_string x.upper_bound) (to_string y.upper_bound) () )
 
   (* x mod n = x - n * floor(x / n) *)
   let mod_pow_2 x n =

--- a/src/base/pedersen.ml
+++ b/src/base/pedersen.ml
@@ -153,8 +153,8 @@ end = struct
     let typ = Typ.field
 
     let choose_preimage x =
-      with_label "Pedersen.Digest.choose_preimage"
-        (Field.Checked.choose_preimage_var ~length:Field.size_in_bits x)
+      with_label "Pedersen.Digest.choose_preimage" (fun () ->
+          Field.Checked.choose_preimage_var ~length:Field.size_in_bits x )
       |> Checked.map ~f:Bitstring.Lsb_first.of_list
   end
 

--- a/src/base/snark_intf.ml
+++ b/src/base/snark_intf.ml
@@ -885,10 +885,10 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
       Any constraints within the checked computation are not added to the
       constraint system unless the lazy value is forced.
   *)
-  val mk_lazy : 'a Checked.t -> 'a Lazy.t Checked.t
+  val mk_lazy : (unit -> 'a Checked.t) -> 'a Lazy.t Checked.t
 
   (** Internal: read the value of the next unused auxiliary input index. *)
-  val next_auxiliary : int Checked.t
+  val next_auxiliary : unit -> int Checked.t
 
   (** [request_witness typ create_request] runs the [create_request]
       {!type:As_prover.t} block to generate a {!type:Request.t}.
@@ -951,13 +951,14 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
   (** Add a request handler to the checked computation, to be used by
       {!val:request_witness}, {!val:perform}, {!val:request} or {!val:exists}.
   *)
-  val handle : 'a Checked.t -> Handler.t -> 'a Checked.t
+  val handle : (unit -> 'a Checked.t) -> Handler.t -> 'a Checked.t
 
   (** Generate a handler using the {!module:As_prover} 'superpowers', and use
       it for {!val:request_witness}, {!val:perform}, {!val:request} or
       {!val:exists} calls in the wrapped checked computation.
   *)
-  val handle_as_prover : 'a Checked.t -> Handler.t As_prover.t -> 'a Checked.t
+  val handle_as_prover :
+    (unit -> 'a Checked.t) -> Handler.t As_prover.t -> 'a Checked.t
 
   (** [if_ b ~then_ ~else_] returns [then_] if [b] is true, or [else_]
       otherwise.
@@ -976,7 +977,7 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
       If a constraint is checked and isn't satisfied, this label will be shown
       in the error message.
   *)
-  val with_label : string -> 'a Checked.t -> 'a Checked.t
+  val with_label : string -> (unit -> 'a Checked.t) -> 'a Checked.t
 
   val make_checked_ast : 'a Checked.t -> ('a, field) Checked_ast.t
 
@@ -1066,7 +1067,7 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
   val constraint_count :
        ?weight:(Constraint.t -> int)
     -> ?log:(?start:bool -> string -> int -> unit)
-    -> _ Checked.t
+    -> (unit -> _ Checked.t)
     -> int
 
   module Test : sig


### PR DESCRIPTION
This PR adds some unit arguments to functions, to make the imperative and monadic APIs consistent.