### PR TITLE
Add defining constants to Sponge Intf

### DIFF
--- a/sponge/intf.ml
+++ b/sponge/intf.ml
@@ -43,6 +43,8 @@ module Inputs = struct
       val zero : t
     end
 
+    val alpha : int
+
     val to_the_alpha : Field.t -> Field.t
 
     module Operations : Operations with module Field := Field
@@ -93,6 +95,10 @@ module type Hash = sig
   module Field : T
 
   module State : T1
+
+  val state_size : int
+
+  val rate : int
 
   val update :
        Field.t Params.t

--- a/sponge/sponge.ml
+++ b/sponge/sponge.ml
@@ -60,6 +60,8 @@ module Bn382_inputs (Field : Intf.Field_mutable) = struct
 
   module Field = Field
 
+  let alpha = 17
+
   (* alpha = 17 *)
   let to_the_alpha x =
     let open Field in
@@ -206,6 +208,10 @@ end
 module Make_hash (P : Intf.Permutation) = struct
   open P
 
+  let state_size = m
+
+  let rate = state_size - 1
+
   let add_block ~state block = Array.iteri block ~f:(add_assign ~state)
 
   let sponge perm blocks ~state =
@@ -237,15 +243,13 @@ module Make_hash (P : Intf.Permutation) = struct
       (Array.map (to_blocks 2 [| z; z; z |]) ~f:(Array.map ~f:ignore))
       [| [| (); () |]; [| (); () |] |]
 
-  let r = m - 1
-
   let update params ~state inputs =
     let state = copy state in
-    sponge (block_cipher params) (to_blocks r inputs) ~state
+    sponge (block_cipher params) (to_blocks rate inputs) ~state
 
   let digest state = state.(0)
 
-  let initial_state = Array.init m ~f:(fun _ -> Field.zero)
+  let initial_state = Array.init state_size ~f:(fun _ -> Field.zero)
 
   let hash ?(init = initial_state) params inputs =
     update params ~state:init inputs |> digest

--- a/sponge/test_vectors/hash_function.ml
+++ b/sponge/test_vectors/hash_function.ml
@@ -62,6 +62,8 @@ module ConfigFpLegacy = struct
 
   let rounds_partial = 0
 
+  let alpha = 5
+
   let to_the_alpha x =
     let open Field in
     let x_2 = x * x in
@@ -94,6 +96,8 @@ module ConfigFpKimchi = struct
   let initial_ark = false
 
   let rounds_partial = 0
+
+  let alpha = 7
 
   let to_the_alpha x =
     let open Field in


### PR DESCRIPTION
With the goal of auto-generating all constants which define Poseidon behaviour from the OCaml source (for https://github.com/o1-labs/snarkyjs/pull/572), this PR adds three such constants to `sponge/intf.ml`, namely, `alpha`, the `state_size` and the `rate` 