### PR TITLE
website: Mark API docs as linguist-generated

### DIFF
--- a/website/website/pages/api/.gitattributes
+++ b/website/website/pages/api/.gitattributes
@@ -1,1 +1,2 @@
 * binary linguist-generated
+.gitattributes text -linguist-generated

--- a/website/website/pages/api/.gitattributes
+++ b/website/website/pages/api/.gitattributes
@@ -1,1 +1,1 @@
-* binary
+* binary linguist-generated


### PR DESCRIPTION
This removes the generated *.html files from the Linguist statistics.