### PR TITLE
Extract the AST interpreter from the rest of the checked runner

### DIFF
--- a/src/base/ast_runner.ml
+++ b/src/base/ast_runner.ml
@@ -1,0 +1,97 @@
+open Core_kernel
+
+exception Runtime_error of string list * exn * string
+
+let stack_to_string = String.concat ~sep:"\n"
+
+(* Register a printer for [Runtime_error], so that the user sees a useful,
+   well-formatted message. This will contain all of the information that
+   raising the original error would have raised, along with the extra
+   information added to [Runtime_error].
+
+   NOTE: The message in its entirety is included in [Runtime_error], so that
+         all of the information will be visible to the user in some form even
+         if they don't use the [Print_exc] pretty-printer.
+*)
+let () =
+  Stdlib.Printexc.register_printer (fun exn ->
+      match exn with
+      | Runtime_error (stack, exn, bt) ->
+          Some
+            (Printf.sprintf
+               "Snarky.Checked_runner.Runtime_error(_, _, _, _)\n\n\
+                Encountered an error while evaluating the checked computation:\n\
+               \  %s\n\n\
+                Label stack trace:\n\
+                %s\n\n\n\
+                %s"
+               (Exn.to_string exn) (stack_to_string stack) bt )
+      | _ ->
+          None )
+
+module Make_runner
+    (Checked : Checked_intf.Basic
+                 with type ('a, 'f) Types.As_prover.t =
+                   ('a, 'f) Types.As_prover.t
+                  and type ('a, 'f) Types.Provider.provider =
+                   ('a, 'f) Types.Provider.provider) =
+struct
+  let handle_error label f =
+    try f () with
+    | Runtime_error (stack, exn, bt) ->
+        let bt_new = Printexc.get_backtrace () in
+        raise (Runtime_error (label :: stack, exn, bt ^ "\n\n" ^ bt_new))
+    | exn ->
+        let bt = Printexc.get_backtrace () in
+        raise (Runtime_error ([ label ], exn, bt))
+
+  let rec run :
+      type a.
+      (a, 'f Checked.field) Checked_ast.t -> (a, 'f Checked.field) Checked.t =
+   fun t ->
+    match t with
+    | As_prover (x, k) ->
+        Checked.bind (Checked.as_prover x) ~f:(fun () -> run k)
+    | Pure x ->
+        Checked.return x
+    | Direct (d, k) ->
+        Checked.bind (Checked.direct d) ~f:(fun y -> run (k y))
+    | Lazy (x, k) ->
+        Checked.bind (Checked.mk_lazy (fun () -> run x)) ~f:(fun y -> run (k y))
+    | With_label (lab, t, k) ->
+        Checked.bind
+          (Checked.with_label lab (fun () -> handle_error lab (fun () -> run t)))
+          ~f:(fun y -> run (k y))
+    | Add_constraint (c, t) ->
+        Checked.bind (Checked.add_constraint c) ~f:(fun () -> run t)
+    | With_handler (h, t, k) ->
+        Checked.bind
+          (Checked.with_handler h (fun () -> run t))
+          ~f:(fun y -> run (k y))
+    | Exists
+        ( Typ
+            { var_to_fields
+            ; var_of_fields
+            ; value_to_fields
+            ; value_of_fields
+            ; size_in_field_elements
+            ; constraint_system_auxiliary
+            ; check
+            }
+        , p
+        , k ) ->
+        let typ =
+          Types.Typ.Typ
+            { var_to_fields
+            ; var_of_fields
+            ; value_to_fields
+            ; value_of_fields
+            ; size_in_field_elements
+            ; constraint_system_auxiliary
+            ; check = (fun var -> run (check var))
+            }
+        in
+        Checked.bind (Checked.exists typ p) ~f:(fun y -> run (k y))
+    | Next_auxiliary k ->
+        Checked.bind (Checked.next_auxiliary ()) ~f:(fun y -> run (k y))
+end

--- a/src/base/checked_ast.ml
+++ b/src/base/checked_ast.ml
@@ -133,6 +133,8 @@ module Basic :
 
   let next_auxiliary () = Next_auxiliary return
 
+  let direct f = Direct (f, return)
+
   (** Count the constraints generated in the circuit definition.
 
       This evaluates the circuit definition, and will run code in the same

--- a/src/base/checked_intf.ml
+++ b/src/base/checked_intf.ml
@@ -26,6 +26,9 @@ module type Basic = sig
 
   val next_auxiliary : unit -> (int, 'f field) t
 
+  val direct :
+    ('f field Run_state.t -> 'f field Run_state.t * 'a) -> ('a, 'f field) t
+
   val constraint_count :
        ?weight:(('f field Cvar.t, 'f field) Constraint.t -> int)
     -> ?log:(?start:bool -> string -> int -> unit)
@@ -118,6 +121,9 @@ module type S = sig
     -> 'f field Cvar.t
     -> 'f field Cvar.t
     -> (unit, 'f field) t
+
+  val direct :
+    ('f field Run_state.t -> 'f field Run_state.t * 'a) -> ('a, 'f field) t
 
   val constraint_count :
        ?weight:(('f field Cvar.t, 'f field) Constraint.t -> int)

--- a/src/base/checked_runner.ml
+++ b/src/base/checked_runner.ml
@@ -1,34 +1,7 @@
 open Core_kernel
 module Constraint0 = Constraint
 
-exception Runtime_error of string list * exn * string
-
-let stack_to_string = String.concat ~sep:"\n"
-
-(* Register a printer for [Runtime_error], so that the user sees a useful,
-   well-formatted message. This will contain all of the information that
-   raising the original error would have raised, along with the extra
-   information added to [Runtime_error].
-
-   NOTE: The message in its entirety is included in [Runtime_error], so that
-         all of the information will be visible to the user in some form even
-         if they don't use the [Print_exc] pretty-printer.
-*)
-let () =
-  Stdlib.Printexc.register_printer (fun exn ->
-      match exn with
-      | Runtime_error (stack, exn, bt) ->
-          Some
-            (Printf.sprintf
-               "Snarky.Checked_runner.Runtime_error(_, _, _, _)\n\n\
-                Encountered an error while evaluating the checked computation:\n\
-               \  %s\n\n\
-                Label stack trace:\n\
-                %s\n\n\n\
-                %s"
-               (Exn.to_string exn) (stack_to_string stack) bt )
-      | _ ->
-          None )
+let stack_to_string = Ast_runner.stack_to_string
 
 let eval_constraints = ref true
 
@@ -287,73 +260,6 @@ module type Run_extras = sig
     -> field Run_state.t * 'a option
 end
 
-module Make_runner
-    (Checked : Checked_intf.Basic
-                 with type ('a, 'f) Types.As_prover.t =
-                   ('a, 'f) Types.As_prover.t
-                  and type ('a, 'f) Types.Provider.provider =
-                   ('a, 'f) Types.Provider.provider) =
-struct
-  let handle_error label f =
-    try f () with
-    | Runtime_error (stack, exn, bt) ->
-        let bt_new = Printexc.get_backtrace () in
-        raise (Runtime_error (label :: stack, exn, bt ^ "\n\n" ^ bt_new))
-    | exn ->
-        let bt = Printexc.get_backtrace () in
-        raise (Runtime_error ([ label ], exn, bt))
-
-  let rec run :
-      type a.
-      (a, 'f Checked.field) Checked_ast.t -> (a, 'f Checked.field) Checked.t =
-   fun t ->
-    match t with
-    | As_prover (x, k) ->
-        Checked.bind (Checked.as_prover x) ~f:(fun () -> run k)
-    | Pure x ->
-        Checked.return x
-    | Direct (d, k) ->
-        Checked.bind (Checked.direct d) ~f:(fun y -> run (k y))
-    | Lazy (x, k) ->
-        Checked.bind (Checked.mk_lazy (fun () -> run x)) ~f:(fun y -> run (k y))
-    | With_label (lab, t, k) ->
-        Checked.bind
-          (Checked.with_label lab (fun () -> handle_error lab (fun () -> run t)))
-          ~f:(fun y -> run (k y))
-    | Add_constraint (c, t) ->
-        Checked.bind (Checked.add_constraint c) ~f:(fun () -> run t)
-    | With_handler (h, t, k) ->
-        Checked.bind
-          (Checked.with_handler h (fun () -> run t))
-          ~f:(fun y -> run (k y))
-    | Exists
-        ( Typ
-            { var_to_fields
-            ; var_of_fields
-            ; value_to_fields
-            ; value_of_fields
-            ; size_in_field_elements
-            ; constraint_system_auxiliary
-            ; check
-            }
-        , p
-        , k ) ->
-        let typ =
-          Types.Typ.Typ
-            { var_to_fields
-            ; var_of_fields
-            ; value_to_fields
-            ; value_of_fields
-            ; size_in_field_elements
-            ; constraint_system_auxiliary
-            ; check = (fun var -> run (check var))
-            }
-        in
-        Checked.bind (Checked.exists typ p) ~f:(fun y -> run (k y))
-    | Next_auxiliary k ->
-        Checked.bind (Checked.next_auxiliary ()) ~f:(fun y -> run (k y))
-end
-
 module Make (Backend : Backend_extended.S) = struct
   open Backend
 
@@ -387,7 +293,7 @@ module Make (Backend : Backend_extended.S) = struct
       end )
 
   module Types = Checked_ast.Types
-  include Make_runner (Checked_runner)
+  include Ast_runner.Make_runner (Checked_runner)
 
   let dummy_vector = Run_state.Vector.null
 

--- a/src/base/checked_runner.ml
+++ b/src/base/checked_runner.ml
@@ -125,7 +125,11 @@ struct
 
   let with_label lab t s =
     let stack = Run_state.stack s in
+    Option.iter (Run_state.log_constraint s) ~f:(fun f ->
+        f ~at_label_boundary:(`Start, lab) None ) ;
     let s', y = t () (Run_state.set_stack s (lab :: stack)) in
+    Option.iter (Run_state.log_constraint s) ~f:(fun f ->
+        f ~at_label_boundary:(`End, lab) None ) ;
     (Run_state.set_stack s' stack, y)
 
   let log_constraint { basic; _ } s =
@@ -356,11 +360,7 @@ module Make (Backend : Backend_extended.S) = struct
         let k = handle_error s (fun () -> k y) in
         run k s
     | With_label (lab, t, k) ->
-        Option.iter (Run_state.log_constraint s) ~f:(fun f ->
-            f ~at_label_boundary:(`Start, lab) None ) ;
         let s, y = with_label lab (fun () -> run t) s in
-        Option.iter (Run_state.log_constraint s) ~f:(fun f ->
-            f ~at_label_boundary:(`End, lab) None ) ;
         let k = handle_error s (fun () -> k y) in
         run k s
     | Add_constraint (c, t) ->

--- a/src/base/checked_runner.ml
+++ b/src/base/checked_runner.ml
@@ -242,6 +242,8 @@ struct
 
   let next_auxiliary () s = (s, Run_state.next_auxiliary s)
 
+  let direct f = f
+
   let constraint_count ?(weight = Fn.const 1)
       ?(log = fun ?start:_ _lab _pos -> ()) t =
     (* TODO: Integrate log with log_constraint *)
@@ -352,7 +354,7 @@ module Make (Backend : Backend_extended.S) = struct
     | Pure x ->
         (s, x)
     | Direct (d, k) ->
-        let s, y = handle_error s (fun () -> d s) in
+        let s, y = handle_error s (fun () -> direct d s) in
         let k = handle_error s (fun () -> k y) in
         run k s
     | Lazy (x, k) ->

--- a/src/base/checked_runner.ml
+++ b/src/base/checked_runner.ml
@@ -287,6 +287,73 @@ module type Run_extras = sig
     -> field Run_state.t * 'a option
 end
 
+module Make_runner
+    (Checked : Checked_intf.Basic
+                 with type ('a, 'f) Types.As_prover.t =
+                   ('a, 'f) Types.As_prover.t
+                  and type ('a, 'f) Types.Provider.provider =
+                   ('a, 'f) Types.Provider.provider) =
+struct
+  let handle_error label f =
+    try f () with
+    | Runtime_error (stack, exn, bt) ->
+        let bt_new = Printexc.get_backtrace () in
+        raise (Runtime_error (label :: stack, exn, bt ^ "\n\n" ^ bt_new))
+    | exn ->
+        let bt = Printexc.get_backtrace () in
+        raise (Runtime_error ([ label ], exn, bt))
+
+  let rec run :
+      type a.
+      (a, 'f Checked.field) Checked_ast.t -> (a, 'f Checked.field) Checked.t =
+   fun t ->
+    match t with
+    | As_prover (x, k) ->
+        Checked.bind (Checked.as_prover x) ~f:(fun () -> run k)
+    | Pure x ->
+        Checked.return x
+    | Direct (d, k) ->
+        Checked.bind (Checked.direct d) ~f:(fun y -> run (k y))
+    | Lazy (x, k) ->
+        Checked.bind (Checked.mk_lazy (fun () -> run x)) ~f:(fun y -> run (k y))
+    | With_label (lab, t, k) ->
+        Checked.bind
+          (Checked.with_label lab (fun () -> handle_error lab (fun () -> run t)))
+          ~f:(fun y -> run (k y))
+    | Add_constraint (c, t) ->
+        Checked.bind (Checked.add_constraint c) ~f:(fun () -> run t)
+    | With_handler (h, t, k) ->
+        Checked.bind
+          (Checked.with_handler h (fun () -> run t))
+          ~f:(fun y -> run (k y))
+    | Exists
+        ( Typ
+            { var_to_fields
+            ; var_of_fields
+            ; value_to_fields
+            ; value_of_fields
+            ; size_in_field_elements
+            ; constraint_system_auxiliary
+            ; check
+            }
+        , p
+        , k ) ->
+        let typ =
+          Types.Typ.Typ
+            { var_to_fields
+            ; var_of_fields
+            ; value_to_fields
+            ; value_of_fields
+            ; size_in_field_elements
+            ; constraint_system_auxiliary
+            ; check = (fun var -> run (check var))
+            }
+        in
+        Checked.bind (Checked.exists typ p) ~f:(fun y -> run (k y))
+    | Next_auxiliary k ->
+        Checked.bind (Checked.next_auxiliary ()) ~f:(fun y -> run (k y))
+end
+
 module Make (Backend : Backend_extended.S) = struct
   open Backend
 

--- a/src/base/snark0.ml
+++ b/src/base/snark0.ml
@@ -3,7 +3,7 @@ module Bignum_bigint = Bigint
 module Checked_ast = Checked_ast
 open Core_kernel
 
-exception Runtime_error = Checked_runner.Runtime_error
+exception Runtime_error = Ast_runner.Runtime_error
 
 module Runner = Checked_runner
 

--- a/src/base/snark0.mli
+++ b/src/base/snark0.mli
@@ -12,13 +12,12 @@ val set_eval_constraints : bool -> unit
     exception.
 
     The arguments are:
-    1. a generic error message, with a presentation of the backtrace
-    2. the backtrace of all active labels at the point in the checked
+    1. the backtrace of all active labels at the point in the checked
        computation when the exception was raised
-    3. the original exception that was raised
-    4. the backtrace of the original exception
+    2. the original exception that was raised
+    3. the backtrace of the original exception
 *)
-exception Runtime_error of string * string list * exn * string
+exception Runtime_error of string list * exn * string
 
 module Make (Backend : Backend_intf.S) :
   Snark_intf.S


### PR DESCRIPTION
This PR extracts the logic for the AST interpreter from the rest of the `Checked_runner` module. Most notably, this also restructures the runner so that it will function correctly over any `Checked.t` implementation.

As a side-effect, the `Runtime_error` type can no longer access the full stack of labels, so we have to build them incrementally and generate the error message at the end. This also tweaks the backtrace printing so that we don't elide intermediate backtraces any more (which has long been an ask!)