### PR TITLE
remove As_prover from Types.Types

### DIFF
--- a/src/base/as_prover.ml
+++ b/src/base/as_prover.ml
@@ -8,20 +8,16 @@ end
 module type S = sig
   module Types : Types.Types
 
-  include
-    Basic
-      with type ('a, 'f) t = ('a, 'f) Types.As_prover.t
-       and type ('a, 'f) Provider.t = ('a, 'f) Types.Provider.t
+  include Basic with type ('a, 'f) Provider.t = ('a, 'f) Types.Provider.t
 
   module Ref : sig
     type 'a t = 'a Ref0.t
 
-    val create :
-      ('a, 'f field) Types.As_prover.t -> ('a t, 'f field) Types.Checked.t
+    val create : ('a, 'f field) As_prover0.t -> ('a t, 'f field) Types.Checked.t
 
-    val get : 'a t -> ('a, 'f field) Types.As_prover.t
+    val get : 'a t -> ('a, 'f field) As_prover0.t
 
-    val set : 'a t -> 'a -> (unit, 'f field) Types.As_prover.t
+    val set : 'a t -> 'a -> (unit, 'f field) As_prover0.t
 
     val typ : ('a t, 'a, 'f field) Types.Typ.t
   end
@@ -36,9 +32,9 @@ module type Extended = sig
     S
       with module Types := Types
       with type 'f field := field
-       and type ('a, 'f) t := ('a, 'f) Types.As_prover.t
+       and type ('a, 'f) t := ('a, 'f) As_prover0.t
 
-  type 'a t = ('a, field) Types.As_prover.t
+  type 'a t = ('a, field) As_prover0.t
 end
 
 module Make_ref_typ (Checked : Monad_let.S2) = struct
@@ -57,14 +53,11 @@ end
 module Make
     (Checked : Checked_intf.S)
     (As_prover : Basic
-                   with type ('a, 'f) t := ('a, 'f) Checked.Types.As_prover.t
-                    and type 'f field := 'f Checked.field
+                   with type 'f field := 'f Checked.field
                     and type ('a, 'f) Provider.t =
                      ('a, 'f) Checked.Types.Provider.t) =
 struct
   module Types = Checked.Types
-
-  type ('a, 'f) t = ('a, 'f) Types.As_prover.t
 
   type 'f field = 'f Checked.field
 
@@ -73,7 +66,7 @@ struct
   module Ref = struct
     type 'a t = 'a Ref0.t
 
-    let create (x : ('a, 'field) Types.As_prover.t) : ('a t, 'field) Checked.t =
+    let create (x : ('a, 'field) As_prover0.t) : ('a t, 'field) Checked.t =
       let r = ref None in
       let open Checked in
       let%map () =
@@ -108,7 +101,7 @@ end)
 struct
   module Types = Checked.Types
 
-  type 'a t = ('a, Env.field) Types.As_prover.t
+  type 'a t = ('a, Env.field) As_prover0.t
 
   include Env
 
@@ -117,5 +110,5 @@ struct
       S
         with module Types := Types
         with type 'f field := field
-         and type ('a, 'f) t := ('a, 'f) Types.As_prover.t )
+         and type ('a, 'f) t := ('a, 'f) As_prover0.t )
 end

--- a/src/base/as_prover.mli
+++ b/src/base/as_prover.mli
@@ -7,20 +7,16 @@ end
 module type S = sig
   module Types : Types.Types
 
-  include
-    Basic
-      with type ('a, 'f) t = ('a, 'f) Types.As_prover.t
-       and type ('a, 'f) Provider.t = ('a, 'f) Types.Provider.t
+  include Basic with type ('a, 'f) Provider.t = ('a, 'f) Types.Provider.t
 
   module Ref : sig
     type 'a t = 'a Ref0.t
 
-    val create :
-      ('a, 'f field) Types.As_prover.t -> ('a t, 'f field) Types.Checked.t
+    val create : ('a, 'f field) As_prover0.t -> ('a t, 'f field) Types.Checked.t
 
-    val get : 'a t -> ('a, 'f field) Types.As_prover.t
+    val get : 'a t -> ('a, 'f field) As_prover0.t
 
-    val set : 'a t -> 'a -> (unit, 'f field) Types.As_prover.t
+    val set : 'a t -> 'a -> (unit, 'f field) As_prover0.t
 
     val typ : ('a t, 'a, 'f field) Types.Typ.t
   end
@@ -35,9 +31,9 @@ module type Extended = sig
     S
       with module Types := Types
       with type 'f field := field
-       and type ('a, 'f) t := ('a, 'f) Types.As_prover.t
+       and type ('a, 'f) t := ('a, 'f) As_prover0.t
 
-  type 'a t = ('a, field) Types.As_prover.t
+  type 'a t = ('a, field) As_prover0.t
 end
 
 module Make_ref_typ (Checked : Monad_let.S2) : sig
@@ -47,8 +43,7 @@ end
 module Make
     (Checked : Checked_intf.S)
     (As_prover : Basic
-                   with type ('a, 'f) t := ('a, 'f) Checked.Types.As_prover.t
-                    and type 'f field := 'f Checked.field
+                   with type 'f field := 'f Checked.field
                     and type ('a, 'f) Provider.t =
                      ('a, 'f) Checked.Types.Provider.t) :
   S with module Types = Checked.Types with type 'f field = 'f Checked.field

--- a/src/base/as_prover_intf.ml
+++ b/src/base/as_prover_intf.ml
@@ -1,5 +1,5 @@
 module type Basic = sig
-  type ('a, 'f) t
+  type ('a, 'f) t = ('a, 'f) As_prover0.t
 
   type 'f field
 

--- a/src/base/checked.ml
+++ b/src/base/checked.ml
@@ -2,9 +2,7 @@ open Core_kernel
 
 module Make
     (Basic : Checked_intf.Basic)
-    (As_prover : As_prover_intf.Basic
-                   with type ('a, 'f) t = ('a, 'f) Basic.Types.As_prover.t
-                    and type 'f field := 'f Basic.field) :
+    (As_prover : As_prover_intf.Basic with type 'f field := 'f Basic.field) :
   Checked_intf.S
     with module Types = Basic.Types
     with type 'f field = 'f Basic.field = struct

--- a/src/base/checked_ast.ml
+++ b/src/base/checked_ast.ml
@@ -91,10 +91,6 @@ module Types = struct
     type ('a, 'f) t = ('a, 'f) Checked0.t
   end
 
-  module As_prover = struct
-    type ('a, 'f) t = ('a, 'f) As_prover0.t
-  end
-
   module Typ = struct
     include Types.Typ.T
 

--- a/src/base/checked_intf.ml
+++ b/src/base/checked_intf.ml
@@ -10,7 +10,7 @@ module type Basic = sig
   val add_constraint :
     ('f field Cvar.t, 'f field) Constraint.t -> (unit, 'f field) t
 
-  val as_prover : (unit, 'f field) Types.As_prover.t -> (unit, 'f field) t
+  val as_prover : (unit, 'f field) As_prover0.t -> (unit, 'f field) t
 
   val mk_lazy : (unit -> ('a, 'f) t) -> ('a Lazy.t, 'f) t
 
@@ -45,13 +45,13 @@ module type S = sig
 
   include Monad_let.S2 with type ('a, 'f) t := ('a, 'f) t
 
-  val as_prover : (unit, 'f field) Types.As_prover.t -> (unit, 'f field) t
+  val as_prover : (unit, 'f field) As_prover0.t -> (unit, 'f field) t
 
   val mk_lazy : (unit -> ('a, 'f) t) -> ('a Lazy.t, 'f) t
 
   val request_witness :
        ('var, 'value, 'f field) Types.Typ.t
-    -> ('value Request.t, 'f field) Types.As_prover.t
+    -> ('value Request.t, 'f field) As_prover0.t
     -> ('var, 'f field) t
 
   val request :
@@ -61,14 +61,14 @@ module type S = sig
     -> ('var, 'f field) t
 
   val exists_handle :
-       ?request:('value Request.t, 'f field) Types.As_prover.t
-    -> ?compute:('value, 'f field) Types.As_prover.t
+       ?request:('value Request.t, 'f field) As_prover0.t
+    -> ?compute:('value, 'f field) As_prover0.t
     -> ('var, 'value, 'f field) Types.Typ.t
     -> (('var, 'value) Handle.t, 'f field) t
 
   val exists :
-       ?request:('value Request.t, 'f field) Types.As_prover.t
-    -> ?compute:('value, 'f field) Types.As_prover.t
+       ?request:('value Request.t, 'f field) As_prover0.t
+    -> ?compute:('value, 'f field) As_prover0.t
     -> ('var, 'value, 'f field) Types.Typ.t
     -> ('var, 'f field) t
 
@@ -86,7 +86,7 @@ module type S = sig
 
   val handle_as_prover :
        (unit -> ('a, 'f field) t)
-    -> (request -> response, 'f field) Types.As_prover.t
+    -> (request -> response, 'f field) As_prover0.t
     -> ('a, 'f field) t
 
   val next_auxiliary : unit -> (int, 'f field) t

--- a/src/base/checked_runner.ml
+++ b/src/base/checked_runner.ml
@@ -332,7 +332,7 @@ module type Run_extras = sig
   val get_value : field Run_state.t -> cvar -> field
 
   val run_as_prover :
-       ('a, field) Types.As_prover.t option
+       ('a, field) As_prover0.t option
     -> field Run_state.t
     -> field Run_state.t * 'a option
 end

--- a/src/base/types.ml
+++ b/src/base/types.ml
@@ -69,10 +69,6 @@ module type Types = sig
     type ('a, 'f) t
   end
 
-  module As_prover : sig
-    type ('a, 'f) t
-  end
-
   module Typ : sig
     include module type of Typ.T
 


### PR DESCRIPTION
builds on top of https://github.com/o1-labs/snarky/pull/686

I'm hoping that this change will help me fully removing checked_ast