### PR TITLE
remove Var module

### DIFF
--- a/src/base/backend_intf.ml
+++ b/src/base/backend_intf.ml
@@ -34,14 +34,6 @@ module type S = sig
 
   val field_size : Bigint.R.t
 
-  module Var : sig
-    type t
-
-    val index : t -> int
-
-    val create : int -> t
-  end
-
   module R1CS_constraint_system :
     Constraint_system_intf with module Field := Field
 end

--- a/src/base/cvar.ml
+++ b/src/base/cvar.ml
@@ -30,15 +30,7 @@ module Unsafe = struct
   let of_index v = Var v
 end
 
-module Make
-    (Field : Snarky_intf.Field.Extended) (Var : sig
-      include Comparable.S
-
-      include Sexpable.S with type t := t
-
-      val create : int -> t
-    end) =
-struct
+module Make (Field : Snarky_intf.Field.Extended) = struct
   type t = Field.t cvar [@@deriving sexp]
 
   let length _ = failwith "TODO"
@@ -79,7 +71,7 @@ struct
       | Constant c ->
           (Field.add constant (Field.mul scale c), terms)
       | Var v ->
-          (constant, (scale, Var.create v) :: terms)
+          (constant, (scale, v) :: terms)
       | Scale (s, t) ->
           go (Field.mul s scale) constant terms t
       | Add (x1, x2) ->

--- a/src/base/runners.ml
+++ b/src/base/runners.ml
@@ -36,7 +36,6 @@ struct
   end
 
   module Bigint = Bigint
-  module Var = Var
   module Field0 = Field
   module Cvar = Cvar
   module Constraint = Constraint

--- a/src/base/snark0.ml
+++ b/src/base/snark0.ml
@@ -27,7 +27,6 @@ struct
   module Checked_S = Checked_intf.Unextend (Checked)
   include Runners.Make (Backend) (Checked) (As_prover) (Runner)
   module Bigint = Bigint
-  module Var = Var
   module Field0 = Field
   module Cvar = Cvar
   module Constraint = Constraint
@@ -627,8 +626,6 @@ struct
 
     let typ = Typ.field
 
-    type var' = Var.t
-
     module Var = Cvar1
 
     let parity x = Bigint.(test_bit (of_field x) 0)
@@ -1149,7 +1146,6 @@ module Run = struct
     let make_checked_ast = make_checked
 
     module R1CS_constraint_system = Snark.R1CS_constraint_system
-    module Var = Snark.Var
 
     type field = Snark.field
 

--- a/src/base/snark0.mli
+++ b/src/base/snark0.mli
@@ -24,7 +24,6 @@ module Make (Backend : Backend_intf.S) :
     with type field = Backend.Field.t
      and type Bigint.t = Backend.Bigint.R.t
      and type R1CS_constraint_system.t = Backend.R1CS_constraint_system.t
-     and type Var.t = Backend.Var.t
      and type Field.Vector.t = Backend.Field.Vector.t
 
 module Run : sig
@@ -33,7 +32,6 @@ module Run : sig
       with type field = Backend.Field.t
        and type Bigint.t = Backend.Bigint.R.t
        and type R1CS_constraint_system.t = Backend.R1CS_constraint_system.t
-       and type Var.t = Backend.Var.t
        and type Field.Constant.Vector.t = Backend.Field.Vector.t
 end
 

--- a/src/base/snark_intf.ml
+++ b/src/base/snark_intf.ml
@@ -316,8 +316,6 @@ end
 module type Field_var_intf = sig
   type field
 
-  type var
-
   type boolean_var
 
   (** The type that stores booleans as R1CS variables. *)
@@ -330,7 +328,7 @@ module type Field_var_intf = sig
 
   (** Convert a {!type:t} value to its constituent constant and a list of
           scaled R1CS variables. *)
-  val to_constant_and_terms : t -> field option * (field * var) list
+  val to_constant_and_terms : t -> field option * (field * int) list
 
   (** [constant x] creates a new R1CS variable containing the constant
           field element [x]. *)
@@ -573,15 +571,6 @@ module type Basic = sig
     val digest : t -> Md5.t
   end
 
-  (** Variables in the R1CS. *)
-  module Var : sig
-    include Comparable.S
-
-    val create : int -> t
-
-    val index : t -> int
-  end
-
   module Bigint : sig
     include Snarky_intf.Bigint_intf.Extended with type field := field
 
@@ -709,12 +698,9 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
     (** Get the least significant bit of a field element. *)
     val parity : t -> bool
 
-    type var' = Var.t
-
     module Var :
       Field_var_intf
         with type field := field
-         and type var := Var.t
          and type boolean_var := Boolean.var
 
     module Checked :
@@ -1133,15 +1119,6 @@ module type Run_basic = sig
     val get_rows_len : t -> int
   end
 
-  (** Variables in the R1CS. *)
-  module Var : sig
-    include Comparable.S
-
-    val create : int -> t
-
-    val index : t -> int
-  end
-
   (** The finite field over which the R1CS operates. *)
   type field
 
@@ -1210,7 +1187,6 @@ module type Run_basic = sig
     include
       Field_var_intf
         with type field := field
-         and type var := Var.t
          and type boolean_var := Boolean.var
 
     include


### PR DESCRIPTION
Looks like the `Var` module might have been a vestige of the past? It's currently nothing more than an `int`:

https://github.com/MinaProtocol/mina/blob/develop/src/lib/crypto/kimchi_backend/common/var.ml#L3