### PR TITLE
fix the runner for pure computations

### DIFF
--- a/src/base/run_state.ml
+++ b/src/base/run_state.ml
@@ -106,4 +106,6 @@ let set_handler t handler = { t with handler }
 
 let is_running { is_running; _ } = is_running
 
+let set_is_running t is_running = { t with is_running }
+
 let next_auxiliary { next_auxiliary; _ } = !next_auxiliary

--- a/src/base/run_state.mli
+++ b/src/base/run_state.mli
@@ -68,4 +68,6 @@ val set_handler : 'field t -> Request.Handler.t -> 'field t
 
 val is_running : _ t -> bool
 
+val set_is_running : 'f t -> bool -> 'f t
+
 val next_auxiliary : _ t -> int

--- a/src/base/snark0.ml
+++ b/src/base/snark0.ml
@@ -1027,7 +1027,7 @@ module Make (Backend : Backend_intf.S) = struct
 
     type 'a t = ('a, field) Types.Checked.t
 
-    let run (f : ('a, 'f) Checked1.t) (s : Checked_runner.run_state) = f s
+    let run = Runner0.run
   end
 
   module Basic =
@@ -1098,14 +1098,14 @@ module Run = struct
       x
 
     let as_stateful x state' =
-      printf "as_stateful with is_running: %B\n"
-      (Run_state.is_running state') ;
+      printf "as_stateful with is_running: %B\n" (Run_state.is_running state') ;
       state := state' ;
       let a = x () in
       (!state, a)
 
-    let make_checked (type a) (f : unit -> a) : run_state -> run_state * a =
-      as_stateful f
+    let make_checked (type a) (f : unit -> a) : _ Checked.t =
+      let g : run_state -> run_state * a = as_stateful f in
+      Function g
 
     module R1CS_constraint_system = Snark.R1CS_constraint_system
 

--- a/src/base/snark0.ml
+++ b/src/base/snark0.ml
@@ -1074,10 +1074,10 @@ module Run = struct
       is_active_functor_id this_functor_id && Run_state.is_running !state
 
     let run (checked : _ Checked.t) =
-      if Run_state.is_running !state then print_endline "is_running"
-      else print_endline "is_not_running" ;
-      if not (is_active_functor_id this_functor_id) then
-        failwithf
+      match checked with
+      | Pure a ->
+          a
+      | _ ->
           if not (is_active_functor_id this_functor_id) then
             failwithf
               "Could not run this function.\n\n\

--- a/src/base/snark0.ml
+++ b/src/base/snark0.ml
@@ -97,16 +97,12 @@ struct
     let mul ?(label = "Checked.mul") (x : Cvar.t) (y : Cvar.t) =
       match (x, y) with
       | Constant x, Constant y ->
-          print_endline "constant" ;
           return (Cvar.constant (Field.mul x y))
       | Constant x, _ ->
-          print_endline "half constant" ;
           return (Cvar.scale y x)
       | _, Constant y ->
-          print_endline "half constant" ;
           return (Cvar.scale x y)
       | _, _ ->
-          print_endline "not constant" ;
           with_label label (fun () ->
               let open Let_syntax in
               let%bind z =
@@ -1082,23 +1078,21 @@ module Run = struct
       else print_endline "is_not_running" ;
       if not (is_active_functor_id this_functor_id) then
         failwithf
-          "Could not run this function.\n\n\
-           Hint: The module used to create this function had internal ID %i, \
-           but the module used to run it had internal ID %i. The same instance \
-           of Snarky.Snark.Run.Make must be used for both."
-          this_functor_id (active_functor_id ()) ()
-      else if not (Run_state.is_running !state) then (
-        print_endline "this is the bug" ;
-        if Run_state.is_running !state then print_endline "bug: is_running"
-        else print_endline "bug: is_not_running" ;
-        failwith "This function can't be run outside of a checked computation."
-        ) ;
-      let state', x = Runner.run checked !state in
-      state := state' ;
-      x
+          if not (is_active_functor_id this_functor_id) then
+            failwithf
+              "Could not run this function.\n\n\
+               Hint: The module used to create this function had internal ID \
+               %i, but the module used to run it had internal ID %i. The same \
+               instance of Snarky.Snark.Run.Make must be used for both."
+              this_functor_id (active_functor_id ()) ()
+          else if not (Run_state.is_running !state) then
+            failwith
+              "This function can't be run outside of a checked computation." ;
+          let state', x = Runner.run checked !state in
+          state := state' ;
+          x
 
     let as_stateful x state' =
-      printf "as_stateful with is_running: %B\n" (Run_state.is_running state') ;
       state := state' ;
       let a = x () in
       (!state, a)
@@ -1681,8 +1675,6 @@ module Run = struct
                  x ) )
 
       let as_stateful x state' =
-        printf "other as_stateful with is_running: %B\n"
-          (Run_state.is_running state') ;
         state := state' ;
         map (x ()) ~f:(fun a -> (!state, a))
 


### PR DESCRIPTION
We change the state monad to take into account pure computations (computations that do not need to be ran in a circuit because it only involves constants)

```diff
- type ('a, 'f) t = 'f Run_state.t -> 'f Run_state.t * 'a
+ type ('a, 'f) t = Pure of 'a | Function of ('f Run_state.t -> 'f Run_state.t * 'a)
```

We also make sure that `is_running` is set to `false` in the global at ALL time except when we're running a circuit (e.g. in user-facing functions like `constraint_system` and `generate_witness`). This means we have to set it to `false` at the end of running these functions.

Perhaps we should additionally:

* always check when using functions like `constraint_system` and `generate_witness` that `is_running` is set to `false` at the start (otherwise we're in the middle of a computation?)
