### PR TITLE
[part1] Generalize Typ.t over Cvar.t

### DIFF
--- a/src/base/as_prover0.ml
+++ b/src/base/as_prover0.ml
@@ -29,8 +29,8 @@ let read_var (v : 'var) : ('field, 'field) t = fun tbl -> tbl v
 
 let read
     (Typ { var_to_fields; value_of_fields; _ } :
-      ('var, 'value, 'field, _) Types.Typ.t ) (var : 'var) : ('value, 'field) t
-    =
+      ('var, 'value, 'field, 'field_var, _) Types.Typ.t ) (var : 'var) :
+    ('value, 'field) t =
  fun tbl ->
   let field_vars, aux = var_to_fields var in
   let fields = Array.map ~f:tbl field_vars in

--- a/src/base/as_prover0.ml
+++ b/src/base/as_prover0.ml
@@ -84,15 +84,24 @@ end
 module type Extended = sig
   type field
 
-  include As_prover_intf.Basic with type 'f field := field
+  type field_var
+
+  include
+    As_prover_intf.Basic
+      with type 'f field := field
+       and type 'f field_var := field_var
 
   type nonrec 'a t = ('a, field) t
 end
 
 module Make_extended (Env : sig
   type field
+
+  type field_var
 end)
-(As_prover : As_prover_intf.Basic with type 'f field := Env.field) =
+(As_prover : As_prover_intf.Basic
+               with type 'f field := Env.field
+                and type 'f field_var := Env.field_var) =
 struct
   include Env
   include As_prover

--- a/src/base/as_prover_intf.ml
+++ b/src/base/as_prover_intf.ml
@@ -3,9 +3,11 @@ module type Basic = sig
 
   type 'f field
 
+  type 'f field_var
+
   include Monad_let.S2 with type ('a, 'f) t := ('a, 'f field) t
 
-  val run : ('a, 'f field) t -> ('f field Cvar.t -> 'f field) -> 'a
+  val run : ('a, 'f field) t -> ('f field_var -> 'f field) -> 'a
 
   val map2 :
        ('a, 'f field) t
@@ -13,10 +15,10 @@ module type Basic = sig
     -> f:('a -> 'b -> 'c)
     -> ('c, 'f field) t
 
-  val read_var : 'f field Cvar.t -> ('f field, 'f field) t
+  val read_var : 'f field_var -> ('f field, 'f field) t
 
   val read :
-       ('var, 'value, 'f field, 'f field Cvar.t, _) Types.Typ.t
+       ('var, 'value, 'f field, 'f field_var, _) Types.Typ.t
     -> 'var
     -> ('value, 'f field) t
 
@@ -26,7 +28,7 @@ module type Basic = sig
     val run :
          ('a, 'f field) t
       -> string list
-      -> ('f field Cvar.t -> 'f field)
+      -> ('f field_var -> 'f field)
       -> Request.Handler.t
       -> 'a
   end

--- a/src/base/as_prover_intf.ml
+++ b/src/base/as_prover_intf.ml
@@ -16,7 +16,9 @@ module type Basic = sig
   val read_var : 'f field Cvar.t -> ('f field, 'f field) t
 
   val read :
-    ('var, 'value, 'f field, _) Types.Typ.t -> 'var -> ('value, 'f field) t
+       ('var, 'value, 'f field, 'f field Cvar.t, _) Types.Typ.t
+    -> 'var
+    -> ('value, 'f field) t
 
   module Provider : sig
     type ('a, 'f) t

--- a/src/base/as_prover_ref.ml
+++ b/src/base/as_prover_ref.ml
@@ -3,7 +3,7 @@ open Core_kernel
 type 'a t = 'a option ref
 
 module Make_ref_typ (Checked : Monad_let.S2) = struct
-  let typ : ('a t, 'a, _, _) Types.Typ.t =
+  let typ : ('a t, 'a, _, _, _) Types.Typ.t =
     Typ
       { var_to_fields = (fun x -> ([||], !x))
       ; var_of_fields = (fun (_, x) -> ref x)

--- a/src/base/as_prover_ref.ml
+++ b/src/base/as_prover_ref.ml
@@ -35,6 +35,7 @@ module Make
     (Checked : Checked_intf.S)
     (As_prover : As_prover_intf.Basic
                    with type 'f field := 'f Checked.field
+                    and type 'f field_var := 'f Checked.field_var
                     and type ('a, 'f) Provider.t =
                      ('a, 'f) Checked.Types.Provider.t) :
   S

--- a/src/base/checked.ml
+++ b/src/base/checked.ml
@@ -8,7 +8,9 @@ end)
 (Basic : Checked_intf.Basic
            with type 'f field = Field.t
             and type 'f field_var = Field.t Cvar.t)
-(As_prover : As_prover_intf.Basic with type 'f field := 'f Basic.field) :
+(As_prover : As_prover_intf.Basic
+               with type 'f field := 'f Basic.field
+                and type 'f field_var := 'f Basic.field_var) :
   Checked_intf.S
     with module Types = Basic.Types
     with type 'f field = 'f Basic.field

--- a/src/base/checked.ml
+++ b/src/base/checked.ml
@@ -5,15 +5,17 @@ module Make (Field : sig
 
   val equal : t -> t -> bool
 end)
-(Basic : Checked_intf.Basic with type 'f field = Field.t)
+(Basic : Checked_intf.Basic
+           with type 'f field = Field.t
+            and type 'f field_var = Field.t Cvar.t)
 (As_prover : As_prover_intf.Basic with type 'f field := 'f Basic.field) :
   Checked_intf.S
     with module Types = Basic.Types
-    with type 'f field = 'f Basic.field = struct
+    with type 'f field = 'f Basic.field
+     and type 'f field_var = 'f Basic.field_var = struct
   include Basic
 
-  let request_witness
-      (typ : ('var, 'value, 'f field, 'f field Cvar.t) Types.Typ.t)
+  let request_witness (typ : ('var, 'value, 'f field, 'f field_var) Types.Typ.t)
       (r : ('value Request.t, 'f field) As_prover.t) =
     let%map h = exists typ (Request r) in
     Handle.var h

--- a/src/base/checked.ml
+++ b/src/base/checked.ml
@@ -12,7 +12,8 @@ end)
     with type 'f field = 'f Basic.field = struct
   include Basic
 
-  let request_witness (typ : ('var, 'value, 'f field) Types.Typ.t)
+  let request_witness
+      (typ : ('var, 'value, 'f field, 'f field Cvar.t) Types.Typ.t)
       (r : ('value Request.t, 'f field) As_prover.t) =
     let%map h = exists typ (Request r) in
     Handle.var h

--- a/src/base/checked_intf.ml
+++ b/src/base/checked_intf.ml
@@ -20,7 +20,7 @@ module type Basic = sig
     Request.Handler.single -> (unit -> ('a, 'f field) t) -> ('a, 'f field) t
 
   val exists :
-       ('var, 'value, 'f field) Types.Typ.t
+       ('var, 'value, 'f field, 'f field Cvar.t) Types.Typ.t
     -> ('value, 'f field) Types.Provider.t
     -> (('var, 'value) Handle.t, 'f field) t
 
@@ -50,26 +50,26 @@ module type S = sig
   val mk_lazy : (unit -> ('a, 'f) t) -> ('a Lazy.t, 'f) t
 
   val request_witness :
-       ('var, 'value, 'f field) Types.Typ.t
+       ('var, 'value, 'f field, 'f field Cvar.t) Types.Typ.t
     -> ('value Request.t, 'f field) As_prover0.t
     -> ('var, 'f field) t
 
   val request :
        ?such_that:('var -> (unit, 'f field) t)
-    -> ('var, 'value, 'f field) Types.Typ.t
+    -> ('var, 'value, 'f field, 'f field Cvar.t) Types.Typ.t
     -> 'value Request.t
     -> ('var, 'f field) t
 
   val exists_handle :
        ?request:('value Request.t, 'f field) As_prover0.t
     -> ?compute:('value, 'f field) As_prover0.t
-    -> ('var, 'value, 'f field) Types.Typ.t
+    -> ('var, 'value, 'f field, 'f field Cvar.t) Types.Typ.t
     -> (('var, 'value) Handle.t, 'f field) t
 
   val exists :
        ?request:('value Request.t, 'f field) As_prover0.t
     -> ?compute:('value, 'f field) As_prover0.t
-    -> ('var, 'value, 'f field) Types.Typ.t
+    -> ('var, 'value, 'f field, 'f field Cvar.t) Types.Typ.t
     -> ('var, 'f field) t
 
   type response = Request.response

--- a/src/base/checked_runner.ml
+++ b/src/base/checked_runner.ml
@@ -18,7 +18,8 @@ module Simple = struct
     module Typ = struct
       include Types.Typ.T
 
-      type ('var, 'value, 'f) t = ('var, 'value, 'f, (unit, 'f) Checked.t) typ
+      type ('var, 'value, 'f, 'field_var) t =
+        ('var, 'value, 'f, 'field_var, (unit, 'f) Checked.t) typ
     end
 
     module Provider = struct
@@ -80,7 +81,8 @@ struct
     module Typ = struct
       include Types.Typ.T
 
-      type ('var, 'value, 'f) t = ('var, 'value, 'f, (unit, 'f) Checked.t) typ
+      type ('var, 'value, 'f, 'field_var) t =
+        ('var, 'value, 'f, 'field_var, (unit, 'f) Checked.t) typ
     end
 
     module Provider = struct
@@ -248,7 +250,7 @@ struct
          ; constraint_system_auxiliary
          ; _
          } :
-        (_, _, _, _ Simple.t) Types.Typ.typ ) p : _ Simple.t =
+        (_, _, _, _, _ Simple.t) Types.Typ.typ ) p : _ Simple.t =
     Function
       (fun s ->
         if Run_state.has_witness s then (

--- a/src/base/checked_runner.ml
+++ b/src/base/checked_runner.ml
@@ -69,7 +69,9 @@ end
 
 module Make_checked
     (Backend : Backend_extended.S)
-    (As_prover : As_prover_intf.Basic with type 'f field := Backend.Field.t) =
+    (As_prover : As_prover_intf.Basic
+                   with type 'f field := Backend.Field.t
+                    and type 'f field_var := Backend.Cvar.t) =
 struct
   type run_state = Backend.Field.t Run_state.t
 

--- a/src/base/checked_runner.ml
+++ b/src/base/checked_runner.ml
@@ -95,6 +95,8 @@ struct
 
   type 'f field = Backend.Field.t
 
+  type 'f field_var = Backend.Cvar.t
+
   include Types.Checked
 
   let eval : ('a, 'f) t -> run_state -> run_state * 'a = Simple.eval
@@ -356,6 +358,7 @@ module Make (Backend : Backend_extended.S) = struct
           Checked_intf.Basic
             with module Types := Checked_runner.Types
             with type 'f field := 'f Checked_runner.field
+             and type 'f field_var := 'f Checked_runner.field_var
 
         include
           Run_extras

--- a/src/base/runners.ml
+++ b/src/base/runners.ml
@@ -6,7 +6,9 @@ module Make
     (Checked : Checked_intf.Extended
                  with type field = Backend.Field.t
                   and type field_var = Backend.Cvar.t)
-    (As_prover : As_prover0.Extended with type field := Backend.Field.t)
+    (As_prover : As_prover0.Extended
+                   with type field := Backend.Field.t
+                    and type field_var := Backend.Cvar.t)
     (Runner : Checked_runner.S
                 with module Types := Checked.Types
                 with type field := Backend.Field.t

--- a/src/base/runners.ml
+++ b/src/base/runners.ml
@@ -3,7 +3,9 @@ module Types0 = Types
 
 module Make
     (Backend : Backend_extended.S)
-    (Checked : Checked_intf.Extended with type field = Backend.Field.t)
+    (Checked : Checked_intf.Extended
+                 with type field = Backend.Field.t
+                  and type field_var = Backend.Cvar.t)
     (As_prover : As_prover0.Extended with type field := Backend.Field.t)
     (Runner : Checked_runner.S
                 with module Types := Checked.Types

--- a/src/base/runners.ml
+++ b/src/base/runners.ml
@@ -174,6 +174,7 @@ struct
              ( input_var
              , input_value
              , field
+             , Cvar.t
              , (unit, field) Checked.Types.Checked.t )
              Types.Typ.typ
         -> return_typ:_ Types.Typ.t
@@ -208,9 +209,10 @@ struct
              ( input_var
              , input_value
              , field
+             , Cvar.t
              , (unit, field) Checked.Types.Checked.t )
              Types.Typ.typ
-        -> return_typ:(a, retval, _, _) Types.Typ.t
+        -> return_typ:(a, retval, field, Cvar.t, _) Types.Typ.t
         -> (input_var -> checked)
         -> R1CS_constraint_system.t =
      fun ~run next_input ~input_typ ~return_typ k ->
@@ -228,7 +230,7 @@ struct
 
     let constraint_system (type a checked input_var) :
            run:(a, checked) Runner.run
-        -> input_typ:(input_var, _, _, _) Types.Typ.typ
+        -> input_typ:(input_var, _, _, _, _) Types.Typ.typ
         -> return_typ:_
         -> (input_var -> checked)
         -> R1CS_constraint_system.t =
@@ -236,7 +238,7 @@ struct
       r1cs_h ~run (ref 1) ~input_typ ~return_typ k
 
     let generate_public_input :
-           ('input_var, 'input_value, _, _) Types.Typ.typ
+           ('input_var, 'input_value, _, _, _) Types.Typ.typ
         -> 'input_value
         -> Field.Vector.t =
      fun (Typ { value_to_fields; _ }) value ->
@@ -250,7 +252,7 @@ struct
     let conv :
         type r_var r_value.
            (int -> _ -> r_var -> Field.Vector.t -> r_value)
-        -> ('input_var, 'input_value, _, _) Types.Typ.t
+        -> ('input_var, 'input_value, _, _, _) Types.Typ.t
         -> _ Types.Typ.t
         -> (unit -> 'input_var -> r_var)
         -> 'input_value
@@ -280,7 +282,7 @@ struct
     let generate_auxiliary_input :
            run:('a, 'checked) Runner.run
         -> input_typ:_ Types.Typ.t
-        -> return_typ:(_, _, _, _) Types.Typ.t
+        -> return_typ:(_, _, _, _, _) Types.Typ.t
         -> ?handlers:Handler.t list
         -> 'k_var
         -> 'k_value =

--- a/src/base/snark0.ml
+++ b/src/base/snark0.ml
@@ -10,7 +10,9 @@ let set_eval_constraints b = Runner.eval_constraints := b
 
 module Make_basic
     (Backend : Backend_extended.S)
-    (Checked : Checked_intf.Extended with type field = Backend.Field.t)
+    (Checked : Checked_intf.Extended
+                 with type field = Backend.Field.t
+                  and type field_var = Backend.Cvar.t)
     (As_prover : As_prover0.Extended with type field := Backend.Field.t)
     (Ref : As_prover_ref.S
              with module Types := Checked.Types
@@ -71,7 +73,8 @@ struct
       Checked :
         Checked_intf.Extended
           with module Types := Checked.Types
-          with type field := field )
+          with type field := field
+           and type field_var := Cvar.t )
 
     let perform req = request_witness Typ.unit req
 
@@ -671,9 +674,12 @@ module Make (Backend : Backend_intf.S) = struct
         Checked_intf.S
           with module Types = Checked1.Types
           with type ('a, 'f) t := ('a, 'f) Checked1.t
-           and type 'f field := Backend_extended.Field.t )
+           and type 'f field := Backend_extended.Field.t
+           and type 'f field_var := Backend_extended.Cvar.t )
 
     type field = Backend_extended.Field.t
+
+    type field_var = Backend_extended.Cvar.t
 
     type 'a t = ('a, field) Types.Checked.t
 

--- a/src/base/snark0.ml
+++ b/src/base/snark0.ml
@@ -13,7 +13,9 @@ module Make_basic
     (Checked : Checked_intf.Extended
                  with type field = Backend.Field.t
                   and type field_var = Backend.Cvar.t)
-    (As_prover : As_prover0.Extended with type field := Backend.Field.t)
+    (As_prover : As_prover0.Extended
+                   with type field := Backend.Field.t
+                    and type field_var = Backend.Cvar.t)
     (Ref : As_prover_ref.S
              with module Types := Checked.Types
               and type 'f field := Backend.Field.t
@@ -657,6 +659,8 @@ module Make (Backend : Backend_intf.S) = struct
 
   module Field_T = struct
     type field = Backend_extended.Field.t
+
+    type field_var = Backend_extended.Cvar.t
   end
 
   module As_prover_ext = As_prover0.Make_extended (Field_T) (As_prover0)

--- a/src/base/snark0.ml
+++ b/src/base/snark0.ml
@@ -40,7 +40,7 @@ struct
     module T = Typ.Make (Checked_S)
     include T.T
 
-    type ('var, 'value) t = ('var, 'value, Field.t) T.t
+    type ('var, 'value) t = ('var, 'value, Field.t, Cvar.t) T.t
 
     let unit : (unit, unit) t = unit ()
 

--- a/src/base/snark0.ml
+++ b/src/base/snark0.ml
@@ -1418,10 +1418,7 @@ module Run = struct
   end
 end
 
-type 'field m =
-  (module Snark_intf.Run
-     with type field = 'field
-      and type field_var = 'field Cvar.t )
+type 'field m = (module Snark_intf.Run_with_cvar with type field = 'field)
 
 let make (type field) (module Backend : Backend_intf.S with type Field.t = field)
     : field m =

--- a/src/base/snark0.ml
+++ b/src/base/snark0.ml
@@ -35,6 +35,8 @@ struct
   module Cvar = Cvar
   module Constraint = Constraint
 
+  type field_var = Cvar.t
+
   module Handler = struct
     type t = Request.request -> Request.response
   end
@@ -772,6 +774,8 @@ module Run = struct
 
     type field = Snark.field
 
+    type field_var = Snark.field_var
+
     module Bigint = Snark.Bigint
     module Constraint = Snark.Constraint
 
@@ -1414,7 +1418,10 @@ module Run = struct
   end
 end
 
-type 'field m = (module Snark_intf.Run with type field = 'field)
+type 'field m =
+  (module Snark_intf.Run
+     with type field = 'field
+      and type field_var = 'field Cvar.t )
 
 let make (type field) (module Backend : Backend_intf.S with type Field.t = field)
     : field m =

--- a/src/base/snark0.mli
+++ b/src/base/snark0.mli
@@ -22,6 +22,7 @@ exception Runtime_error of string list * exn * string
 module Make (Backend : Backend_intf.S) :
   Snark_intf.S
     with type field = Backend.Field.t
+     and type field_var = Backend.Field.t Cvar.t
      and type Bigint.t = Backend.Bigint.t
      and type R1CS_constraint_system.t = Backend.R1CS_constraint_system.t
      and type Field.Vector.t = Backend.Field.Vector.t
@@ -30,11 +31,15 @@ module Run : sig
   module Make (Backend : Backend_intf.S) :
     Snark_intf.Run
       with type field = Backend.Field.t
+       and type field_var = Backend.Field.t Cvar.t
        and type Bigint.t = Backend.Bigint.t
        and type R1CS_constraint_system.t = Backend.R1CS_constraint_system.t
        and type Field.Constant.Vector.t = Backend.Field.Vector.t
 end
 
-type 'field m = (module Snark_intf.Run with type field = 'field)
+type 'field m =
+  (module Snark_intf.Run
+     with type field = 'field
+      and type field_var = 'field Cvar.t )
 
 val make : (module Backend_intf.S with type Field.t = 'field) -> 'field m

--- a/src/base/snark0.mli
+++ b/src/base/snark0.mli
@@ -37,9 +37,6 @@ module Run : sig
        and type Field.Constant.Vector.t = Backend.Field.Vector.t
 end
 
-type 'field m =
-  (module Snark_intf.Run
-     with type field = 'field
-      and type field_var = 'field Cvar.t )
+type 'field m = (module Snark_intf.Run_with_cvar with type field = 'field)
 
 val make : (module Backend_intf.S with type Field.t = 'field) -> 'field m

--- a/src/base/snark_intf.ml
+++ b/src/base/snark_intf.ml
@@ -309,7 +309,7 @@ module type Field_var_intf = sig
   type boolean_var
 
   (** The type that stores booleans as R1CS variables. *)
-  type t = field Cvar.t
+  type t
 
   (** For debug purposes *)
   val length : t -> int
@@ -553,6 +553,8 @@ module type Basic = sig
   (** The finite field over which the R1CS operates. *)
   type field
 
+  type field_var
+
   (** The rank-1 constraint system used by this instance. See
       {!module:Backend_intf.S.R1CS_constraint_system}. *)
   module R1CS_constraint_system : sig
@@ -698,6 +700,7 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
     module Var :
       Field_var_intf
         with type field := field
+         and type t = field_var
          and type boolean_var := Boolean.var
 
     module Checked :
@@ -1120,6 +1123,8 @@ module type Run_basic = sig
   (** The finite field over which the R1CS operates. *)
   type field
 
+  type field_var
+
   module Bigint : sig
     include Snarky_intf.Bigint_intf.Extended with type field := field
 
@@ -1192,6 +1197,7 @@ module type Run_basic = sig
     include
       Field_var_intf
         with type field := field
+         and type t = field_var
          and type boolean_var := Boolean.var
 
     include
@@ -1266,6 +1272,7 @@ module type Run_basic = sig
   and Internal_Basic :
     (Basic
       with type field = field
+       and type field_var = field_var
        and type 'a Checked.t = ('a, field) Checked_runner.Simple.t
        and type 'a As_prover.Ref.t = 'a As_prover_ref.t)
 

--- a/src/base/snark_intf.ml
+++ b/src/base/snark_intf.ml
@@ -1104,6 +1104,12 @@ module type S = sig
        and type t := M.t
 end
 
+module type S_with_cvar = sig
+  type field
+
+  include S with type field := field and type field_var = field Cvar.t
+end
+
 (** The imperative interface to Snarky. *)
 module type Run_basic = sig
   val dump : unit -> string
@@ -1456,4 +1462,10 @@ module type Run = sig
        and type bool_var := Boolean.var
        and type var = Field.t
        and type t := M.t
+end
+
+module type Run_with_cvar = sig
+  type field
+
+  include Run with type field := field and type field_var = field Cvar.t
 end

--- a/src/base/snark_intf.ml
+++ b/src/base/snark_intf.ml
@@ -150,7 +150,8 @@ module type Typ_intf = sig
           example, that a [Boolean.t] is either a {!val:Field.zero} or a
           {!val:Field.one}.
     *)
-  type ('var, 'value) t = ('var, 'value, field, checked_unit) Types.Typ.t
+  type ('var, 'value) t =
+    ('var, 'value, field, field_var, checked_unit) Types.Typ.t
 
   (** Basic instances: *)
 
@@ -585,7 +586,14 @@ module type Basic = sig
          and type checked_unit := unit Checked.t
          and type _ checked := unit Checked.t
          and type ('a, 'b, 'c, 'd) data_spec :=
-          ('a, 'b, 'c, 'd, field, unit Checked.t) Typ0.Data_spec0.data_spec
+          ( 'a
+          , 'b
+          , 'c
+          , 'd
+          , field
+          , Field.Var.t
+          , unit Checked.t )
+          Typ0.Data_spec0.data_spec
          and type 'a prover_ref := 'a As_prover_ref.t
 
     include module type of Types.Typ.T
@@ -1139,6 +1147,7 @@ module type Run_basic = sig
         , 'c
         , 'd
         , field
+        , Field.t
         , unit Internal_Basic.Checked.t )
         Typ0.Data_spec0.data_spec
        and type 'a prover_ref := 'a As_prover_ref.t)

--- a/src/base/types.ml
+++ b/src/base/types.ml
@@ -43,9 +43,9 @@ module Typ = struct
     let or (x : t) = Snark.Boolean.(x.b1 || x.b2)
   end
 ]}*)
-    type ('var, 'value, 'aux, 'field, 'checked) typ' =
-      { var_to_fields : 'var -> 'field Cvar.t array * 'aux
-      ; var_of_fields : 'field Cvar.t array * 'aux -> 'var
+    type ('var, 'value, 'aux, 'field, 'field_var, 'checked) typ' =
+      { var_to_fields : 'var -> 'field_var array * 'aux
+      ; var_of_fields : 'field_var array * 'aux -> 'var
       ; value_to_fields : 'value -> 'field array * 'aux
       ; value_of_fields : 'field array * 'aux -> 'value
       ; size_in_field_elements : int
@@ -53,15 +53,16 @@ module Typ = struct
       ; check : 'var -> 'checked
       }
 
-    type ('var, 'value, 'field, 'checked) typ =
+    type ('var, 'value, 'field, 'field_var, 'checked) typ =
       | Typ :
-          ('var, 'value, 'aux, 'field, 'checked) typ'
-          -> ('var, 'value, 'field, 'checked) typ
+          ('var, 'value, 'aux, 'field, 'field_var, 'checked) typ'
+          -> ('var, 'value, 'field, 'field_var, 'checked) typ
   end
 
   include T
 
-  type ('var, 'value, 'field, 'checked) t = ('var, 'value, 'field, 'checked) typ
+  type ('var, 'value, 'field, 'field_var, 'checked) t =
+    ('var, 'value, 'field, 'field_var, 'checked) typ
 end
 
 module type Types = sig
@@ -72,7 +73,8 @@ module type Types = sig
   module Typ : sig
     include module type of Typ.T
 
-    type ('var, 'value, 'f) t = ('var, 'value, 'f, (unit, 'f) Checked.t) Typ.t
+    type ('var, 'value, 'f, 'field_var) t =
+      ('var, 'value, 'f, 'field_var, (unit, 'f) Checked.t) Typ.t
   end
 
   module Provider : sig

--- a/src/base/utils.ml
+++ b/src/base/utils.ml
@@ -9,7 +9,9 @@ module Make
     (Checked : Checked_intf.Extended
                  with type field = Backend.Field.t
                   and type field_var = Backend.Cvar.t)
-    (As_prover : As_prover0.Extended with type field := Backend.Field.t)
+    (As_prover : As_prover0.Extended
+                   with type field := Backend.Field.t
+                    and type field_var := Backend.Cvar.t)
     (Runner : Runner.S
                 with module Types := Checked.Types
                 with type field := Backend.Field.t

--- a/src/base/utils.ml
+++ b/src/base/utils.ml
@@ -24,7 +24,7 @@ struct
     module T = Typ.Make (Checked_intf.Unextend (Checked))
     include T.T
 
-    type ('var, 'value) t = ('var, 'value, Field.t) T.t
+    type ('var, 'value) t = ('var, 'value, Field.t, Cvar.t) T.t
 
     let unit : (unit, unit) t = unit ()
 

--- a/src/base/utils.ml
+++ b/src/base/utils.ml
@@ -6,7 +6,9 @@ let set_eval_constraints b = Runner.eval_constraints := b
 
 module Make
     (Backend : Backend_extended.S)
-    (Checked : Checked_intf.Extended with type field = Backend.Field.t)
+    (Checked : Checked_intf.Extended
+                 with type field = Backend.Field.t
+                  and type field_var = Backend.Cvar.t)
     (As_prover : As_prover0.Extended with type field := Backend.Field.t)
     (Runner : Runner.S
                 with module Types := Checked.Types
@@ -35,7 +37,8 @@ struct
     Checked :
       Checked_intf.Extended
         with module Types := Checked.Types
-        with type field := field )
+        with type field := field
+         and type field_var := Cvar.t )
 
   (* [equal_constraints z z_inv r] asserts that
      if z = 0 then r = 1, or

--- a/src/base/utils.mli
+++ b/src/base/utils.mli
@@ -5,7 +5,9 @@ val set_eval_constraints : bool -> unit
 
 module Make : functor
   (Backend : Backend_extended.S)
-  (Checked : Checked_intf.Extended with type field = Backend.Field.t)
+  (Checked : Checked_intf.Extended
+               with type field = Backend.Field.t
+                and type field_var = Backend.Cvar.t)
   (As_prover : As_prover0.Extended with type field := Backend.Field.t)
   (Runner : Runner.S
               with module Types := Checked.Types

--- a/src/base/utils.mli
+++ b/src/base/utils.mli
@@ -26,10 +26,10 @@ module Make : functor
     -> (Checked.field Cvar0.t, Checked.field) Checked.Types.Checked.t
 
   module Typ2 : sig
-    type ('var, 'value, 'aux, 'field, 'checked) typ' =
-          ('var, 'value, 'aux, 'field, 'checked) Types.Typ.typ' =
-      { var_to_fields : 'var -> 'field Cvar0.t array * 'aux
-      ; var_of_fields : 'field Cvar0.t array * 'aux -> 'var
+    type ('var, 'value, 'aux, 'field, 'field_var, 'checked) typ' =
+          ('var, 'value, 'aux, 'field, 'field_var, 'checked) Types.Typ.typ' =
+      { var_to_fields : 'var -> 'field_var array * 'aux
+      ; var_of_fields : 'field_var array * 'aux -> 'var
       ; value_to_fields : 'value -> 'field array * 'aux
       ; value_of_fields : 'field array * 'aux -> 'value
       ; size_in_field_elements : int
@@ -37,22 +37,24 @@ module Make : functor
       ; check : 'var -> 'checked
       }
 
-    type ('var, 'value, 'field, 'checked) typ =
-          ('var, 'value, 'field, 'checked) Types.Typ.typ =
+    type ('var, 'value, 'field, 'field_var, 'checked) typ =
+          ('var, 'value, 'field, 'field_var, 'checked) Types.Typ.typ =
       | Typ :
-          ('var, 'value, 'aux, 'field, 'checked) typ'
-          -> ('var, 'value, 'field, 'checked) typ
+          ('var, 'value, 'aux, 'field, 'field_var, 'checked) typ'
+          -> ('var, 'value, 'field, 'field_var, 'checked) typ
 
     module T : sig
-      type ('var, 'value, 'field) t =
+      type ('var, 'value, 'field, 'field_var) t =
         ( 'var
         , 'value
         , 'field
+        , 'field_var
         , (unit, 'field) Snarky_backendless__.Checked_intf.Unextend(Checked).t
         )
         typ
 
-      type ('var, 'value, 'field) typ = ('var, 'value, 'field) t
+      type ('var, 'value, 'field, 'field_var) typ =
+        ('var, 'value, 'field, 'field_var) t
 
       module type S = sig
         type field
@@ -84,10 +86,11 @@ module Make : functor
         end
       end
 
-      val unit : unit -> (unit, unit, 'field) t
+      val unit : unit -> (unit, unit, 'field, 'field_var) t
     end
 
-    type ('var, 'value) t = ('var, 'value, Checked.field) T.t
+    type ('var, 'value) t =
+      ('var, 'value, Checked.field, Checked.field Cvar.t) T.t
 
     val unit : (unit, unit) t
   end

--- a/src/base/utils.mli
+++ b/src/base/utils.mli
@@ -8,7 +8,9 @@ module Make : functor
   (Checked : Checked_intf.Extended
                with type field = Backend.Field.t
                 and type field_var = Backend.Cvar.t)
-  (As_prover : As_prover0.Extended with type field := Backend.Field.t)
+  (As_prover : As_prover0.Extended
+                 with type field := Backend.Field.t
+                  and type field_var := Backend.Cvar.t)
   (Runner : Runner.S
               with module Types := Checked.Types
               with type field := Backend.Field.t


### PR DESCRIPTION
This PR generalizes `Typ.t` over `Cvar.t`, by adding a type parameter.

This also makes some tweaks to the functors and module types to make it easier to port this to Mina.