### PR TITLE
[DO NOT MERGE] removing references in Run_state.t

### DIFF
--- a/src/base/checked_runner.ml
+++ b/src/base/checked_runner.ml
@@ -306,8 +306,8 @@ struct
     in
     let state =
       Run_state.make ~num_inputs:0 ~input:Run_state.Vector.null
-        ~next_auxiliary:(ref 1) ~aux:Run_state.Vector.null
-        ~eval_constraints:false ~log_constraint ~with_witness:false ()
+        ~next_auxiliary:1 ~aux:Run_state.Vector.null ~eval_constraints:false
+        ~log_constraint ~with_witness:false ()
     in
     let _ = Simple.eval (t ()) state in
     !count
@@ -368,11 +368,6 @@ module Make (Backend : Backend_extended.S) = struct
 
   let dummy_vector = Run_state.Vector.null
 
-  let fake_state next_auxiliary stack =
-    Run_state.make ~num_inputs:0 ~input:Run_state.Vector.null ~next_auxiliary
-      ~aux:Run_state.Vector.null ~eval_constraints:false ~stack
-      ~with_witness:false ()
-
   module State = struct
     let make ~num_inputs ~input ~next_auxiliary ~aux ?system
         ?(eval_constraints = !eval_constraints_ref) ?handler ~with_witness
@@ -430,7 +425,7 @@ module type S = sig
     val make :
          num_inputs:int
       -> input:field Run_state.Vector.t
-      -> next_auxiliary:int ref
+      -> next_auxiliary:int
       -> aux:field Run_state.Vector.t
       -> ?system:r1cs
       -> ?eval_constraints:bool

--- a/src/base/run_state.ml
+++ b/src/base/run_state.ml
@@ -43,7 +43,7 @@ type 'field t =
   ; stack : string list
   ; handler : Request.Handler.t
   ; is_running : bool
-  ; as_prover : bool ref
+  ; mutable as_prover : bool
   ; log_constraint :
       (   ?at_label_boundary:[ `Start | `End ] * string
        -> ('field Cvar.t, 'field) Constraint.t option
@@ -67,7 +67,7 @@ let make ~num_inputs ~input ~next_auxiliary ~aux ?system ~eval_constraints
   ; stack
   ; handler = Option.value handler ~default:Request.Handler.fail
   ; is_running
-  ; as_prover = ref false
+  ; as_prover = false
   ; log_constraint
   }
 
@@ -75,7 +75,7 @@ let dump (t : _ t) =
   Format.sprintf
     "state { is_running: %B; as_prover: %B; has_witness: %B; eval_constraints: \
      %B; num_inputs: %d; next_auxiliary: %d }\n"
-    t.is_running !(t.as_prover) t.has_witness t.eval_constraints t.num_inputs
+    t.is_running t.as_prover t.has_witness t.eval_constraints t.num_inputs
     !(t.next_auxiliary)
 
 let get_variable_value { num_inputs; input; aux; _ } : int -> 'field =
@@ -93,9 +93,9 @@ let alloc_var { next_auxiliary; _ } () =
 
 let has_witness { has_witness; _ } = has_witness
 
-let as_prover { as_prover; _ } = !as_prover
+let as_prover { as_prover; _ } = as_prover
 
-let set_as_prover t as_prover = t.as_prover := as_prover
+let set_as_prover t as_prover = t.as_prover <- as_prover
 
 let stack { stack; _ } = stack
 

--- a/src/base/run_state.mli
+++ b/src/base/run_state.mli
@@ -20,7 +20,7 @@ type 'field t
 val make :
      num_inputs:int
   -> input:'field Vector.t
-  -> next_auxiliary:int ref
+  -> next_auxiliary:int
   -> aux:'field Vector.t
   -> ?system:'field Constraint_system.t
   -> eval_constraints:bool

--- a/src/base/runners.ml
+++ b/src/base/runners.ml
@@ -48,7 +48,7 @@ struct
   let constraint_system ~run ~num_inputs ~return_typ:(Types.Typ.Typ return_typ)
       output t : R1CS_constraint_system.t =
     let input = field_vec () in
-    let next_auxiliary = ref (1 + num_inputs) in
+    let next_auxiliary = 1 + num_inputs in
     let aux = field_vec () in
     let system = R1CS_constraint_system.create () in
     let state =
@@ -62,14 +62,14 @@ struct
       Array.fold2_exn ~init:state res output ~f:(fun state res output ->
           fst @@ Checked.run (Checked.assert_equal res output) state )
     in
-    let auxiliary_input_size = !next_auxiliary - (1 + num_inputs) in
+    let auxiliary_input_size = next_auxiliary - (1 + num_inputs) in
     R1CS_constraint_system.set_auxiliary_input_size system auxiliary_input_size ;
     system
 
   let auxiliary_input ?system ~run ~num_inputs
       ?(handlers = ([] : Handler.t list)) t0 (input : Field.Vector.t)
       ~return_typ:(Types.Typ.Typ return_typ) ~output : Field.Vector.t * _ =
-    let next_auxiliary = ref (1 + num_inputs) in
+    let next_auxiliary = 1 + num_inputs in
     let aux = Field.Vector.create () in
     let handler =
       List.fold ~init:Request.Handler.fail handlers ~f:(fun handler h ->
@@ -91,7 +91,7 @@ struct
       return_typ.var_of_fields (output, auxiliary_output_data)
     in
     Option.iter system ~f:(fun system ->
-        let auxiliary_input_size = !next_auxiliary - (1 + num_inputs) in
+        let auxiliary_input_size = next_auxiliary - (1 + num_inputs) in
         R1CS_constraint_system.set_auxiliary_input_size system
           auxiliary_input_size ;
         R1CS_constraint_system.finalize system ) ;
@@ -100,7 +100,7 @@ struct
   let run_and_check' ~run t0 =
     let num_inputs = 0 in
     let input = field_vec () in
-    let next_auxiliary = ref 1 in
+    let next_auxiliary = 1 in
     let aux = Field.Vector.create () in
     let system = R1CS_constraint_system.create () in
     let get_value : Cvar.t -> Field.t =
@@ -121,7 +121,7 @@ struct
   let run_and_check_deferred' ~map ~return ~run t0 =
     let num_inputs = 0 in
     let input = field_vec () in
-    let next_auxiliary = ref 1 in
+    let next_auxiliary = 1 in
     let aux = Field.Vector.create () in
     let system = R1CS_constraint_system.create () in
     let get_value : Cvar.t -> Field.t =
@@ -142,7 +142,7 @@ struct
   let run_unchecked ~run t0 =
     let num_inputs = 0 in
     let input = field_vec () in
-    let next_auxiliary = ref 1 in
+    let next_auxiliary = 1 in
     let aux = field_vec () in
     let state =
       Runner.State.make ~num_inputs ~input ~next_auxiliary ~aux

--- a/src/base/snark0.ml
+++ b/src/base/snark0.ml
@@ -720,7 +720,7 @@ module Run = struct
     let state =
       ref
         (Run_state.make ~input:(field_vec ()) ~aux:(field_vec ())
-           ~eval_constraints:false ~num_inputs:0 ~next_auxiliary:(ref 1)
+           ~eval_constraints:false ~num_inputs:0 ~next_auxiliary:1
            ~with_witness:false ~stack:[] ~is_running:false () )
 
     let dump () = Run_state.dump !state
@@ -1385,7 +1385,7 @@ module Run = struct
       let old = !state in
       state :=
         Runner.State.make ~num_inputs:0 ~input:Vector.null ~aux:Vector.null
-          ~next_auxiliary:(ref 1) ~eval_constraints:false ~with_witness:false
+          ~next_auxiliary:1 ~eval_constraints:false ~with_witness:false
           ~log_constraint () ;
       ignore (mark_active ~f:x) ;
       state := old ;


### PR DESCRIPTION
# References in `Run_state.t`

There are two fields in the Run_state that are references (`int ref` and `bool ref`). It seems like a very dangerous pattern to me. There's two scenarios in the current logic that I'm worried of (as we transition to a Rust struct):

* something uses a reference to initialize a field of the state, and later on mutate that reference (which should mutate the state)
* something retrieves a reference field from the state and then mutates it later

Let's check to make sure! There are two reference fields: `as_prover` and `next_auxiliary`.

## As_prover

This one is easy, it always gets initialized to `false`, and you can't retrieve the reference (only its value). So we can safely remove the reference.

You can see it in this code change that was not merged but only created to showcase the change: https://github.com/o1-labs/snarky/pull/800/commits/55ae8dab6a5d38a7690170bcfaad0f571a509d3b

## Next_auxiliary

The reference can't be retrieved either, as this is the only way to get the value out of it:

```ocaml
let next_auxiliary { next_auxiliary; _ } = !next_auxiliary
```

Note that the `make` function also modifies next_auxiliary due to the R1CS trick:

```ocaml
next_auxiliary := 1 + num_inputs
```

So it is actually never used, it is just a way to return the correct value for `next_auxiliary` to the caller. 

The only real danger here is then if the caller starts mutating this after calling `make`.

This commit shows that there's no danger there as well: https://github.com/o1-labs/snarky/pull/800/commits/7549ca9e5151bca214e5823dae513298828ea468