### PR TITLE
Remove unnecessary Bigint.R module

### DIFF
--- a/src/base/backend_intf.ml
+++ b/src/base/backend_intf.ml
@@ -28,11 +28,9 @@ end
 module type S = sig
   module Field : Snarky_intf.Field.S
 
-  module Bigint : sig
-    module R : Snarky_intf.Bigint_intf.Extended with type field := Field.t
-  end
+  module Bigint : Snarky_intf.Bigint_intf.Extended with type field := Field.t
 
-  val field_size : Bigint.R.t
+  val field_size : Bigint.t
 
   module R1CS_constraint_system :
     Constraint_system_intf with module Field := Field

--- a/src/base/snark0.mli
+++ b/src/base/snark0.mli
@@ -22,7 +22,7 @@ exception Runtime_error of string list * exn * string
 module Make (Backend : Backend_intf.S) :
   Snark_intf.S
     with type field = Backend.Field.t
-     and type Bigint.t = Backend.Bigint.R.t
+     and type Bigint.t = Backend.Bigint.t
      and type R1CS_constraint_system.t = Backend.R1CS_constraint_system.t
      and type Field.Vector.t = Backend.Field.Vector.t
 
@@ -30,7 +30,7 @@ module Run : sig
   module Make (Backend : Backend_intf.S) :
     Snark_intf.Run
       with type field = Backend.Field.t
-       and type Bigint.t = Backend.Bigint.R.t
+       and type Bigint.t = Backend.Bigint.t
        and type R1CS_constraint_system.t = Backend.R1CS_constraint_system.t
        and type Field.Constant.Vector.t = Backend.Field.Vector.t
 end


### PR DESCRIPTION
This PR removes the `R` module inside `Bigint`, a holdover from the long-dead libsnark backend

Corresponding Mina changes in [this branch](https://github.com/MinaProtocol/mina/compare/feature/snarky-remove-bigint-R-module?expand=1).