### PR TITLE
[part5] Changes to snarky to make snarky-rs integration work 

### DIFF
--- a/snarky_integer/integer.ml
+++ b/snarky_integer/integer.ml
@@ -12,7 +12,8 @@ module Interval = struct
 
   let iter t ~f = match t with Constant x -> f x | Less_than x -> f x
 
-  let check (type f field_var) ~m:((module M) : (f, field_var) m) t =
+  let check (type f field_var state) ~m:((module M) : (f, field_var, state) m) t
+      =
     iter t ~f:(fun x -> assert (B.(x < M.Field.size))) ;
     t
 
@@ -124,8 +125,8 @@ let create ~value ~upper_bound =
 
 let to_field t = t.value
 
-let constant (type f field_var) ?length ~m:((module M) as m : (f, field_var) m)
-    x =
+let constant (type f field_var state) ?length
+    ~m:((module M) as m : (f, field_var, state) m) x =
   let open M in
   assert (B.( < ) x Field.size) ;
   let upper_bound = B.(one + x) in
@@ -146,7 +147,8 @@ let constant (type f field_var) ?length ~m:((module M) as m : (f, field_var) m)
              constant Boolean.typ B.(shift_right x i land one = one) ) )
   }
 
-let shift_left (type f field_var) ~m:((module M) as m : (f, field_var) m) t k =
+let shift_left (type f field_var state)
+    ~m:((module M) as m : (f, field_var, state) m) t k =
   let open M in
   let two_to_k = B.(one lsl k) in
   { value = Field.(constant (bigint_to_field ~m two_to_k) * t.value)
@@ -156,7 +158,8 @@ let shift_left (type f field_var) ~m:((module M) as m : (f, field_var) m) t k =
           List.init k ~f:(fun _ -> Boolean.false_) @ bs )
   }
 
-let of_bits (type f field_var) ~m:((module M) : (f, field_var) m) bs =
+let of_bits (type f field_var state) ~m:((module M) : (f, field_var, state) m)
+    bs =
   let bs = Bitstring.Lsb_first.to_list bs in
   { value = M.Field.project bs
   ; interval = Less_than B.(one lsl List.length bs)
@@ -168,7 +171,8 @@ let of_bits (type f field_var) ~m:((module M) : (f, field_var) m) bs =
     a = q * b + r
     r < b
 *)
-let div_mod (type f field_var) ~m:((module M) as m : (f, field_var) m) a b =
+let div_mod (type f field_var state)
+    ~m:((module M) as m : (f, field_var, state) m) a b =
   let open M in
   (* Guess (q, r) *)
   let q, r =
@@ -199,8 +203,8 @@ let div_mod (type f field_var) ~m:((module M) as m : (f, field_var) m) a b =
     }
   , { value = r; interval = b.interval; bits = Some r_bits } )
 
-let subtract_unpacking (type f field_var) ~m:((module M) : (f, field_var) m) a b
-    =
+let subtract_unpacking (type f field_var state)
+    ~m:((module M) : (f, field_var, state) m) a b =
   M.with_label "Integer.subtract_unpacking" (fun () ->
       assert (Interval.gte a.interval b.interval) ;
       let value = M.Field.(sub a.value b.value) in
@@ -209,15 +213,18 @@ let subtract_unpacking (type f field_var) ~m:((module M) : (f, field_var) m) a b
       let bits = M.Field.unpack value ~length in
       { value; interval = a.interval; bits = Some bits } )
 
-let add (type f field_var) ~m:((module M) as m : (f, field_var) m) a b =
+let add (type f field_var state) ~m:((module M) as m : (f, field_var, state) m)
+    a b =
   let interval = Interval.(add ~m a.interval b.interval) in
   { value = M.Field.(a.value + b.value); interval; bits = None }
 
-let mul (type f field_var) ~m:((module M) as m : (f, field_var) m) a b =
+let mul (type f field_var state) ~m:((module M) as m : (f, field_var, state) m)
+    a b =
   let interval = Interval.(mul ~m a.interval b.interval) in
   { value = M.Field.(a.value * b.value); interval; bits = None }
 
-let to_bits ?length (type f field_var) ~m:((module M) : (f, field_var) m) t =
+let to_bits ?length (type f field_var state)
+    ~m:((module M) : (f, field_var, state) m) t =
   match t.bits with
   | Some bs -> (
       let bs = Bitstring.Lsb_first.of_list bs in
@@ -241,7 +248,7 @@ let to_bits_exn t = Bitstring.Lsb_first.of_list (Option.value_exn t.bits)
 
 let to_bits_opt t = Option.map ~f:Bitstring.Lsb_first.of_list t.bits
 
-let min (type f field_var) ~m:((module M) : (f, field_var) m)
+let min (type f field_var state) ~m:((module M) : (f, field_var, state) m)
     (a : (f, field_var) t) (b : (f, field_var) t) =
   let open M in
   let bit_length =
@@ -253,48 +260,53 @@ let min (type f field_var) ~m:((module M) : (f, field_var) m)
   ; bits = None
   }
 
-let if_ (type f field_var) ~m:((module M) : (f, field_var) m) cond ~then_ ~else_
-    =
+let if_ (type f field_var state) ~m:((module M) : (f, field_var, state) m) cond
+    ~then_ ~else_ =
   { value = M.Field.if_ cond ~then_:then_.value ~else_:else_.value
   ; interval = Interval.lub then_.interval else_.interval
   ; bits = None
   }
 
-let succ_if (type f field_var) ~m:((module M) as m : (f, field_var) m) t
-    (cond : field_var Boolean.t) =
+let succ_if (type f field_var state)
+    ~m:((module M) as m : (f, field_var, state) m) t (cond : field_var Boolean.t)
+    =
   let open M in
   { value = Field.(add (cond :> t) t.value)
   ; interval = Interval.(lub t.interval (succ ~m t.interval))
   ; bits = None
   }
 
-let succ (type f field_var) ~m:((module M) as m : (f, field_var) m) t =
+let succ (type f field_var state) ~m:((module M) as m : (f, field_var, state) m)
+    t =
   let open M in
   { value = Field.(add one t.value)
   ; interval = Interval.succ ~m t.interval
   ; bits = None
   }
 
-let equal (type f field_var) ~m:((module M) : (f, field_var) m) a b =
+let equal (type f field_var state) ~m:((module M) : (f, field_var, state) m) a b
+    =
   M.Field.equal a.value b.value
 
 let max_bits a b =
   Int.max (Interval.bits_needed a.interval) (Interval.bits_needed b.interval)
 
-let lt (type f field_var) ~m:((module M) : (f, field_var) m) a b =
+let lt (type f field_var state) ~m:((module M) : (f, field_var, state) m) a b =
   (M.Field.compare ~bit_length:(max_bits a b) a.value b.value).less
 
-let lte (type f field_var) ~m:((module M) : (f, field_var) m) a b =
+let lte (type f field_var state) ~m:((module M) : (f, field_var, state) m) a b =
   (M.Field.compare ~bit_length:(max_bits a b) a.value b.value).less_or_equal
 
-let gte (type f field_var) ~m:((module M) as m : (f, field_var) m) a b =
+let gte (type f field_var state) ~m:((module M) as m : (f, field_var, state) m)
+    a b =
   M.Boolean.not (lt ~m a b)
 
-let gt (type f field_var) ~m:((module M) as m : (f, field_var) m) a b =
+let gt (type f field_var state) ~m:((module M) as m : (f, field_var, state) m) a
+    b =
   M.Boolean.not (lte ~m a b)
 
-let subtract_unpacking_or_zero (type f field_var)
-    ~m:((module M) as m : (f, field_var) m) a b =
+let subtract_unpacking_or_zero (type f field_var state)
+    ~m:((module M) as m : (f, field_var, state) m) a b =
   let flag = lt ~m a b in
   ( `Underflow flag
   , { value =

--- a/snarky_integer/integer.mli
+++ b/snarky_integer/integer.mli
@@ -30,7 +30,7 @@ type ('f, 'field_var) t =
     when given.
 *)
 val constant :
-  ?length:int -> m:('f, 'field_var) m -> Bigint.t -> ('f, 'field_var) t
+  ?length:int -> m:('f, 'field_var, 'state) m -> Bigint.t -> ('f, 'field_var) t
 
 (** [shift_left ~m x k] is equivalent to multiplying [x] by [2^k].
 
@@ -38,14 +38,17 @@ val constant :
     cached bit representation.
 *)
 val shift_left :
-  m:('f, 'field_var) m -> ('f, 'field_var) t -> int -> ('f, 'field_var) t
+     m:('f, 'field_var, 'state) m
+  -> ('f, 'field_var) t
+  -> int
+  -> ('f, 'field_var) t
 
 (** Create a value from the given bit string.
 
     The given bit representation is cached.
 *)
 val of_bits :
-     m:('f, 'field_var) m
+     m:('f, 'field_var, 'state) m
   -> 'field_var Boolean.t Bitstring.Lsb_first.t
   -> ('f, 'field_var) t
 
@@ -57,7 +60,7 @@ val of_bits :
 *)
 val to_bits :
      ?length:int
-  -> m:('f, 'field_var) m
+  -> m:('f, 'field_var, 'state) m
   -> ('f, 'field_var) t
   -> 'field_var Boolean.t Bitstring.Lsb_first.t
 
@@ -80,7 +83,7 @@ val to_bits_opt :
     NOTE: This uses approximately [log2(a) + 2 * log2(b)] constraints.
 *)
 val div_mod :
-     m:('f, 'field_var) m
+     m:('f, 'field_var, 'state) m
   -> ('f, 'field_var) t
   -> ('f, 'field_var) t
   -> ('f, 'field_var) t * ('f, 'field_var) t
@@ -94,13 +97,13 @@ val create : value:'field_var -> upper_bound:Bigint.t -> ('f, 'field_var) t
     The result does not carry a cached bit representation.
 *)
 val min :
-     m:('f, 'field_var) m
+     m:('f, 'field_var, 'state) m
   -> ('f, 'field_var) t
   -> ('f, 'field_var) t
   -> ('f, 'field_var) t
 
 val if_ :
-     m:('f, 'field_var) m
+     m:('f, 'field_var, 'state) m
   -> 'field_var Boolean.t
   -> then_:('f, 'field_var) t
   -> else_:('f, 'field_var) t
@@ -110,7 +113,8 @@ val if_ :
 
     The result does not carry a cached bit representation.
 *)
-val succ : m:('f, 'field_var) m -> ('f, 'field_var) t -> ('f, 'field_var) t
+val succ :
+  m:('f, 'field_var, 'state) m -> ('f, 'field_var) t -> ('f, 'field_var) t
 
 (** [succ_if ~m x b] computes the integer [x+1] if [b] is [true], or [x]
     otherwise.
@@ -118,37 +122,37 @@ val succ : m:('f, 'field_var) m -> ('f, 'field_var) t -> ('f, 'field_var) t
     The result does not carry a cached bit representation.
 *)
 val succ_if :
-     m:('f, 'field_var) m
+     m:('f, 'field_var, 'state) m
   -> ('f, 'field_var) t
   -> 'field_var Boolean.t
   -> ('f, 'field_var) t
 
 val equal :
-     m:('f, 'field_var) m
+     m:('f, 'field_var, 'state) m
   -> ('f, 'field_var) t
   -> ('f, 'field_var) t
   -> 'field_var Boolean.t
 
 val lt :
-     m:('f, 'field_var) m
+     m:('f, 'field_var, 'state) m
   -> ('f, 'field_var) t
   -> ('f, 'field_var) t
   -> 'field_var Boolean.t
 
 val lte :
-     m:('f, 'field_var) m
+     m:('f, 'field_var, 'state) m
   -> ('f, 'field_var) t
   -> ('f, 'field_var) t
   -> 'field_var Boolean.t
 
 val gt :
-     m:('f, 'field_var) m
+     m:('f, 'field_var, 'state) m
   -> ('f, 'field_var) t
   -> ('f, 'field_var) t
   -> 'field_var Boolean.t
 
 val gte :
-     m:('f, 'field_var) m
+     m:('f, 'field_var, 'state) m
   -> ('f, 'field_var) t
   -> ('f, 'field_var) t
   -> 'field_var Boolean.t
@@ -158,7 +162,7 @@ val gte :
     The result does not carry a cached bit representation.
 *)
 val add :
-     m:('f, 'field_var) m
+     m:('f, 'field_var, 'state) m
   -> ('f, 'field_var) t
   -> ('f, 'field_var) t
   -> ('f, 'field_var) t
@@ -168,7 +172,7 @@ val add :
     The result does not carry a cached bit representation.
 *)
 val mul :
-     m:('f, 'field_var) m
+     m:('f, 'field_var, 'state) m
   -> ('f, 'field_var) t
   -> ('f, 'field_var) t
   -> ('f, 'field_var) t
@@ -181,7 +185,7 @@ val mul :
     NOTE: This uses approximately [log2(x)] constraints.
 *)
 val subtract_unpacking :
-     m:('f, 'field_var) m
+     m:('f, 'field_var, 'state) m
   -> ('f, 'field_var) t
   -> ('f, 'field_var) t
   -> ('f, 'field_var) t
@@ -198,7 +202,7 @@ val subtract_unpacking :
     NOTE: This uses approximately [log2(x)] constraints.
 *)
 val subtract_unpacking_or_zero :
-     m:('f, 'field_var) m
+     m:('f, 'field_var, 'state) m
   -> ('f, 'field_var) t
   -> ('f, 'field_var) t
   -> [ `Underflow of 'field_var Boolean.t ] * ('f, 'field_var) t

--- a/snarky_integer/util.ml
+++ b/snarky_integer/util.ml
@@ -3,10 +3,12 @@ open Snarky_backendless
 open Snark
 module B = Bigint
 
-let bigint_to_field (type f field_var) ~m:((module M) : (f, field_var) m) =
+let bigint_to_field (type f field_var state)
+    ~m:((module M) : (f, field_var, state) m) =
   let open M in
   Fn.compose Bigint.to_field Bigint.of_bignum_bigint
 
-let bigint_of_field (type f field_var) ~m:((module M) : (f, field_var) m) =
+let bigint_of_field (type f field_var state)
+    ~m:((module M) : (f, field_var, state) m) =
   let open M in
   Fn.compose Bigint.to_bignum_bigint Bigint.of_field

--- a/src/base/backend_extended.ml
+++ b/src/base/backend_extended.ml
@@ -47,11 +47,6 @@ module type S = sig
     val square : (Cvar.t -> Cvar.t -> t) with_constraint_args
 
     val annotation : t -> string
-
-    val eval :
-         (Cvar.t, Field.t) Constraint.basic_with_annotation
-      -> (Cvar.t -> Field.t)
-      -> bool
   end
 end
 
@@ -181,7 +176,5 @@ module Make (Backend : Backend_intf.S) :
     let t_of_sexp _ = failwith "unimplemented"
 
     let sexp_of_t = sexp_of_opaque
-
-    let eval = Run_state.eval_constraint
   end
 end

--- a/src/base/backend_extended.ml
+++ b/src/base/backend_extended.ml
@@ -172,7 +172,6 @@ module Make (Backend : Backend_intf.S) :
   module Run_state = State.Make (Cvar) (Field) (Constraint_system) (Run_state)
 
   module Constraint = struct
-    open Constraint
     include Constraint.T
 
     type 'k with_constraint_args = ?label:string -> 'k
@@ -183,8 +182,6 @@ module Make (Backend : Backend_intf.S) :
 
     let sexp_of_t = sexp_of_opaque
 
-    let m = (module Field : Snarky_intf.Field.S with type t = Field.t)
-
-    let eval { basic; _ } get_value = Constraint.Basic.eval m get_value basic
+    let eval = Run_state.eval_constraint
   end
 end

--- a/src/base/backend_extended.ml
+++ b/src/base/backend_extended.ml
@@ -168,6 +168,8 @@ module Make (Backend : Backend_intf.S) :
   end
 
   module Cvar = Cvar
+  module Constraint_system = Constraint_system
+  module Run_state = State.Make (Cvar) (Field) (Constraint_system) (Run_state)
 
   module Constraint = struct
     open Constraint
@@ -185,7 +187,4 @@ module Make (Backend : Backend_intf.S) :
 
     let eval { basic; _ } get_value = Constraint.Basic.eval m get_value basic
   end
-
-  module Constraint_system = Constraint_system
-  module Run_state = State.Make (Cvar) (Field) (Constraint_system) (Run_state)
 end

--- a/src/base/backend_intf.ml
+++ b/src/base/backend_intf.ml
@@ -97,6 +97,11 @@ module type Run_state_intf = sig
   val next_auxiliary : t -> int
 
   val seal : t -> cvar -> cvar
+
+  val eval_constraint :
+       (cvar, Field.t) Constraint.basic_with_annotation
+    -> (cvar -> Field.t)
+    -> bool
 end
 
 module type S = sig

--- a/src/base/backend_intf.ml
+++ b/src/base/backend_intf.ml
@@ -96,7 +96,7 @@ module type Run_state_intf = sig
 
   val seal : t -> cvar -> cvar
 
-  val get_value : t -> cvar -> Field.t
+  val evaluate_var : t -> cvar -> Field.t
 
   (* TODO: maybe not a good place to provide this... *)
   val eval_constraint :

--- a/src/base/backend_intf.ml
+++ b/src/base/backend_intf.ml
@@ -33,8 +33,6 @@ module type Cvar_intf = sig
     val of_index : int -> t
   end
 
-  val eval : [ `Return_values_will_be_mutated of int -> field ] -> t -> field
-
   val constant : field -> t
 
   val add : t -> t -> t

--- a/src/base/backend_intf.ml
+++ b/src/base/backend_intf.ml
@@ -67,6 +67,8 @@ module type Run_state_intf = sig
 
   val make : int -> bool -> bool -> t
 
+  val debug : t -> string
+
   val add_constraint :
     ?label:string -> t -> (cvar, Field.t) Constraint.basic -> unit
 

--- a/src/base/backend_intf.ml
+++ b/src/base/backend_intf.ml
@@ -17,8 +17,6 @@ module type Constraint_system_intf = sig
 
   val to_json : t -> string
 
-  val set_primary_input_size : t -> int -> unit
-
   val get_primary_input_size : t -> int
 
   val get_rows_len : t -> int

--- a/src/base/backend_intf.ml
+++ b/src/base/backend_intf.ml
@@ -97,12 +97,6 @@ module type Run_state_intf = sig
   val seal : t -> cvar -> cvar
 
   val evaluate_var : t -> cvar -> Field.t
-
-  (* TODO: maybe not a good place to provide this... *)
-  val eval_constraint :
-       (cvar, Field.t) Constraint.basic_with_annotation
-    -> (cvar -> Field.t)
-    -> bool
 end
 
 module type S = sig

--- a/src/base/backend_intf.ml
+++ b/src/base/backend_intf.ml
@@ -88,6 +88,8 @@ module type Run_state_intf = sig
 
   val eval_constraints : t -> bool
 
+  val set_eval_constraints : t -> bool -> unit
+
   val system : t -> constraint_system option
 
   val finalize : t -> unit

--- a/src/base/backend_intf.ml
+++ b/src/base/backend_intf.ml
@@ -98,6 +98,9 @@ module type Run_state_intf = sig
 
   val seal : t -> cvar -> cvar
 
+  val get_value : t -> cvar -> Field.t
+
+  (* TODO: maybe not a good place to provide this... *)
   val eval_constraint :
        (cvar, Field.t) Constraint.basic_with_annotation
     -> (cvar -> Field.t)

--- a/src/base/backend_intf.ml
+++ b/src/base/backend_intf.ml
@@ -72,8 +72,6 @@ module type Run_state_intf = sig
   val add_constraint :
     ?label:string -> t -> (cvar, Field.t) Constraint.basic -> unit
 
-  val get_variable_value : t -> int -> Field.t
-
   val store_field_elt : t -> Field.t -> cvar
 
   val alloc_var : t -> cvar

--- a/src/base/boolean.ml
+++ b/src/base/boolean.ml
@@ -1,5 +1,7 @@
 type 'v t = 'v
 
+let to_field_var (t : 'v t) : 'v = t
+
 module Unsafe = struct
   let create x = x
 end

--- a/src/base/boolean.mli
+++ b/src/base/boolean.mli
@@ -1,5 +1,7 @@
 type 'v t = private 'v
 
+val to_field_var : 'v t -> 'v
+
 module Unsafe : sig
   val create : 'v -> 'v t
 end

--- a/src/base/checked_runner.ml
+++ b/src/base/checked_runner.ml
@@ -1,7 +1,7 @@
 open Core_kernel
 module Constraint0 = Constraint
 
-let stack_to_string = String.concat ~sep:"\n"
+let stack_to_string = String.concat ~sep:", "
 
 let eval_constraints = ref true
 

--- a/src/base/checked_runner.ml
+++ b/src/base/checked_runner.ml
@@ -216,24 +216,7 @@ struct
           (s, ())
         else (
           Option.iter (Run_state.log_constraint s) ~f:(fun f -> f (Some c)) ;
-          if
-            Run_state.eval_constraints s
-            && not (Constraint.eval c (Run_state.get_value s))
-          then
-            failwithf
-              "Constraint unsatisfied (unreduced):\n\
-               %s\n\
-               %s\n\n\
-               Constraint:\n\
-               %s\n\
-               Data:\n\
-               %s"
-              (Constraint.annotation c)
-              (stack_to_string (Run_state.stack s))
-              (Sexp.to_string (Constraint.sexp_of_t c))
-              (log_constraint c s) () ;
-          if not (Run_state.as_prover s) then
-            add_constraint ~stack:(Run_state.stack s) c s ;
+          add_constraint ~stack:(Run_state.stack s) c s ;
           (s, ()) ) )
 
   let with_handler h t : _ Simple.t =

--- a/src/base/runners.ml
+++ b/src/base/runners.ml
@@ -118,11 +118,7 @@ struct
       (* update public output part of public input
          note that this works because [input] is a Rust value that is mutable
       *)
-      let start = Field.Vector.length input in
-      let end_ = start + return_typ.size_in_field_elements - 1 in
-      for ii = start to end_ do
-        Field.Vector.set input ii fields.(ii)
-      done ;
+      Array.iter fields ~f:(Field.Vector.emplace_back input) ;
 
       return_typ.value_of_fields (fields, aux)
     in

--- a/src/base/runners.ml
+++ b/src/base/runners.ml
@@ -119,7 +119,7 @@ struct
          note that this works because [input] is a Rust value that is mutable
       *)
       let start = Field.Vector.length input in
-      let end_ = start + return_typ.size_in_field_elements in
+      let end_ = start + return_typ.size_in_field_elements - 1 in
       for ii = start to end_ do
         Field.Vector.set input ii fields.(ii)
       done ;

--- a/src/base/runners.ml
+++ b/src/base/runners.ml
@@ -92,7 +92,8 @@ struct
     let output, _ = return_typ.var_to_fields output in
     let _state =
       Array.fold2_exn ~init:state res output ~f:(fun state res output ->
-          Field.Vector.emplace_back input (Runner.get_value state res) ;
+          Field.Vector.emplace_back input
+            (Backend.Run_state.get_value state res) ;
           fst @@ Checked.run (Checked.assert_equal res output) state )
     in
     let true_output =

--- a/src/base/snark0.ml
+++ b/src/base/snark0.ml
@@ -1417,13 +1417,8 @@ module Run = struct
   end
 end
 
-type ('field, 'field_var) m =
+type ('field, 'field_var, 'state) m =
   (module Snark_intf.Run
      with type field = 'field
-      and type field_var = 'field_var )
-
-let make (type field field_var)
-    (module Backend : Backend_intf.S
-      with type Field.t = field
-       and type Cvar.t = field_var ) : (field, field_var) m =
-  (module Run.Make (Backend))
+      and type field_var = 'field_var
+      and type run_state = 'state )

--- a/src/base/snark0.ml
+++ b/src/base/snark0.ml
@@ -1132,7 +1132,7 @@ module Run = struct
 
       let eval_as_prover f =
         if Run_state.as_prover !state && Run_state.has_witness !state then
-          let a = f (Runner.get_value !state) in
+          let a = f (Run_state.get_value !state) in
           a
         else failwith "Can't evaluate prover code outside an as_prover block"
 

--- a/src/base/snark0.ml
+++ b/src/base/snark0.ml
@@ -827,6 +827,8 @@ module Run = struct
 
       let false_ = false_
 
+      let to_field_var = to_field_var
+
       let if_ b ~then_ ~else_ = run (if_ b ~then_ ~else_)
 
       let not = not

--- a/src/base/snark0.ml
+++ b/src/base/snark0.ml
@@ -1400,11 +1400,7 @@ module Run = struct
       state := old ;
       !count
 
-    module Internal_Basic = struct
-      include Snark
-
-      type state = Snark.Run_state.t
-    end
+    module Internal_Basic = Snark
 
     let run_checked = run
   end

--- a/src/base/snark0.mli
+++ b/src/base/snark0.mli
@@ -37,13 +37,15 @@ module Run : sig
        and type Field.Constant.Vector.t = Backend.Field.Vector.t
 end
 
-type ('field, 'field_var) m =
+type ('field, 'field_var, 'state) m =
   (module Snark_intf.Run
      with type field = 'field
-      and type field_var = 'field_var )
+      and type field_var = 'field_var
+      and type run_state = 'state )
 
 val make :
      (module Backend_intf.S
         with type Field.t = 'field
-         and type Cvar.t = 'field_var )
-  -> ('field, 'field_var) m
+         and type Cvar.t = 'field_var
+         and type Run_state.t = 'state )
+  -> ('field, 'field_var, 'state) m

--- a/src/base/snark0.mli
+++ b/src/base/snark0.mli
@@ -42,10 +42,3 @@ type ('field, 'field_var, 'state) m =
      with type field = 'field
       and type field_var = 'field_var
       and type run_state = 'state )
-
-val make :
-     (module Backend_intf.S
-        with type Field.t = 'field
-         and type Cvar.t = 'field_var
-         and type Run_state.t = 'state )
-  -> ('field, 'field_var, 'state) m

--- a/src/base/snark_intf.ml
+++ b/src/base/snark_intf.ml
@@ -16,11 +16,14 @@ module type Boolean_intf = sig
 
   type value = bool
 
-  (** An R1CS variable containing {!val:Field.one}, representing [true]. *)
+  (** A variable containing {!val:Field.one}, representing [true]. *)
   val true_ : var
 
-  (** An R1CS variable containing {!val:Field.zero}, representing [false]. *)
+  (** A variable containing {!val:Field.zero}, representing [false]. *)
   val false_ : var
+
+  (** Converts a [t] into a [field_var] *)
+  val to_field_var : var -> field_var
 
   (** [if_ b ~then_ ~else_] returns [then_] if [b] is true, or [else_]
         otherwise.

--- a/src/base/snark_intf.ml
+++ b/src/base/snark_intf.ml
@@ -1254,16 +1254,13 @@ module type Run_basic = sig
       }
   end
 
-  and Internal_Basic : sig
-    type state = run_state
-
-    include
-      Basic
-        with type field = field
-         and type field_var = field_var
-         and type 'a Checked.t = ('a, state) Checked_runner.Simple.t
-         and type 'a As_prover.Ref.t = 'a As_prover_ref.t
-  end
+  and Internal_Basic :
+    (Basic
+      with type field = field
+       and type field_var = field_var
+       and type run_state = run_state
+       and type 'a Checked.t = ('a, run_state) Checked_runner.Simple.t
+       and type 'a As_prover.Ref.t = 'a As_prover_ref.t)
 
   module Bitstring_checked : sig
     type t = Boolean.var list

--- a/src/base/snarky_backendless.ml
+++ b/src/base/snarky_backendless.ml
@@ -12,6 +12,7 @@ module Enumerable = Enumerable
 module Enumerable_intf = Enumerable_intf
 module Field_intf = Snarky_intf.Field
 module Free_monad = Free_monad
+module H_list = H_list
 module Handle = Handle
 module Merkle_tree = Merkle_tree
 module Monad_let = Monad_let

--- a/src/base/state.ml
+++ b/src/base/state.ml
@@ -75,6 +75,9 @@ module type S = sig
 
   val seal : t -> cvar -> cvar
 
+  val get_value : t -> cvar -> Field.t
+
+  (* TODO: maybe not a good place to provide this... *)
   val eval_constraint :
        (cvar, Field.t) Constraint.basic_with_annotation
     -> (cvar -> Field.t)
@@ -144,6 +147,8 @@ module Make
   let finalize t = finalize t.state
 
   let seal t = seal t.state
+
+  let get_value t = get_value t.state
 
   (* We redefine the [make] function with the wrapper in mind. *)
 

--- a/src/base/state.ml
+++ b/src/base/state.ml
@@ -59,6 +59,8 @@ module type S = sig
 
   val eval_constraints : t -> bool
 
+  val set_eval_constraints : t -> bool -> unit
+
   val system : t -> constraint_system option
 
   val finalize : t -> unit
@@ -128,6 +130,8 @@ module Make
   let set_as_prover t b = set_as_prover t.state b
 
   let eval_constraints t = eval_constraints t.state
+
+  let set_eval_constraints t b = set_eval_constraints t.state b
 
   let system t = system t.state
 

--- a/src/base/state.ml
+++ b/src/base/state.ml
@@ -144,7 +144,7 @@ module Make
 
   let seal t = seal t.state
 
-  let get_value t = get_value t.state
+  let get_value t = evaluate_var t.state
 
   (* We redefine the [make] function with the wrapper in mind. *)
 

--- a/src/base/state.ml
+++ b/src/base/state.ml
@@ -76,12 +76,6 @@ module type S = sig
   val seal : t -> cvar -> cvar
 
   val get_value : t -> cvar -> Field.t
-
-  (* TODO: maybe not a good place to provide this... *)
-  val eval_constraint :
-       (cvar, Field.t) Constraint.basic_with_annotation
-    -> (cvar -> Field.t)
-    -> bool
 end
 
 module Make

--- a/src/base/state.ml
+++ b/src/base/state.ml
@@ -27,6 +27,8 @@ module type S = sig
     -> unit
     -> t
 
+  val debug : t -> unit
+
   val add_constraint :
     ?label:string -> t -> (cvar, Field.t) Constraint.basic -> unit
 
@@ -146,7 +148,9 @@ module Make
 
   let get_value t = evaluate_var t.state
 
-  (* We redefine the [make] function with the wrapper in mind. *)
+  (* We redefine some functions in the same way,
+     but with the wrapper in mind as well.
+  *)
 
   let make :
          num_inputs:int
@@ -175,6 +179,11 @@ module Make
     ; is_running
     ; log_constraint
     }
+
+  (* TODO: add [is_running] and other useful stuff in debug *)
+  let debug t =
+    if Option.is_some (Sys.getenv_opt "SNARKY_DEBUG") then
+      printf "[snarky] %s\n" (Run_state.debug t.state)
 
   (* We define a number of functions that are only relevant for the extra fields we added in the wrapper. *)
 

--- a/src/base/state.ml
+++ b/src/base/state.ml
@@ -74,6 +74,11 @@ module type S = sig
   val next_auxiliary : t -> int
 
   val seal : t -> cvar -> cvar
+
+  val eval_constraint :
+       (cvar, Field.t) Constraint.basic_with_annotation
+    -> (cvar -> Field.t)
+    -> bool
 end
 
 module Make

--- a/src/base/state.ml
+++ b/src/base/state.ml
@@ -30,8 +30,6 @@ module type S = sig
   val add_constraint :
     ?label:string -> t -> (cvar, Field.t) Constraint.basic -> unit
 
-  val get_variable_value : t -> int -> Field.t
-
   val store_field_elt : t -> Field.t -> cvar
 
   val alloc_var : t -> cvar
@@ -116,8 +114,6 @@ module Make
     }
 
   (* We redefine a number of functions but on the wrapper. *)
-
-  let get_variable_value t idx = get_variable_value t.state idx
 
   let store_field_elt t field = store_field_elt t.state field
 

--- a/src/base/utils.ml
+++ b/src/base/utils.ml
@@ -221,6 +221,8 @@ struct
 
     let false_ : var = create (Cvar.constant Field.zero)
 
+    let to_field_var : var -> Cvar.t = Boolean.to_field_var
+
     let not (x : var) : var = create Cvar.((true_ :> Cvar.t) - (x :> Cvar.t))
 
     let if_ b ~(then_ : var) ~(else_ : var) =

--- a/src/intf/vector.ml
+++ b/src/intf/vector.ml
@@ -9,6 +9,8 @@ module type S = sig
 
   val get : t -> int -> elt
 
+  val set : t -> int -> elt -> unit
+
   val emplace_back : t -> elt -> unit
 
   val length : t -> int


### PR DESCRIPTION
Builds on top of https://github.com/o1-labs/snarky/pull/799 as it is starting to get quite long.

This contains a number of misc changes that I need to make in order to make the Mina-side work (https://github.com/MinaProtocol/mina/pull/12738). It contains:

* remove the R1CS trick
* move all the `eval_constraint` logic to the Rust side
* obtain `get_value` and `Cvar.eval` from `Backend.Run_state`
* add the `debug` function that helped me a lot