### PR TITLE
move assert_equals to checked

### DIFF
--- a/src/base/snark0.ml
+++ b/src/base/snark0.ml
@@ -635,7 +635,7 @@ module Make (Backend : Backend_intf.S) = struct
   module Backend_extended = Backend_extended.Make (Backend)
   module Runner0 = Runner.Make (Backend_extended)
   module Checked_runner = Runner0.Checked_runner
-  module Checked1 = Checked.Make (Checked_runner) (As_prover0)
+  module Checked1 = Checked.Make (Backend.Field) (Checked_runner) (As_prover0)
 
   module Field_T = struct
     type field = Backend_extended.Field.t

--- a/src/base/utils.ml
+++ b/src/base/utils.ml
@@ -37,15 +37,6 @@ struct
         with module Types := Checked.Types
         with type field := field )
 
-  let assert_equal ?label x y =
-    match (x, y) with
-    | Cvar0.Constant x, Cvar0.Constant y ->
-        if Field.equal x y then Checked.return ()
-        else
-          failwithf !"assert_equal: %{sexp: Field.t} != %{sexp: Field.t}" x y ()
-    | _ ->
-        Checked.assert_equal ?label x y
-
   (* [equal_constraints z z_inv r] asserts that
      if z = 0 then r = 1, or
      if z <> 0 then r = 0 and z * z_inv = 1


### PR DESCRIPTION
to fix a bug I mention in the comment here https://github.com/o1-labs/snarky/pull/752#issuecomment-1376600672 

I'll copy/paste the issue:

## The issue

running into some error, that can be reproduce from mina by doing:

```
make snarkyjs
cd src/lib/snarky_js_bindings/test_module 
npm i
node simple-zkapp-mock-apply.js
```

the issue is an `assert_equals` function that does not handle constant variables correctly.

The reason is that it's using what's in `checked.ml` (which is "impure" as it adds a constraint):

```ocaml
  let assert_ ?label c = add_constraint (Constraint.override_label c label)
  
  let assert_equal ?label x y = assert_ (Constraint.equal ?label x y)
```

whereas we want to use the wrapper that's introduced in `utils.ml` (which handles the constant correctly, and keep the logic "pure"):

```ocaml
  let assert_equal ?label x y =
    match (x, y) with
    | Cvar0.Constant x, Cvar0.Constant y ->
        if Field.equal x y then Checked.return ()
        else
          failwithf !"assert_equal: %{sexp: Field.t} != %{sexp: Field.t}" x y ()
    | _ ->
        Checked.assert_equal ?label x y
```

## The solution

I just moved the correct logic to `checked.ml` 

## It works

the following test runs without issue now!

```console
make snarkyjs
cd src/lib/snarky_js_bindings/test_module 
npm i
node simple-zkapp-mock-apply.js
```

<img width="682" alt="Screenshot 2023-01-09 at 6 42 47 PM" src="https://user-images.githubusercontent.com/1316043/211449820-2b8bf35c-34ef-488c-a90c-aedeaffa5c45.png">
