### PR TITLE
fix imperative interface handling of global state

### DIFF
--- a/src/base/run_state.ml
+++ b/src/base/run_state.ml
@@ -71,6 +71,13 @@ let make ~num_inputs ~input ~next_auxiliary ~aux ?system ~eval_constraints
   ; log_constraint
   }
 
+let dump (t : _ t) =
+  Format.sprintf
+    "state { is_running: %B; as_prover: %B; has_witness: %B; eval_constraints: \
+     %B; num_inputs: %d; next_auxiliary: %d }\n"
+    t.is_running !(t.as_prover) t.has_witness t.eval_constraints t.num_inputs
+    !(t.next_auxiliary)
+
 let get_variable_value { num_inputs; input; aux; _ } : int -> 'field =
  fun i ->
   if i <= num_inputs then Vector.get input (i - 1)

--- a/src/base/run_state.mli
+++ b/src/base/run_state.mli
@@ -35,6 +35,9 @@ val make :
   -> unit
   -> 'field t
 
+(** dumps some information about a state [t] *)
+val dump : 'field t -> string
+
 val get_variable_value : 'field t -> int -> 'field
 
 val store_field_elt : 'field t -> 'field -> 'field Cvar.t

--- a/src/base/snark0.ml
+++ b/src/base/snark0.ml
@@ -708,6 +708,8 @@ module Run = struct
            ~eval_constraints:false ~num_inputs:0 ~next_auxiliary:(ref 1)
            ~with_witness:false ~stack:[] ~is_running:false () )
 
+    let dump () = Run_state.dump !state
+
     let in_prover () : bool = Run_state.has_witness !state
 
     let in_checked_computation () : bool =

--- a/src/base/snark0.ml
+++ b/src/base/snark0.ml
@@ -1253,9 +1253,13 @@ module Run = struct
       let inject_wrapper ~f x = f x in
       inject_wrapper ~f (x a)
 
+    (** Caches the global [state] before running [f]. 
+        It is expected that [f] will reset the global state for its own use only, 
+        hence why we need to reset it after running [f].*)
     let finalize_is_running f =
+      let cached_state = !state in
       let x = f () in
-      state := Run_state.set_is_running !state false ;
+      state := cached_state ;
       x
 
     let constraint_system ~input_typ ~return_typ x : R1CS_constraint_system.t =

--- a/src/base/snark0.ml
+++ b/src/base/snark0.ml
@@ -396,10 +396,10 @@ struct
         let not_equal (x : t) (y : t) =
           match (x, y) with
           | Constant x, Constant y ->
-            if Field.(equal x y) then
-              failwithf "not_equal: failed on constants %s and %s"
-                (Field.to_string x) (Field.to_string y) () ;
-            Checked.return ()
+              if Field.(equal x y) then
+                failwithf "not_equal: failed on constants %s and %s"
+                  (Field.to_string x) (Field.to_string y) () ;
+              Checked.return ()
           | _, _ ->
               Checked.with_label "Checked.Assert.not_equal" (fun () ->
                   non_zero (sub x y) )

--- a/src/base/snark0.ml
+++ b/src/base/snark0.ml
@@ -1275,7 +1275,17 @@ module Run = struct
         hence why we need to reset it after running [f].*)
     let finalize_is_running f =
       let cached_state = !state in
-      let x = f () in
+      let x =
+        match f () with
+        | exception e ->
+            (* Warning: it is important to clean the global state before reraising the exception.
+               Imagine if a user of snarky catches exceptions instead of letting the program panic,
+                then the next usage of snarky might be messed up. *)
+            state := cached_state ;
+            raise e
+        | x ->
+            x
+      in
       state := cached_state ;
       x
 

--- a/src/base/snark_intf.ml
+++ b/src/base/snark_intf.ml
@@ -1095,6 +1095,8 @@ end
 
 (** The imperative interface to Snarky. *)
 module type Run_basic = sig
+  val dump : unit -> string
+
   (** The rank-1 constraint system used by this instance. See
       {!module:Backend_intf.S.R1CS_constraint_system}. *)
   module R1CS_constraint_system : sig


### PR DESCRIPTION
this fixes a number of issues detected by the tests in https://github.com/MinaProtocol/mina/pull/12627. More specifically:

* make sure that the global state is reset between API calls
* make sure that API calls that raise exceptions clean the state
* make utility functions handle pure functions gracefully