### PR TITLE
[part4] Changes to snarky to make snarky-rs integration work

### DIFF
--- a/src/base/backend_extended.ml
+++ b/src/base/backend_extended.ml
@@ -27,11 +27,7 @@ module type S = sig
       with module Field := Field
        and type cvar := Cvar.t
 
-  module Run_state :
-    State.S
-      with module Field := Field
-       and type cvar := Cvar.t
-       and type constraint_system := R1CS_constraint_system.t
+  module Run_state : State.S with module Field := Field and type cvar := Cvar.t
 
   module Constraint : sig
     type t = (Cvar.t, Field.t) Constraint.t [@@deriving sexp]

--- a/src/base/backend_extended.ml
+++ b/src/base/backend_extended.ml
@@ -22,7 +22,7 @@ module type S = sig
 
   module Cvar : Backend_intf.Cvar_intf with type field := Field.t
 
-  module R1CS_constraint_system :
+  module Constraint_system :
     Backend_intf.Constraint_system_intf
       with module Field := Field
        and type cvar := Cvar.t
@@ -31,7 +31,7 @@ module type S = sig
     State.S
       with module Field := Field
        and type cvar := Cvar.t
-       and type constraint_system := R1CS_constraint_system.t
+       and type constraint_system := Constraint_system.t
 
   module Constraint : sig
     type t = (Cvar.t, Field.t) Constraint.t [@@deriving sexp]
@@ -61,8 +61,7 @@ module Make (Backend : Backend_intf.S) :
      and type Cvar.t = Backend.Cvar.t
      and type Field.Vector.t = Backend.Field.Vector.t
      and type Bigint.t = Backend.Bigint.t
-     and type R1CS_constraint_system.t = Backend.R1CS_constraint_system.t =
-struct
+     and type Constraint_system.t = Backend.Constraint_system.t = struct
   open Backend
 
   module Bigint = struct
@@ -187,7 +186,6 @@ struct
     let eval { basic; _ } get_value = Constraint.Basic.eval m get_value basic
   end
 
-  module R1CS_constraint_system = R1CS_constraint_system
-  module Run_state =
-    State.Make (Cvar) (Field) (R1CS_constraint_system) (Run_state)
+  module Constraint_system = Constraint_system
+  module Run_state = State.Make (Cvar) (Field) (Constraint_system) (Run_state)
 end

--- a/src/base/backend_extended.ml
+++ b/src/base/backend_extended.ml
@@ -28,7 +28,7 @@ module type S = sig
        and type cvar := Cvar.t
 
   module Run_state :
-    Backend_intf.Run_state_intf
+    State.S
       with module Field := Field
        and type cvar := Cvar.t
        and type constraint_system := R1CS_constraint_system.t
@@ -61,8 +61,8 @@ module Make (Backend : Backend_intf.S) :
      and type Cvar.t = Backend.Cvar.t
      and type Field.Vector.t = Backend.Field.Vector.t
      and type Bigint.t = Backend.Bigint.t
-     and type R1CS_constraint_system.t = Backend.R1CS_constraint_system.t
-     and type Run_state.t = Backend.Run_state.t = struct
+     and type R1CS_constraint_system.t = Backend.R1CS_constraint_system.t =
+struct
   open Backend
 
   module Bigint = struct
@@ -188,5 +188,6 @@ module Make (Backend : Backend_intf.S) :
   end
 
   module R1CS_constraint_system = R1CS_constraint_system
-  module Run_state = Run_state
+  module Run_state =
+    State.Make (Cvar) (Field) (R1CS_constraint_system) (Run_state)
 end

--- a/src/base/backend_extended.ml
+++ b/src/base/backend_extended.ml
@@ -27,7 +27,11 @@ module type S = sig
       with module Field := Field
        and type cvar := Cvar.t
 
-  module Run_state : State.S with module Field := Field and type cvar := Cvar.t
+  module Run_state :
+    State.S
+      with module Field := Field
+       and type cvar := Cvar.t
+       and type constraint_system := R1CS_constraint_system.t
 
   module Constraint : sig
     type t = (Cvar.t, Field.t) Constraint.t [@@deriving sexp]

--- a/src/base/backend_intf.ml
+++ b/src/base/backend_intf.ml
@@ -67,9 +67,7 @@ module type Run_state_intf = sig
 
   type constraint_system
 
-  val make : int -> bool -> t
-
-  val make_system : int -> bool -> t
+  val make : int -> bool -> bool -> t
 
   val add_constraint :
     ?label:string -> t -> (cvar, Field.t) Constraint.basic -> unit

--- a/src/base/backend_intf.ml
+++ b/src/base/backend_intf.ml
@@ -15,6 +15,8 @@ module type Constraint_system_intf = sig
 
   val digest : t -> Md5.t
 
+  val to_json : t -> string
+
   val set_primary_input_size : t -> int -> unit
 
   val get_primary_input_size : t -> int

--- a/src/base/backend_intf.ml
+++ b/src/base/backend_intf.ml
@@ -104,12 +104,12 @@ module type S = sig
 
   val field_size : Bigint.t
 
-  module R1CS_constraint_system :
+  module Constraint_system :
     Constraint_system_intf with module Field := Field and type cvar := Cvar.t
 
   module Run_state :
     Run_state_intf
       with module Field := Field
        and type cvar := Cvar.t
-       and type constraint_system := R1CS_constraint_system.t
+       and type constraint_system := Constraint_system.t
 end

--- a/src/base/backend_intf.ml
+++ b/src/base/backend_intf.ml
@@ -76,7 +76,7 @@ module type Run_state_intf = sig
 
   val store_field_elt : t -> Field.t -> cvar
 
-  val alloc_var : t -> unit -> cvar
+  val alloc_var : t -> cvar
 
   val has_witness : t -> bool
 

--- a/src/base/backend_intf.ml
+++ b/src/base/backend_intf.ml
@@ -88,6 +88,8 @@ module type Run_state_intf = sig
 
   val system : t -> constraint_system option
 
+  val finalize : t -> unit
+
   val next_auxiliary : t -> int
 end
 

--- a/src/base/backend_intf.ml
+++ b/src/base/backend_intf.ml
@@ -96,8 +96,6 @@ module type Run_state_intf = sig
 
   val eval_constraints : t -> bool
 
-  val system : t -> constraint_system option
-
   val next_auxiliary : t -> int
 end
 

--- a/src/base/backend_intf.ml
+++ b/src/base/backend_intf.ml
@@ -13,9 +13,6 @@ module type Constraint_system_intf = sig
 
   val finalize : t -> unit
 
-  val add_constraint :
-    ?label:string -> t -> (cvar, Field.t) Constraint.basic -> unit
-
   val digest : t -> Md5.t
 
   val set_primary_input_size : t -> int -> unit
@@ -81,6 +78,9 @@ module type Run_state_intf = sig
     -> as_prover:bool
     -> unit
     -> t
+
+  val add_constraint :
+    t -> string option -> (cvar, Field.t) Constraint.basic -> unit
 
   val get_variable_value : t -> int -> Field.t
 

--- a/src/base/backend_intf.ml
+++ b/src/base/backend_intf.ml
@@ -70,7 +70,7 @@ module type Run_state_intf = sig
   val make_system : int -> Field.Vector.t -> Field.Vector.t -> bool -> bool -> t
 
   val add_constraint :
-    t -> string option -> (cvar, Field.t) Constraint.basic -> unit
+    ?label:string -> t -> (cvar, Field.t) Constraint.basic -> unit
 
   val get_variable_value : t -> int -> Field.t
 

--- a/src/base/backend_intf.ml
+++ b/src/base/backend_intf.ml
@@ -32,8 +32,6 @@ module type Cvar_intf = sig
 
   type field
 
-  val length : t -> int
-
   module Unsafe : sig
     val of_index : int -> t
   end
@@ -41,8 +39,6 @@ module type Cvar_intf = sig
   val eval : [ `Return_values_will_be_mutated of int -> field ] -> t -> field
 
   val constant : field -> t
-
-  val to_constant_and_terms : t -> field option * (field * int) list
 
   val add : t -> t -> t
 
@@ -61,8 +57,6 @@ module type Cvar_intf = sig
   val ( - ) : t -> t -> t
 
   val ( * ) : field -> t -> t
-
-  val var_indices : t -> int list
 
   val to_constant : t -> field option
 end

--- a/src/base/backend_intf.ml
+++ b/src/base/backend_intf.ml
@@ -48,8 +48,6 @@ module type Cvar_intf = sig
 
   val sub : t -> t -> t
 
-  val linear_combination : (field * t) list -> t
-
   val sum : t list -> t
 
   val ( + ) : t -> t -> t

--- a/src/base/backend_intf.ml
+++ b/src/base/backend_intf.ml
@@ -86,6 +86,8 @@ module type Run_state_intf = sig
 
   val eval_constraints : t -> bool
 
+  val system : t -> constraint_system option
+
   val next_auxiliary : t -> int
 end
 

--- a/src/base/backend_intf.ml
+++ b/src/base/backend_intf.ml
@@ -48,8 +48,6 @@ module type Cvar_intf = sig
 
   val sub : t -> t -> t
 
-  val sum : t list -> t
-
   val ( + ) : t -> t -> t
 
   val ( - ) : t -> t -> t

--- a/src/base/backend_intf.ml
+++ b/src/base/backend_intf.ml
@@ -67,9 +67,9 @@ module type Run_state_intf = sig
 
   type constraint_system
 
-  val make : int -> bool -> bool -> t
+  val make : int -> bool -> t
 
-  val make_system : int -> bool -> bool -> t
+  val make_system : int -> bool -> t
 
   val add_constraint :
     ?label:string -> t -> (cvar, Field.t) Constraint.basic -> unit

--- a/src/base/backend_intf.ml
+++ b/src/base/backend_intf.ml
@@ -22,7 +22,7 @@ module type Constraint_system_intf = sig
 
   val set_auxiliary_input_size : t -> int -> unit
 
-  val get_public_input_size : t -> int Core_kernel.Set_once.t
+  val get_primary_input_size : t -> int
 
   val get_rows_len : t -> int
 end

--- a/src/base/backend_intf.ml
+++ b/src/base/backend_intf.ml
@@ -67,9 +67,9 @@ module type Run_state_intf = sig
 
   type constraint_system
 
-  val make : int -> Field.Vector.t -> Field.Vector.t -> bool -> bool -> t
+  val make : int -> bool -> bool -> t
 
-  val make_system : int -> Field.Vector.t -> Field.Vector.t -> bool -> bool -> t
+  val make_system : int -> bool -> bool -> t
 
   val add_constraint :
     ?label:string -> t -> (cvar, Field.t) Constraint.basic -> unit

--- a/src/base/backend_intf.ml
+++ b/src/base/backend_intf.ml
@@ -95,6 +95,8 @@ module type Run_state_intf = sig
   val finalize : t -> unit
 
   val next_auxiliary : t -> int
+
+  val seal : t -> cvar -> cvar
 end
 
 module type S = sig

--- a/src/base/backend_intf.ml
+++ b/src/base/backend_intf.ml
@@ -17,8 +17,6 @@ module type Constraint_system_intf = sig
 
   val set_primary_input_size : t -> int -> unit
 
-  val set_auxiliary_input_size : t -> int -> unit
-
   val get_primary_input_size : t -> int
 
   val get_rows_len : t -> int
@@ -67,17 +65,9 @@ module type Run_state_intf = sig
 
   type constraint_system
 
-  val make :
-       num_inputs:int
-    -> input:Field.Vector.t
-    -> next_auxiliary:int ref
-    -> aux:Field.Vector.t
-    -> system:constraint_system option
-    -> eval_constraints:bool
-    -> with_witness:bool
-    -> as_prover:bool
-    -> unit
-    -> t
+  val make : int -> Field.Vector.t -> Field.Vector.t -> bool -> bool -> t
+
+  val make_system : int -> Field.Vector.t -> Field.Vector.t -> bool -> bool -> t
 
   val add_constraint :
     t -> string option -> (cvar, Field.t) Constraint.basic -> unit

--- a/src/base/backend_intf.ml
+++ b/src/base/backend_intf.ml
@@ -75,21 +75,12 @@ module type Run_state_intf = sig
     -> input:Field.Vector.t
     -> next_auxiliary:int ref
     -> aux:Field.Vector.t
-    -> ?system:constraint_system
+    -> system:constraint_system option
     -> eval_constraints:bool
-    -> ?log_constraint:
-         (   ?at_label_boundary:[ `End | `Start ] * string
-          -> (cvar, 'field) Constraint.t option
-          -> unit )
-    -> ?handler:Request.Handler.t
     -> with_witness:bool
-    -> ?stack:string list
-    -> ?is_running:bool
+    -> as_prover:bool
     -> unit
     -> t
-
-  (** dumps some information about a state [t] *)
-  val dump : t -> string
 
   val get_variable_value : t -> int -> Field.t
 
@@ -103,28 +94,9 @@ module type Run_state_intf = sig
 
   val set_as_prover : t -> bool -> unit
 
-  val stack : t -> string list
-
-  val set_stack : t -> string list -> t
-
-  val log_constraint :
-       t
-    -> (   ?at_label_boundary:[ `Start | `End ] * string
-        -> (cvar, Field.t) Constraint.t option
-        -> unit )
-       option
-
   val eval_constraints : t -> bool
 
   val system : t -> constraint_system option
-
-  val handler : t -> Request.Handler.t
-
-  val set_handler : t -> Request.Handler.t -> t
-
-  val is_running : t -> bool
-
-  val set_is_running : t -> bool -> t
 
   val next_auxiliary : t -> int
 end

--- a/src/base/backend_intf.ml
+++ b/src/base/backend_intf.ml
@@ -82,6 +82,10 @@ module type Run_state_intf = sig
 
   val has_witness : t -> bool
 
+  val set_public_inputs : t -> Field.Vector.t -> unit
+
+  val get_private_inputs : t -> Field.Vector.t
+
   val as_prover : t -> bool
 
   val set_as_prover : t -> bool -> unit

--- a/src/base/checked_intf.ml
+++ b/src/base/checked_intf.ml
@@ -21,6 +21,8 @@ module type Basic = sig
 
   val with_label : string -> (unit -> ('a, 'run_state) t) -> ('a, 'run_state) t
 
+  val seal : 'f field_var -> ('f field_var, 'run_state) t
+
   val with_handler :
     Request.Handler.single -> (unit -> ('a, 'run_state) t) -> ('a, 'run_state) t
 
@@ -74,6 +76,8 @@ module type S = sig
     -> ?compute:('value, 'f field, 'f field_var) As_prover0.t
     -> ('var, 'value, 'f field, 'f field_var, 'run_state) Types.Typ.t
     -> (('var, 'value) Handle.t, 'run_state) t
+
+  val seal : 'f field_var -> ('f field_var, 'run_state) t
 
   val exists :
        ?request:('value Request.t, 'f field, 'f field_var) As_prover0.t

--- a/src/base/checked_runner.ml
+++ b/src/base/checked_runner.ml
@@ -315,8 +315,7 @@ struct
       count := !count + Option.value_map ~default:0 ~f:weight c
     in
     let state =
-      Run_state.make ~num_inputs:0 ~input:(Field.Vector.create ())
-        ~aux:(Field.Vector.create ()) ~system:false ~eval_constraints:false
+      Run_state.make ~num_inputs:0 ~system:false ~eval_constraints:false
         ~log_constraint ~with_witness:false ()
     in
     let _ = Simple.eval (t ()) state in
@@ -382,8 +381,6 @@ module Make (Backend : Backend_extended.S) = struct
   module State = struct
     let make :
            num_inputs:int
-        -> input:Field.Vector.t
-        -> aux:Field.Vector.t
         -> system:bool
         -> ?eval_constraints:bool
         -> ?handler:Request.Handler.t
@@ -394,9 +391,8 @@ module Make (Backend : Backend_extended.S) = struct
               -> unit )
         -> unit
         -> run_state =
-     fun ~num_inputs ~input ~aux ~system
-         ?(eval_constraints = !eval_constraints_ref) ?handler ~with_witness
-         ?log_constraint () ->
+     fun ~num_inputs ~system ?(eval_constraints = !eval_constraints_ref)
+         ?handler ~with_witness ?log_constraint () ->
       let log_constraint =
         match log_constraint with
         | Some _ ->
@@ -407,8 +403,8 @@ module Make (Backend : Backend_extended.S) = struct
       (* We can't evaluate the constraints if we are not computing over a value. *)
       let eval_constraints = eval_constraints && with_witness in
 
-      Run_state.make ~num_inputs ~input ~aux ~system ~eval_constraints
-        ?log_constraint ?handler ~with_witness ()
+      Run_state.make ~num_inputs ~system ~eval_constraints ?log_constraint
+        ?handler ~with_witness ()
   end
 end
 
@@ -433,8 +429,6 @@ module type S = sig
   module State : sig
     val make :
          num_inputs:int
-      -> input:field_vector
-      -> aux:field_vector
       -> system:bool
       -> ?eval_constraints:bool
       -> ?handler:Request.Handler.t

--- a/src/base/checked_runner.ml
+++ b/src/base/checked_runner.ml
@@ -379,11 +379,6 @@ module Make (Backend : Backend_extended.S) = struct
 
   let run = Simple.eval
 
-  let fake_state next_auxiliary stack =
-    Run_state.make ~num_inputs:0 ~input:(Field.Vector.create ()) ~next_auxiliary
-      ~aux:(Field.Vector.create ()) ~eval_constraints:false ~stack
-      ~with_witness:false ()
-
   module State = struct
     let make :
            num_inputs:int

--- a/src/base/checked_runner.ml
+++ b/src/base/checked_runner.ml
@@ -316,7 +316,7 @@ struct
     in
     let state =
       Run_state.make ~num_inputs:0 ~system:false ~eval_constraints:false
-        ~log_constraint ~with_witness:false ()
+        ~log_constraint ()
     in
     let _ = Simple.eval (t ()) state in
     !count
@@ -384,7 +384,6 @@ module Make (Backend : Backend_extended.S) = struct
         -> system:bool
         -> ?eval_constraints:bool
         -> ?handler:Request.Handler.t
-        -> with_witness:bool
         -> ?log_constraint:
              (   ?at_label_boundary:[ `End | `Start ] * string
               -> Constraint.t option
@@ -392,7 +391,7 @@ module Make (Backend : Backend_extended.S) = struct
         -> unit
         -> run_state =
      fun ~num_inputs ~system ?(eval_constraints = !eval_constraints_ref)
-         ?handler ~with_witness ?log_constraint () ->
+         ?handler ?log_constraint () ->
       let log_constraint =
         match log_constraint with
         | Some _ ->
@@ -400,11 +399,9 @@ module Make (Backend : Backend_extended.S) = struct
         | None ->
             !constraint_logger
       in
-      (* We can't evaluate the constraints if we are not computing over a value. *)
-      let eval_constraints = eval_constraints && with_witness in
 
       Run_state.make ~num_inputs ~system ~eval_constraints ?log_constraint
-        ?handler ~with_witness ()
+        ?handler ()
   end
 end
 
@@ -432,7 +429,6 @@ module type S = sig
       -> system:bool
       -> ?eval_constraints:bool
       -> ?handler:Request.Handler.t
-      -> with_witness:bool
       -> ?log_constraint:
            (   ?at_label_boundary:[ `End | `Start ] * string
             -> (cvar, field) Constraint.t option

--- a/src/base/checked_runner.ml
+++ b/src/base/checked_runner.ml
@@ -206,9 +206,9 @@ struct
           !"%{sexp:(Field.t, Field.t) Constraint0.basic}"
           (Constraint0.Basic.map basic ~f:(get_value s))
 
-  let add_constraint ~stack ({ basic; annotation } : Constraint.t) system =
+  let add_constraint ~stack ({ basic; annotation } : Constraint.t) state =
     let label = Option.value annotation ~default:"<unknown>" in
-    Backend.R1CS_constraint_system.add_constraint system basic
+    Run_state.add_constraint state basic
       ~label:(stack_to_string (label :: stack))
 
   let add_constraint c : _ Simple.t =
@@ -236,8 +236,7 @@ struct
               (Sexp.to_string (Constraint.sexp_of_t c))
               (log_constraint c s) () ;
           if not (Run_state.as_prover s) then
-            Option.iter (Run_state.system s) ~f:(fun system ->
-                add_constraint ~stack:(Run_state.stack s) c system ) ;
+            add_constraint ~stack:(Run_state.stack s) c s ;
           (s, ()) ) )
 
   let with_handler h t : _ Simple.t =

--- a/src/base/checked_runner.ml
+++ b/src/base/checked_runner.ml
@@ -316,8 +316,8 @@ struct
     in
     let state =
       Run_state.make ~num_inputs:0 ~input:(Field.Vector.create ())
-        ~aux:(Field.Vector.create ()) ~eval_constraints:false ~log_constraint
-        ~with_witness:false ()
+        ~aux:(Field.Vector.create ()) ~system:false ~eval_constraints:false
+        ~log_constraint ~with_witness:false ()
     in
     let _ = Simple.eval (t ()) state in
     !count

--- a/src/base/checked_runner.ml
+++ b/src/base/checked_runner.ml
@@ -301,6 +301,12 @@ struct
 
   let direct f : _ Simple.t = Function f
 
+  let seal var : _ Simple.t =
+    Function
+      (fun s ->
+        let sealed_var = Run_state.seal s var in
+        (s, sealed_var) )
+
   let constraint_count ?(weight = Fn.const 1)
       ?(log = fun ?start:_ _lab _pos -> ()) (t : unit -> _ Simple.t) =
     (* TODO: Integrate log with log_constraint *)

--- a/src/base/checked_runner.ml
+++ b/src/base/checked_runner.ml
@@ -289,7 +289,7 @@ struct
           let var =
             var_of_fields
               ( Array.init size_in_field_elements ~f:(fun _ ->
-                    Run_state.alloc_var s () )
+                    Run_state.alloc_var s )
               , constraint_system_auxiliary () )
           in
           (* TODO: Push a label onto the stack here *)

--- a/src/base/checked_runner.ml
+++ b/src/base/checked_runner.ml
@@ -316,8 +316,8 @@ struct
     in
     let state =
       Run_state.make ~num_inputs:0 ~input:(Field.Vector.create ())
-        ~next_auxiliary:(ref 1) ~aux:(Field.Vector.create ())
-        ~eval_constraints:false ~log_constraint ~with_witness:false ()
+        ~aux:(Field.Vector.create ()) ~eval_constraints:false ~log_constraint
+        ~with_witness:false ()
     in
     let _ = Simple.eval (t ()) state in
     !count
@@ -383,9 +383,8 @@ module Make (Backend : Backend_extended.S) = struct
     let make :
            num_inputs:int
         -> input:Field.Vector.t
-        -> next_auxiliary:int ref
         -> aux:Field.Vector.t
-        -> ?system:Backend.R1CS_constraint_system.t
+        -> system:bool
         -> ?eval_constraints:bool
         -> ?handler:Request.Handler.t
         -> with_witness:bool
@@ -395,7 +394,7 @@ module Make (Backend : Backend_extended.S) = struct
               -> unit )
         -> unit
         -> run_state =
-     fun ~num_inputs ~input ~next_auxiliary ~aux ?system
+     fun ~num_inputs ~input ~aux ~system
          ?(eval_constraints = !eval_constraints_ref) ?handler ~with_witness
          ?log_constraint () ->
       let log_constraint =
@@ -407,12 +406,9 @@ module Make (Backend : Backend_extended.S) = struct
       in
       (* We can't evaluate the constraints if we are not computing over a value. *)
       let eval_constraints = eval_constraints && with_witness in
-      Option.iter
-        (system : R1CS_constraint_system.t option)
-        ~f:(fun system ->
-          R1CS_constraint_system.set_primary_input_size system num_inputs ) ;
-      Run_state.make ~num_inputs ~input ~next_auxiliary ~aux ?system
-        ~eval_constraints ?log_constraint ?handler ~with_witness ()
+
+      Run_state.make ~num_inputs ~input ~aux ~system ~eval_constraints
+        ?log_constraint ?handler ~with_witness ()
   end
 end
 
@@ -438,9 +434,8 @@ module type S = sig
     val make :
          num_inputs:int
       -> input:field_vector
-      -> next_auxiliary:int ref
       -> aux:field_vector
-      -> ?system:r1cs
+      -> system:bool
       -> ?eval_constraints:bool
       -> ?handler:Request.Handler.t
       -> with_witness:bool

--- a/src/base/runners.ml
+++ b/src/base/runners.ml
@@ -161,12 +161,12 @@ struct
   let check ~run t = run_and_check' ~run t |> Result.map ~f:(Fn.const ())
 
   module Run = struct
-    let alloc_var next_input () =
+    let alloc_var next_input =
       let v = !next_input in
       incr next_input ; Cvar.Unsafe.of_index v
 
     let store_field_elt primary_input next_input x =
-      let v = alloc_var next_input () in
+      let v = alloc_var next_input in
       Field.Vector.emplace_back primary_input x ;
       v
 
@@ -193,7 +193,7 @@ struct
           } =
         var_of_fields
           ( Core_kernel.Array.init size_in_field_elements ~f:(fun _ ->
-                alloc_var next_input () )
+                alloc_var next_input )
           , constraint_system_auxiliary () )
       in
       let var = alloc_input input_typ in
@@ -277,7 +277,7 @@ struct
         let retval =
           return_typ.var_of_fields
             ( Core_kernel.Array.init return_typ.size_in_field_elements
-                ~f:(fun _ -> alloc_var next_input ())
+                ~f:(fun _ -> alloc_var next_input)
             , return_typ.constraint_system_auxiliary () )
         in
         cont0 !next_input retval (k0 () var) primary_input

--- a/src/base/runners.ml
+++ b/src/base/runners.ml
@@ -79,9 +79,7 @@ struct
     in
 
     (* create the state *)
-    let state =
-      Runner.State.make ~system:false ~num_inputs ~handler ~with_witness:true ()
-    in
+    let state = Runner.State.make ~system:false ~num_inputs ~handler () in
 
     (* set the public inputs *)
     Backend.Run_state.set_public_inputs state input ;
@@ -107,13 +105,16 @@ struct
     (aux, true_output)
 
   let run_and_check' ~run t0 =
+    (* TODO: why do we set the public inputs to 0? *)
     let num_inputs = 0 in
 
     (* create state *)
     let state =
-      Runner.State.make ~num_inputs ~system:true ~eval_constraints:true
-        ~with_witness:true ()
+      Runner.State.make ~num_inputs ~system:true ~eval_constraints:true ()
     in
+
+    (* set public input *)
+    Backend.Run_state.set_public_inputs state (Field.Vector.create ()) ;
 
     (* run the circuit with the state *)
     match run t0 state with
@@ -130,13 +131,16 @@ struct
         Ok (x, get_value)
 
   let run_and_check_deferred' ~map ~return ~run t0 =
+    (* TODO: why do we set the public inputs to 0? *)
     let num_inputs = 0 in
 
     (* create the state *)
     let state =
-      Runner.State.make ~num_inputs ~system:true ~eval_constraints:true
-        ~with_witness:true ()
+      Runner.State.make ~num_inputs ~system:true ~eval_constraints:true ()
     in
+
+    (* set the public input *)
+    Backend.Run_state.set_public_inputs state (Field.Vector.create ()) ;
 
     (* run the circuit *)
     match run t0 state with
@@ -153,10 +157,16 @@ struct
         map res ~f:(function _, x -> Ok (x, get_value))
 
   let run_unchecked ~run t0 =
+    (* TODO: why do we set public inputs to 0? *)
     let num_inputs = 0 in
-    let state =
-      Runner.State.make ~system:false ~num_inputs ~with_witness:true ()
-    in
+
+    (* create the state *)
+    let state = Runner.State.make ~system:false ~num_inputs () in
+
+    (* set the public inputs *)
+    Backend.Run_state.set_public_inputs state (Field.Vector.create ()) ;
+
+    (* run the circuit*)
     match run t0 state with _, x -> x
 
   let run_and_check ~run t =

--- a/src/base/runners.ml
+++ b/src/base/runners.ml
@@ -83,7 +83,7 @@ struct
       Runner.State.make ~system:false ~num_inputs ~handler ~with_witness:true ()
     in
 
-    (* set the private inputs *)
+    (* set the public inputs *)
     Backend.Run_state.set_public_inputs state input ;
 
     (* run t0 *)

--- a/src/base/runners.ml
+++ b/src/base/runners.ml
@@ -100,10 +100,6 @@ struct
       return_typ.var_of_fields (output, auxiliary_output_data)
     in
 
-    (* not sure why we're finalizing the system here, if we're not returning it... *)
-    Option.iter system ~f:(fun system ->
-        R1CS_constraint_system.finalize system ) ;
-
     (* return aux/true_output, but isn't aux empty here? *)
     (aux, true_output)
 

--- a/src/base/runners.ml
+++ b/src/base/runners.ml
@@ -104,8 +104,9 @@ struct
 
     (aux, true_output)
 
+  (** This function is useful to check a gadget/subcircuit. *)
   let run_and_check' ~run t0 =
-    (* TODO: why do we set the public inputs to 0? *)
+    (* gadgets don't have public inputs *)
     let num_inputs = 0 in
 
     (* create state *)
@@ -130,8 +131,9 @@ struct
 
         Ok (x, get_value)
 
+  (** This function is useful to check a gadget/subcircuit. *)
   let run_and_check_deferred' ~map ~return ~run t0 =
-    (* TODO: why do we set the public inputs to 0? *)
+    (* gadgets don't have public inputs *)
     let num_inputs = 0 in
 
     (* create the state *)
@@ -156,8 +158,9 @@ struct
 
         map res ~f:(function _, x -> Ok (x, get_value))
 
+  (** This function is useful to check a gadget/subcircuit without creating constraints. *)
   let run_unchecked ~run t0 =
-    (* TODO: why do we set public inputs to 0? *)
+    (* gadgets don't have public inputs *)
     let num_inputs = 0 in
 
     (* create the state *)

--- a/src/base/runners.ml
+++ b/src/base/runners.ml
@@ -67,8 +67,12 @@ struct
           fst @@ Checked.run (Checked.assert_equal res output) state )
     in
 
+    (* finalize the compilation *)
+    Backend.Run_state.finalize state ;
+
     (* return the constraint system *)
-    system
+    let sys = R1cs_constraint_system.system state in
+    sys
 
   let auxiliary_input ~run ~num_inputs ?(handlers = ([] : Handler.t list)) t0
       (input : Field.Vector.t) ~return_typ:(Types.Typ.Typ return_typ) ~output :

--- a/src/base/runners.ml
+++ b/src/base/runners.ml
@@ -16,7 +16,7 @@ module Make
                  and type field_vector := Backend.Field.Vector.t
                  and type cvar := Backend.Cvar.t
                  and type constr := Backend.Constraint.t option
-                 and type r1cs := Backend.R1CS_constraint_system.t
+                 and type r1cs := Backend.Constraint_system.t
                  and type run_state := Backend.Run_state.t) =
 struct
   open Backend
@@ -47,7 +47,7 @@ struct
 
   (* TODO-someday: Add pass to unify variables which have an Equal constraint *)
   let constraint_system ~run ~num_inputs ~return_typ:(Types.Typ.Typ return_typ)
-      output t : R1CS_constraint_system.t =
+      output t : Constraint_system.t =
     (* create the state *)
     let input = Field.Vector.create () in
     let aux = Field.Vector.create () in
@@ -217,7 +217,7 @@ struct
              Types.Typ.typ
         -> return_typ:(a, retval, field, Cvar.t, _) Types.Typ.t
         -> (input_var -> checked)
-        -> R1CS_constraint_system.t =
+        -> Constraint_system.t =
      fun ~run next_input ~input_typ ~return_typ k ->
       let retval, r =
         collect_input_constraints next_input ~input_typ ~return_typ (fun () ->
@@ -236,7 +236,7 @@ struct
         -> input_typ:(input_var, _, _, _, _) Types.Typ.typ
         -> return_typ:_
         -> (input_var -> checked)
-        -> R1CS_constraint_system.t =
+        -> Constraint_system.t =
      fun ~run ~input_typ ~return_typ k ->
       r1cs_h ~run (ref 1) ~input_typ ~return_typ k
 

--- a/src/base/runners.ml
+++ b/src/base/runners.ml
@@ -71,8 +71,8 @@ struct
     Backend.Run_state.finalize state ;
 
     (* return the constraint system *)
-    let sys = R1cs_constraint_system.system state in
-    sys
+    let sys = Backend.Run_state.system state in
+    Option.value_exn sys
 
   let auxiliary_input ~run ~num_inputs ?(handlers = ([] : Handler.t list)) t0
       (input : Field.Vector.t) ~return_typ:(Types.Typ.Typ return_typ) ~output :
@@ -111,14 +111,13 @@ struct
     let num_inputs = 0 in
     let input = Field.Vector.create () in
     let aux = Field.Vector.create () in
-    let system = R1CS_constraint_system.create () in
     let get_value : Cvar.t -> Field.t =
       let get_one v = Field.Vector.get aux (v - 1) in
       Cvar.eval (`Return_values_will_be_mutated get_one)
     in
     let state =
-      Runner.State.make ~num_inputs ~input ~aux ~system ~eval_constraints:true
-        ~with_witness:true ()
+      Runner.State.make ~num_inputs ~input ~aux ~system:true
+        ~eval_constraints:true ~with_witness:true ()
     in
     match run t0 state with
     | exception e ->
@@ -130,14 +129,13 @@ struct
     let num_inputs = 0 in
     let input = Field.Vector.create () in
     let aux = Field.Vector.create () in
-    let system = R1CS_constraint_system.create () in
     let get_value : Cvar.t -> Field.t =
       let get_one v = Field.Vector.get aux (v - 1) in
       Cvar.eval (`Return_values_will_be_mutated get_one)
     in
     let state =
-      Runner.State.make ~num_inputs ~input ~aux ~system ~eval_constraints:true
-        ~with_witness:true ()
+      Runner.State.make ~num_inputs ~input ~aux ~system:true
+        ~eval_constraints:true ~with_witness:true ()
     in
     match run t0 state with
     | exception e ->
@@ -150,7 +148,8 @@ struct
     let input = Field.Vector.create () in
     let aux = Field.Vector.create () in
     let state =
-      Runner.State.make ~num_inputs ~input ~aux ~with_witness:true ()
+      Runner.State.make ~system:false ~num_inputs ~input ~aux ~with_witness:true
+        ()
     in
     match run t0 state with _, x -> x
 

--- a/src/base/runners.ml
+++ b/src/base/runners.ml
@@ -49,9 +49,7 @@ struct
   let constraint_system ~run ~num_inputs ~return_typ:(Types.Typ.Typ return_typ)
       output t : Constraint_system.t =
     (* create the state *)
-    let state =
-      Runner.State.make ~num_inputs ~system:true ~with_witness:false ()
-    in
+    let state = Runner.State.make ~num_inputs ~system:true () in
 
     (* run the state *)
     let state, res = run t state in

--- a/src/base/snark0.ml
+++ b/src/base/snark0.ml
@@ -691,7 +691,7 @@ module Make (Backend : Backend_intf.S) = struct
 
     type run_state = Backend_extended.Run_state.t
 
-    type 'a t = ('a, Backend.Run_state.t) Types.Checked.t
+    type 'a t = ('a, Backend_extended.Run_state.t) Types.Checked.t
 
     let run = Runner0.run
   end
@@ -739,8 +739,6 @@ module Run = struct
            ~aux:(Backend.Field.Vector.create ())
            ~eval_constraints:false ~num_inputs:0 ~next_auxiliary:(ref 1)
            ~with_witness:false ~stack:[] ~is_running:false () )
-
-    let dump () = Run_state.dump !state
 
     let in_prover () : bool = Run_state.has_witness !state
 

--- a/src/base/snark0.ml
+++ b/src/base/snark0.ml
@@ -737,7 +737,7 @@ module Run = struct
     let state =
       ref
         (Run_state.make ~system:false ~eval_constraints:false ~num_inputs:0
-           ~with_witness:false ~stack:[] ~is_running:false () )
+           ~stack:[] ~is_running:false () )
 
     let in_prover () : bool = Run_state.has_witness !state
 
@@ -1391,7 +1391,7 @@ module Run = struct
       let old = !state in
       state :=
         Runner.State.make ~num_inputs:0 ~system:false ~eval_constraints:false
-          ~with_witness:false ~log_constraint () ;
+          ~log_constraint () ;
       ignore (mark_active ~f:x) ;
       state := old ;
       !count

--- a/src/base/snark0.ml
+++ b/src/base/snark0.ml
@@ -27,7 +27,7 @@ module Make_basic
                  and type field_vector := Backend.Field.Vector.t
                  and type cvar := Backend.Cvar.t
                  and type constr := Backend.Constraint.t option
-                 and type r1cs := Backend.R1CS_constraint_system.t
+                 and type r1cs := Backend.Constraint_system.t
                  and type run_state := Backend.Run_state.t) =
 struct
   open Backend
@@ -647,9 +647,7 @@ struct
       [%test_eq: a] checked_result (unchecked input)
   end
 
-  module R1CS_constraint_system = struct
-    include R1CS_constraint_system
-  end
+  module Constraint_system = Constraint_system
 end
 
 (** The main functor for the monadic interface. 
@@ -777,7 +775,7 @@ module Run = struct
       let g : Run_state.t -> Run_state.t * a = as_stateful f in
       Function g
 
-    module R1CS_constraint_system = Snark.R1CS_constraint_system
+    module Constraint_system = Snark.Constraint_system
 
     type field = Snark.field
 
@@ -1300,7 +1298,7 @@ module Run = struct
       state := cached_state ;
       x
 
-    let constraint_system ~input_typ ~return_typ x : R1CS_constraint_system.t =
+    let constraint_system ~input_typ ~return_typ x : Constraint_system.t =
       finalize_is_running (fun () ->
           let x = inject_wrapper x ~f:(fun x () -> mark_active ~f:x) in
           Perform.constraint_system ~run:as_stateful ~input_typ ~return_typ x )

--- a/src/base/snark0.ml
+++ b/src/base/snark0.ml
@@ -1207,6 +1207,8 @@ module Run = struct
 
     let next_auxiliary () = run (next_auxiliary ())
 
+    let seal field_var = run (seal field_var)
+
     let request_witness typ p =
       run (request_witness typ (As_prover.run_prover p))
 

--- a/src/base/snark0.ml
+++ b/src/base/snark0.ml
@@ -737,6 +737,7 @@ module Run = struct
         (Run_state.make
            ~input:(Backend.Field.Vector.create ())
            ~aux:(Backend.Field.Vector.create ())
+           ~system:false
            ~eval_constraints:false ~num_inputs:0 ~with_witness:false ~stack:[]
            ~is_running:false () )
 
@@ -1391,7 +1392,7 @@ module Run = struct
       (* TODO(mrmr1993): Enable label-level logging for the imperative API. *)
       let old = !state in
       state :=
-        Runner.State.make ~num_inputs:0
+        Runner.State.make ~num_inputs:0 ~system:false
           ~input:(Backend.Field.Vector.create ())
           ~aux:(Backend.Field.Vector.create ())
           ~eval_constraints:false ~with_witness:false ~log_constraint () ;

--- a/src/base/snark0.ml
+++ b/src/base/snark0.ml
@@ -1015,11 +1015,6 @@ module Run = struct
 
       type nonrec t = t
 
-      let length = length
-
-      let var_indices = var_indices
-
-      let to_constant_and_terms = to_constant_and_terms
 
       let constant = constant
 

--- a/src/base/snark0.ml
+++ b/src/base/snark0.ml
@@ -35,7 +35,6 @@ struct
   include Runners.Make (Backend) (Checked) (As_prover) (Runner)
   module Bigint = Bigint
   module Field0 = Field
-  module Cvar = Cvar
   module Constraint = Constraint
   module Run_state = Run_state
 

--- a/src/base/snark0.ml
+++ b/src/base/snark0.ml
@@ -110,7 +110,11 @@ struct
         List.fold_left bits ~init:([], Field.one) ~f:(fun (acc, c) v ->
             ((c, (v :> Cvar.t)) :: acc, Field.add c c) )
       in
-      Cvar.linear_combination ts
+      let linear_combination terms =
+        List.fold terms ~init:(Cvar.constant Field.zero) ~f:(fun acc (c, t) ->
+            Cvar.add acc (Cvar.scale t c) )
+      in
+      linear_combination ts
 
     let choose_preimage (v : Cvar.t) ~length : Boolean.var list t =
       let open Let_syntax in
@@ -1014,12 +1018,9 @@ module Run = struct
 
       type nonrec t = t
 
-
       let constant = constant
 
       let to_constant = to_constant
-
-      let linear_combination = linear_combination
 
       let sum = sum
 

--- a/src/base/snark0.ml
+++ b/src/base/snark0.ml
@@ -1022,8 +1022,6 @@ module Run = struct
 
       let to_constant = to_constant
 
-      let sum = sum
-
       let add = add
 
       let negate = negate

--- a/src/base/snark0.ml
+++ b/src/base/snark0.ml
@@ -40,6 +40,8 @@ struct
 
   type field_var = Cvar.t
 
+  type run_state = Run_state.t
+
   module Handler = struct
     type t = Request.request -> Request.response
   end
@@ -732,14 +734,15 @@ module Run = struct
 
     let this_functor_id = incr functor_counter ; !functor_counter
 
+    type run_state = Run_state.t
+
     let state =
       ref
         (Run_state.make
            ~input:(Backend.Field.Vector.create ())
            ~aux:(Backend.Field.Vector.create ())
-           ~system:false
-           ~eval_constraints:false ~num_inputs:0 ~with_witness:false ~stack:[]
-           ~is_running:false () )
+           ~system:false ~eval_constraints:false ~num_inputs:0
+           ~with_witness:false ~stack:[] ~is_running:false () )
 
     let in_prover () : bool = Run_state.has_witness !state
 

--- a/src/base/snark0.ml
+++ b/src/base/snark0.ml
@@ -736,10 +736,7 @@ module Run = struct
 
     let state =
       ref
-        (Run_state.make
-           ~input:(Backend.Field.Vector.create ())
-           ~aux:(Backend.Field.Vector.create ())
-           ~system:false ~eval_constraints:false ~num_inputs:0
+        (Run_state.make ~system:false ~eval_constraints:false ~num_inputs:0
            ~with_witness:false ~stack:[] ~is_running:false () )
 
     let in_prover () : bool = Run_state.has_witness !state
@@ -1393,10 +1390,8 @@ module Run = struct
       (* TODO(mrmr1993): Enable label-level logging for the imperative API. *)
       let old = !state in
       state :=
-        Runner.State.make ~num_inputs:0 ~system:false
-          ~input:(Backend.Field.Vector.create ())
-          ~aux:(Backend.Field.Vector.create ())
-          ~eval_constraints:false ~with_witness:false ~log_constraint () ;
+        Runner.State.make ~num_inputs:0 ~system:false ~eval_constraints:false
+          ~with_witness:false ~log_constraint () ;
       ignore (mark_active ~f:x) ;
       state := old ;
       !count

--- a/src/base/snark0.ml
+++ b/src/base/snark0.ml
@@ -737,8 +737,8 @@ module Run = struct
         (Run_state.make
            ~input:(Backend.Field.Vector.create ())
            ~aux:(Backend.Field.Vector.create ())
-           ~eval_constraints:false ~num_inputs:0 ~next_auxiliary:(ref 1)
-           ~with_witness:false ~stack:[] ~is_running:false () )
+           ~eval_constraints:false ~num_inputs:0 ~with_witness:false ~stack:[]
+           ~is_running:false () )
 
     let in_prover () : bool = Run_state.has_witness !state
 
@@ -1394,8 +1394,7 @@ module Run = struct
         Runner.State.make ~num_inputs:0
           ~input:(Backend.Field.Vector.create ())
           ~aux:(Backend.Field.Vector.create ())
-          ~next_auxiliary:(ref 1) ~eval_constraints:false ~with_witness:false
-          ~log_constraint () ;
+          ~eval_constraints:false ~with_witness:false ~log_constraint () ;
       ignore (mark_active ~f:x) ;
       state := old ;
       !count

--- a/src/base/snark0.mli
+++ b/src/base/snark0.mli
@@ -21,7 +21,6 @@ exception Runtime_error of string list * exn * string
 
 module Make (Backend : Backend_intf.S) :
   Snark_intf.S
-    with module Run_state = Backend.Run_state
     with type field = Backend.Field.t
      and type field_var = Backend.Cvar.t
      and type Bigint.t = Backend.Bigint.t

--- a/src/base/snark0.mli
+++ b/src/base/snark0.mli
@@ -24,7 +24,7 @@ module Make (Backend : Backend_intf.S) :
     with type field = Backend.Field.t
      and type field_var = Backend.Cvar.t
      and type Bigint.t = Backend.Bigint.t
-     and type R1CS_constraint_system.t = Backend.R1CS_constraint_system.t
+     and type Constraint_system.t = Backend.Constraint_system.t
      and type Field.Vector.t = Backend.Field.Vector.t
 
 module Run : sig
@@ -33,7 +33,7 @@ module Run : sig
       with type field = Backend.Field.t
        and type field_var = Backend.Cvar.t
        and type Bigint.t = Backend.Bigint.t
-       and type R1CS_constraint_system.t = Backend.R1CS_constraint_system.t
+       and type Constraint_system.t = Backend.Constraint_system.t
        and type Field.Constant.Vector.t = Backend.Field.Vector.t
 end
 

--- a/src/base/snark_intf.ml
+++ b/src/base/snark_intf.ml
@@ -853,6 +853,9 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
   (** Internal: read the value of the next unused auxiliary input index. *)
   val next_auxiliary : unit -> int Checked.t
 
+  (** Forces a reduction on a [Field.Var.t]. *)
+  val seal : Field.Var.t -> Field.Var.t Checked.t
+
   (** [request_witness typ create_request] runs the [create_request]
       {!type:As_prover.t} block to generate a {!type:Request.t}.
 
@@ -1314,6 +1317,8 @@ module type Run_basic = sig
   val as_prover : (unit -> unit) As_prover.t -> unit
 
   val next_auxiliary : unit -> int
+
+  val seal : Field.t -> Field.t
 
   val request_witness :
     ('var, 'value) Typ.t -> (unit -> 'value Request.t) As_prover.t -> 'var

--- a/src/base/snark_intf.ml
+++ b/src/base/snark_intf.ml
@@ -535,8 +535,8 @@ module type Basic = sig
   type run_state
 
   (** The rank-1 constraint system used by this instance. See
-      {!module:Backend_intf.S.R1CS_constraint_system}. *)
-  module R1CS_constraint_system : sig
+      {!module:Backend_intf.S.Constraint_system}. *)
+  module Constraint_system : sig
     type t
 
     val digest : t -> Md5.t
@@ -947,7 +947,7 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
        input_typ:('input_var, 'input_value) Typ.t
     -> return_typ:('a, _) Typ.t
     -> ('input_var -> 'a Checked.t)
-    -> R1CS_constraint_system.t
+    -> Constraint_system.t
 
   (** Internal: supplies arguments to a checked computation by storing them
       according to the {!type:Data_spec.t} and passing the R1CS versions.
@@ -1091,8 +1091,8 @@ module type Run_basic = sig
   type run_state
 
   (** The rank-1 constraint system used by this instance. See
-      {!module:Backend_intf.S.R1CS_constraint_system}. *)
-  module R1CS_constraint_system : sig
+      {!module:Backend_intf.S.Constraint_system}. *)
+  module Constraint_system : sig
     type t
 
     val digest : t -> Md5.t
@@ -1360,7 +1360,7 @@ module type Run_basic = sig
        input_typ:('input_var, 'input_value) Typ.t
     -> return_typ:('a, _) Typ.t
     -> ('input_var -> unit -> 'a)
-    -> R1CS_constraint_system.t
+    -> Constraint_system.t
 
   val generate_witness :
        input_typ:('input_var, 'input_value) Typ.t

--- a/src/base/snark_intf.ml
+++ b/src/base/snark_intf.ml
@@ -532,8 +532,7 @@ module type Basic = sig
 
   type field_var
 
-  (* TODO: Should this really be exposed? *)
-  module Run_state : T
+  type run_state
 
   (** The rank-1 constraint system used by this instance. See
       {!module:Backend_intf.S.R1CS_constraint_system}. *)
@@ -783,7 +782,7 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
 
   (** Utility functions for calling single checked computations. *)
   module Runner : sig
-    type state
+    type state = run_state
 
     val run : 'a Checked.t -> state -> state * 'a
   end
@@ -1089,6 +1088,8 @@ module type Run_basic = sig
 
   type field_var
 
+  type run_state
+
   (** The rank-1 constraint system used by this instance. See
       {!module:Backend_intf.S.R1CS_constraint_system}. *)
   module R1CS_constraint_system : sig
@@ -1246,7 +1247,7 @@ module type Run_basic = sig
   end
 
   and Internal_Basic : sig
-    type state
+    type state = run_state
 
     include
       Basic

--- a/src/base/snark_intf.ml
+++ b/src/base/snark_intf.ml
@@ -320,13 +320,6 @@ module type Field_var_intf = sig
       *)
   val to_constant : t -> field option
 
-  (** [linear_combination [(f1, x1);...;(fn, xn)]] returns the result of
-          calculating [f1 * x1 + f2 * x2 + ... + fn * xn].
-          This does not add a new constraint; see {!type:Constraint.t} for more
-          information.
-      *)
-  val linear_combination : (field * t) list -> t
-
   (** [sum l] returns the sum of all R1CS variables in [l].
 
           If the result would be greater than or equal to {!val:Field.size}

--- a/src/base/snark_intf.ml
+++ b/src/base/snark_intf.ml
@@ -320,13 +320,6 @@ module type Field_var_intf = sig
       *)
   val to_constant : t -> field option
 
-  (** [sum l] returns the sum of all R1CS variables in [l].
-
-          If the result would be greater than or equal to {!val:Field.size}
-          then the value will overflow to be less than {!val:Field.size}.
-      *)
-  val sum : t list -> t
-
   (** [add x y] returns the result of adding the R1CS variables [x] and
           [y].
 

--- a/src/base/snark_intf.ml
+++ b/src/base/snark_intf.ml
@@ -311,15 +311,6 @@ module type Field_var_intf = sig
   (** The type that stores booleans as R1CS variables. *)
   type t
 
-  (** For debug purposes *)
-  val length : t -> int
-
-  val var_indices : t -> int list
-
-  (** Convert a {!type:t} value to its constituent constant and a list of
-          scaled R1CS variables. *)
-  val to_constant_and_terms : t -> field option * (field * int) list
-
   (** [constant x] creates a new R1CS variable containing the constant
           field element [x]. *)
   val constant : field -> t
@@ -1109,6 +1100,11 @@ end
 module type Run_basic = sig
   val dump : unit -> string
 
+  (** The finite field over which the R1CS operates. *)
+  type field
+
+  type field_var
+
   (** The rank-1 constraint system used by this instance. See
       {!module:Backend_intf.S.R1CS_constraint_system}. *)
   module R1CS_constraint_system : sig
@@ -1120,11 +1116,6 @@ module type Run_basic = sig
 
     val get_rows_len : t -> int
   end
-
-  (** The finite field over which the R1CS operates. *)
-  type field
-
-  type field_var
 
   module Bigint : sig
     include Snarky_intf.Bigint_intf.Extended with type field := field

--- a/src/base/snark_intf.ml
+++ b/src/base/snark_intf.ml
@@ -1084,8 +1084,6 @@ end
 
 (** The imperative interface to Snarky. *)
 module type Run_basic = sig
-  val dump : unit -> string
-
   (** The finite field over which the R1CS operates. *)
   type field
 

--- a/src/base/snark_intf.ml
+++ b/src/base/snark_intf.ml
@@ -1098,7 +1098,7 @@ module type Run_basic = sig
 
     val digest : t -> Md5.t
 
-    val get_public_input_size : t -> int Core_kernel.Set_once.t
+    val get_primary_input_size : t -> int
 
     val get_rows_len : t -> int
   end

--- a/src/base/snark_intf.ml
+++ b/src/base/snark_intf.ml
@@ -1100,6 +1100,8 @@ module type Run_basic = sig
     val get_primary_input_size : t -> int
 
     val get_rows_len : t -> int
+
+    val to_json : t -> string
   end
 
   module Bigint : sig

--- a/src/base/snarky_backendless.ml
+++ b/src/base/snarky_backendless.ml
@@ -12,7 +12,6 @@ module Enumerable = Enumerable
 module Enumerable_intf = Enumerable_intf
 module Field_intf = Snarky_intf.Field
 module Free_monad = Free_monad
-module H_list = H_list
 module Handle = Handle
 module Merkle_tree = Merkle_tree
 module Monad_let = Monad_let

--- a/src/base/state.ml
+++ b/src/base/state.ml
@@ -72,6 +72,8 @@ module type S = sig
   val set_is_running : t -> bool -> t
 
   val next_auxiliary : t -> int
+
+  val seal : t -> cvar -> cvar
 end
 
 module Make
@@ -135,6 +137,8 @@ module Make
     add_constraint t.state ?label cstr
 
   let finalize t = finalize t.state
+
+  let seal t = seal t.state
 
   (* We redefine the [make] function with the wrapper in mind. *)
 

--- a/src/base/state.ml
+++ b/src/base/state.ml
@@ -125,11 +125,7 @@ module Make
   let next_auxiliary t = next_auxiliary t.state
 
   let add_constraint ?label t (cstr : (Cvar.t, Field.t) Constraint.basic) =
-    match label with
-    | Some label ->
-        add_constraint t.state ~label cstr
-    | None ->
-        add_constraint t.state cstr
+    add_constraint t.state ?label cstr
 
   let finalize t = finalize t.state
 

--- a/src/base/state.ml
+++ b/src/base/state.ml
@@ -37,7 +37,7 @@ module type S = sig
 
   val store_field_elt : t -> Field.t -> cvar
 
-  val alloc_var : t -> unit -> cvar
+  val alloc_var : t -> cvar
 
   val has_witness : t -> bool
 
@@ -110,7 +110,7 @@ module Make
 
   let store_field_elt t field = store_field_elt t.state field
 
-  let alloc_var t _ = alloc_var t.state ()
+  let alloc_var t = alloc_var t.state
 
   let has_witness t = has_witness t.state
 

--- a/src/base/state.ml
+++ b/src/base/state.ml
@@ -156,8 +156,7 @@ module Make
        ?(stack = []) ?(is_running = true) () ->
     (* create the inner Rust state *)
     let state : Run_state.t =
-      if system then Run_state.make_system num_inputs eval_constraints
-      else Run_state.make num_inputs eval_constraints
+      Run_state.make num_inputs eval_constraints system
     in
 
     (* create the wrapper state *)

--- a/src/base/state.ml
+++ b/src/base/state.ml
@@ -41,6 +41,10 @@ module type S = sig
 
   val has_witness : t -> bool
 
+  val set_public_inputs : t -> Field.Vector.t -> unit
+
+  val get_private_inputs : t -> Field.Vector.t
+
   val as_prover : t -> bool
 
   val set_as_prover : t -> bool -> unit
@@ -113,6 +117,13 @@ module Make
   let alloc_var t = alloc_var t.state
 
   let has_witness t = has_witness t.state
+
+  (* TODO: make sure that the public input is not already set in there, and that this is the expected public input size *)
+  let set_public_inputs t public_inputs =
+    set_public_inputs t.state public_inputs
+
+  (* TODO: we should make sure that the state was finalized before this can be called *)
+  let get_private_inputs t = get_private_inputs t.state
 
   let as_prover t = as_prover t.state
 

--- a/src/base/state.ml
+++ b/src/base/state.ml
@@ -56,6 +56,8 @@ module type S = sig
 
   val eval_constraints : t -> bool
 
+  val system : t -> constraint_system option
+
   val handler : t -> Request.Handler.t
 
   val set_handler : t -> Request.Handler.t -> t
@@ -110,6 +112,8 @@ module Make
   let set_as_prover t b = set_as_prover t.state b
 
   let eval_constraints t = eval_constraints t.state
+
+  let system t = system t.state
 
   let next_auxiliary t = next_auxiliary t.state
 

--- a/src/base/state.ml
+++ b/src/base/state.ml
@@ -11,6 +11,8 @@ module type S = sig
 
   type cvar
 
+  type constraint_system
+
   val make :
        num_inputs:int
     -> input:Field.Vector.t
@@ -80,7 +82,10 @@ module Make
                    with module Field := Field
                     and type cvar := Cvar.t
                     and type constraint_system := CS.t) :
-  S with module Field := Field and type cvar := Cvar.t = struct
+  S
+    with module Field := Field
+     and type cvar := Cvar.t
+     and type constraint_system := CS.t = struct
   include Run_state
 
   (* We wrap the state coming from Rust, and we add some values that are only relevant for the OCaml implementation. *)

--- a/src/base/state.ml
+++ b/src/base/state.ml
@@ -115,7 +115,6 @@ module Make
 
   let has_witness t = has_witness t.state
 
-  (* TODO: make sure that the public input is not already set in there, and that this is the expected public input size *)
   let set_public_inputs t public_inputs =
     set_public_inputs t.state public_inputs
 

--- a/src/base/state.ml
+++ b/src/base/state.ml
@@ -125,7 +125,11 @@ module Make
   let next_auxiliary t = next_auxiliary t.state
 
   let add_constraint ?label t (cstr : (Cvar.t, Field.t) Constraint.basic) =
-    add_constraint t.state label cstr
+    match label with
+    | Some label ->
+        add_constraint t.state ~label cstr
+    | None ->
+        add_constraint t.state cstr
 
   let finalize t = finalize t.state
 

--- a/src/base/state.ml
+++ b/src/base/state.ml
@@ -15,8 +15,6 @@ module type S = sig
 
   val make :
        num_inputs:int
-    -> input:Field.Vector.t
-    -> aux:Field.Vector.t
     -> system:bool
     -> eval_constraints:bool
     -> ?log_constraint:
@@ -144,8 +142,6 @@ module Make
 
   let make :
          num_inputs:int
-      -> input:Field.Vector.t
-      -> aux:Field.Vector.t
       -> system:bool
       -> eval_constraints:bool
       -> ?log_constraint:
@@ -158,16 +154,16 @@ module Make
       -> ?is_running:bool
       -> unit
       -> t =
-   fun ~num_inputs ~input ~aux ~system ~eval_constraints ?log_constraint
-       ?handler ~with_witness ?(stack = []) ?(is_running = true) () ->
+   fun ~num_inputs ~system ~eval_constraints ?log_constraint ?handler
+       ~with_witness ?(stack = []) ?(is_running = true) () ->
     (* We can't evaluate the constraints if we are not computing over a value. *)
     let eval_constraints = eval_constraints && with_witness in
 
     (* create the inner Rust state *)
     let state : Run_state.t =
       if system then
-        Run_state.make_system num_inputs input aux eval_constraints with_witness
-      else Run_state.make num_inputs input aux eval_constraints with_witness
+        Run_state.make_system num_inputs eval_constraints with_witness
+      else Run_state.make num_inputs eval_constraints with_witness
     in
 
     (* create the wrapper state *)

--- a/src/base/state.ml
+++ b/src/base/state.ml
@@ -49,8 +49,6 @@ module type S = sig
 
   val eval_constraints : t -> bool
 
-  val system : t -> constraint_system option
-
   val handler : t -> Request.Handler.t
 
   val set_handler : t -> Request.Handler.t -> t
@@ -108,8 +106,6 @@ module Make
   let set_as_prover t b = set_as_prover t.state b
 
   let eval_constraints t = eval_constraints t.state
-
-  let system t = system t.state
 
   let next_auxiliary t = next_auxiliary t.state
 

--- a/src/base/state.ml
+++ b/src/base/state.ml
@@ -60,6 +60,8 @@ module type S = sig
 
   val system : t -> constraint_system option
 
+  val finalize : t -> unit
+
   val handler : t -> Request.Handler.t
 
   val set_handler : t -> Request.Handler.t -> t
@@ -124,6 +126,8 @@ module Make
 
   let add_constraint ?label t (cstr : (Cvar.t, Field.t) Constraint.basic) =
     add_constraint t.state label cstr
+
+  let finalize t = finalize t.state
 
   (* We redefine the [make] function with the wrapper in mind. *)
 

--- a/src/base/state.ml
+++ b/src/base/state.ml
@@ -21,6 +21,9 @@ module type S = sig
     -> unit
     -> t
 
+  val add_constraint :
+    ?label:string -> t -> (cvar, Field.t) Constraint.basic -> unit
+
   val get_variable_value : t -> int -> Field.t
 
   val store_field_elt : t -> Field.t -> cvar
@@ -109,6 +112,9 @@ module Make
   let system t = system t.state
 
   let next_auxiliary t = next_auxiliary t.state
+
+  let add_constraint ?label t (cstr : (Cvar.t, Field.t) Constraint.basic) =
+    add_constraint t.state label cstr
 
   (* We redefine the [make] function with the wrapper in mind. *)
 

--- a/src/base/state.ml
+++ b/src/base/state.ml
@@ -1,0 +1,165 @@
+open Core_kernel
+
+module type S = sig
+  include Backend_intf.Run_state_intf
+
+  val make :
+       num_inputs:int
+    -> input:Field.Vector.t
+    -> next_auxiliary:int ref
+    -> aux:Field.Vector.t
+    -> ?system:constraint_system
+    -> eval_constraints:bool
+    -> ?log_constraint:
+         (   ?at_label_boundary:[ `End | `Start ] * string
+          -> (cvar, Field.t) Constraint.t option
+          -> unit )
+    -> ?handler:Request.Handler.t
+    -> with_witness:bool
+    -> ?stack:string list
+    -> ?is_running:bool
+    -> unit
+    -> t
+
+  val get_variable_value : t -> int -> Field.t
+
+  val store_field_elt : t -> Field.t -> cvar
+
+  val alloc_var : t -> unit -> cvar
+
+  val has_witness : t -> bool
+
+  val as_prover : t -> bool
+
+  val set_as_prover : t -> bool -> unit
+
+  val stack : t -> string list
+
+  val set_stack : t -> string list -> t
+
+  val log_constraint :
+       t
+    -> (   ?at_label_boundary:[ `Start | `End ] * string
+        -> (cvar, Field.t) Constraint.t option
+        -> unit )
+       option
+
+  val eval_constraints : t -> bool
+
+  val system : t -> constraint_system option
+
+  val handler : t -> Request.Handler.t
+
+  val set_handler : t -> Request.Handler.t -> t
+
+  val is_running : t -> bool
+
+  val set_is_running : t -> bool -> t
+
+  val next_auxiliary : t -> int
+end
+
+module Make
+    (Cvar : T) (Field : sig
+      type t
+
+      module Vector : T
+    end)
+    (CS : T)
+    (Run_state : Backend_intf.Run_state_intf
+                   with module Field := Field
+                    and type cvar := Cvar.t
+                    and type constraint_system := CS.t) :
+  S
+    with module Field := Field
+     and type cvar := Cvar.t
+     and type constraint_system := CS.t = struct
+  include Run_state
+
+  (* We wrap the state coming from Rust, and we add some values that are only relevant for the OCaml implementation. *)
+
+  type t =
+    { state : Run_state.t
+    ; stack : string list
+    ; handler : Request.Handler.t
+    ; is_running : bool
+    ; log_constraint :
+        (   ?at_label_boundary:[ `Start | `End ] * string
+         -> (Cvar.t, Field.t) Constraint.t option
+         -> unit )
+        option
+    }
+
+  (* We redefine a number of functions but on the wrapper. *)
+
+  let get_variable_value t idx = get_variable_value t.state idx
+
+  let store_field_elt t field = store_field_elt t.state field
+
+  let alloc_var t _ = alloc_var t.state ()
+
+  let has_witness t = has_witness t.state
+
+  let as_prover t = as_prover t.state
+
+  let set_as_prover t b = set_as_prover t.state b
+
+  let eval_constraints t = eval_constraints t.state
+
+  let system t = system t.state
+
+  let next_auxiliary t = next_auxiliary t.state
+
+  (* We redefine the [make] function with the wrapper in mind. *)
+
+  let make :
+         num_inputs:int
+      -> input:Field.Vector.t
+      -> next_auxiliary:int ref
+      -> aux:Field.Vector.t
+      -> ?system:CS.t
+      -> eval_constraints:bool
+      -> ?log_constraint:
+           (   ?at_label_boundary:[ `End | `Start ] * string
+            -> (Cvar.t, Field.t) Constraint.t option
+            -> unit )
+      -> ?handler:Request.Handler.t
+      -> with_witness:bool
+      -> ?stack:string list
+      -> ?is_running:bool
+      -> unit
+      -> t =
+   fun ~num_inputs ~input ~next_auxiliary ~aux ?system ~eval_constraints
+       ?log_constraint ?handler ~with_witness ?(stack = []) ?(is_running = true)
+       () ->
+    next_auxiliary := 1 + num_inputs ;
+    (* We can't evaluate the constraints if we are not computing over a value. *)
+    let eval_constraints = eval_constraints && with_witness in
+    let as_prover = false in
+    let state =
+      Run_state.make ~num_inputs ~input ~next_auxiliary ~aux ~system
+        ~eval_constraints ~with_witness ~as_prover ()
+    in
+    { state
+    ; stack
+    ; handler = Option.value handler ~default:Request.Handler.fail
+    ; is_running
+    ; log_constraint
+    }
+
+  (* We define a number of functions that are only relevant for the extra fields we added in the wrapper. *)
+
+  let stack { stack; _ } = stack
+
+  let set_stack t stack = { t with stack }
+
+  let log_constraint { log_constraint; _ } = log_constraint
+
+  let handler { handler; _ } = handler
+
+  let set_handler t handler = { t with handler }
+
+  let is_running { is_running; _ } = is_running
+
+  let set_is_running t is_running = { t with is_running }
+end

--- a/src/base/state.ml
+++ b/src/base/state.ml
@@ -22,7 +22,6 @@ module type S = sig
           -> (cvar, Field.t) Constraint.t option
           -> unit )
     -> ?handler:Request.Handler.t
-    -> with_witness:bool
     -> ?stack:string list
     -> ?is_running:bool
     -> unit
@@ -149,21 +148,16 @@ module Make
             -> (Cvar.t, Field.t) Constraint.t option
             -> unit )
       -> ?handler:Request.Handler.t
-      -> with_witness:bool
       -> ?stack:string list
       -> ?is_running:bool
       -> unit
       -> t =
    fun ~num_inputs ~system ~eval_constraints ?log_constraint ?handler
-       ~with_witness ?(stack = []) ?(is_running = true) () ->
-    (* We can't evaluate the constraints if we are not computing over a value. *)
-    let eval_constraints = eval_constraints && with_witness in
-
+       ?(stack = []) ?(is_running = true) () ->
     (* create the inner Rust state *)
     let state : Run_state.t =
-      if system then
-        Run_state.make_system num_inputs eval_constraints with_witness
-      else Run_state.make num_inputs eval_constraints with_witness
+      if system then Run_state.make_system num_inputs eval_constraints
+      else Run_state.make num_inputs eval_constraints
     in
 
     (* create the wrapper state *)

--- a/src/base/utils.ml
+++ b/src/base/utils.ml
@@ -57,7 +57,7 @@ module Make
                  and type field_vector := Backend.Field.Vector.t
                  and type cvar := Backend.Cvar.t
                  and type constr := Backend.Constraint.t option
-                 and type r1cs := Backend.R1CS_constraint_system.t
+                 and type r1cs := Backend.Constraint_system.t
                  and type run_state := Backend.Run_state.t) =
 struct
   open Backend

--- a/src/base/utils.ml
+++ b/src/base/utils.ml
@@ -266,6 +266,10 @@ struct
 
     let ( ||| ) = ( || )
 
+    let sum terms =
+      List.fold terms ~init:(Cvar.constant Field.zero) ~f:(fun acc t ->
+          Cvar.add acc t )
+
     let any = function
       | [] ->
           return false_
@@ -276,7 +280,7 @@ struct
       | bs ->
           let open Let_syntax in
           let%map all_zero =
-            equal (Cvar.sum (bs :> Cvar.t list)) (Cvar.constant Field.zero)
+            equal (sum (bs :> Cvar.t list)) (Cvar.constant Field.zero)
           in
           not all_zero
 
@@ -290,7 +294,7 @@ struct
       | bs ->
           equal
             (Cvar.constant (Field.of_int (List.length bs)))
-            (Cvar.sum (bs :> Cvar.t list))
+            (sum (bs :> Cvar.t list))
 
     let to_constant (b : var) =
       Option.map (Cvar.to_constant (b :> Cvar.t)) ~f:Field.(equal one)
@@ -424,15 +428,15 @@ struct
       let is_true (v : var) = v = true_
 
       let%snarkydef_ any (bs : var list) =
-        assert_non_zero (Cvar.sum (bs :> Cvar.t list))
+        assert_non_zero (sum (bs :> Cvar.t list))
 
       let%snarkydef_ all (bs : var list) =
         assert_equal
-          (Cvar.sum (bs :> Cvar.t list))
+          (sum (bs :> Cvar.t list))
           (Cvar.constant (Field.of_int (List.length bs)))
 
       let%snarkydef_ exactly_one (bs : var list) =
-        assert_equal (Cvar.sum (bs :> Cvar.t list)) (Cvar.constant Field.one)
+        assert_equal (sum (bs :> Cvar.t list)) (Cvar.constant Field.one)
     end
 
     module Expr = struct


### PR DESCRIPTION
Builds on top of https://github.com/o1-labs/snarky/pull/798

This contains a number of misc changes that I need to make in order to make the Mina-side work (https://github.com/MinaProtocol/mina/pull/12738). It contains:

* remove `length`, `to_constant_and_terms`, `var_indices`, `linear_combination`, `sum` from Cvar (unused)
* makes sure that the reference fields of run_state are not impacted (explained in this PR: https://github.com/o1-labs/snarky/pull/800)
* create a wrapper state around the rust state (in `state.ml`)
* delete unused `fake_state` function
* make OCaml code use what's passed from backend (state, cvar)
* clean up the `State.make` function
* introduce the `seal` function that exists in pickles (so we can delete it there)

the wrapper state has moved anything that's not relevant to Rust to its own fields:

```ocaml
  type t =
    { state : Run_state.t
    ; stack : string list
    ; handler : Request.Handler.t
    ; is_running : bool
    ; log_constraint :
        (   ?at_label_boundary:[ `Start | `End ] * string
         -> (Cvar.t, Field.t) Constraint.t option
         -> unit )
        option
    }
```