### PR TITLE
Treat *.ml{i} in Linguist as OCaml

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 src/camlsnark_c/libsnark-caml/* linguist-vendored
+*.ml linguist-language=OCaml
+*.mli linguist-language=OCaml


### PR DESCRIPTION
Linguist is marking some *.ml{i} files as SML instead of OCaml; this should fix the statistics.