### PR TITLE
Add run_and_check_exn and friends

### DIFF
--- a/src/base/runners.ml
+++ b/src/base/runners.ml
@@ -97,7 +97,7 @@ struct
         R1CS_constraint_system.finalize system ) ;
     (aux, true_output)
 
-  let run_and_check' ~run t0 =
+  let run_and_check_exn' ~run t0 =
     let num_inputs = 0 in
     let input = field_vec () in
     let next_auxiliary = ref 0 in
@@ -112,13 +112,17 @@ struct
         ~aux:(pack_field_vec aux) ~system ~eval_constraints:true
         ~with_witness:true ()
     in
-    match run t0 state with
+    let _, x = run t0 state in
+    (x, get_value)
+
+  let run_and_check' ~run t0 =
+    match run_and_check_exn' ~run t0 with
     | exception e ->
         Or_error.of_exn ~backtrace:`Get e
-    | _, x ->
-        Ok (x, get_value)
+    | res ->
+        Ok res
 
-  let run_and_check_deferred' ~map ~return ~run t0 =
+  let run_and_check_deferred_exn' ~map ~run t0 =
     let num_inputs = 0 in
     let input = field_vec () in
     let next_auxiliary = ref 0 in
@@ -133,11 +137,19 @@ struct
         ~aux:(pack_field_vec aux) ~system ~eval_constraints:true
         ~with_witness:true ()
     in
-    match run t0 state with
+    let res = run t0 state in
+    map res ~f:(function _, x -> (x, get_value))
+
+  let run_and_check_deferred' ~map ~return ~run t0 =
+    match
+      run_and_check_deferred_exn'
+        ~map:(fun x ~f -> map x ~f:(fun x -> Ok (f x)))
+        ~run t0
+    with
     | exception e ->
         return (Or_error.of_exn ~backtrace:`Get e)
     | res ->
-        map res ~f:(function _, x -> Ok (x, get_value))
+        res
 
   let run_unchecked ~run t0 =
     let num_inputs = 0 in
@@ -150,10 +162,17 @@ struct
     in
     match run t0 state with _, x -> x
 
+  let run_and_check_exn ~run t =
+    let x, get_value = run_and_check_exn' ~run t in
+    let x = As_prover.run x get_value in
+    x
+
   let run_and_check ~run t =
     Or_error.map (run_and_check' ~run t) ~f:(fun (x, get_value) ->
         let x = As_prover.run x get_value in
         x )
+
+  let check_exn ~run t = run_and_check_exn' ~run t |> Fn.const ()
 
   let check ~run t = run_and_check' ~run t |> Result.map ~f:(Fn.const ())
 
@@ -354,7 +373,11 @@ struct
 
     let run_unchecked = run_unchecked
 
+    let run_and_check_exn = run_and_check_exn
+
     let run_and_check = run_and_check
+
+    let check_exn = check_exn
 
     let check = check
   end
@@ -380,5 +403,9 @@ struct
 
   let run_and_check t = run_and_check ~run:Checked.run t
 
+  let run_and_check_exn t = run_and_check_exn ~run:Checked.run t
+
   let check t = check ~run:Checked.run t
+
+  let check_exn t = check_exn ~run:Checked.run t
 end

--- a/src/base/snark0.ml
+++ b/src/base/snark0.ml
@@ -1314,6 +1314,18 @@ module Run = struct
       finalize_is_running (fun () ->
           Perform.run_unchecked ~run:as_stateful (fun () -> mark_active ~f:x) )
 
+    let run_and_check_exn (type a) (x : unit -> (unit -> a) As_prover.t) : a =
+      finalize_is_running (fun () ->
+          let res =
+            Perform.run_and_check_exn ~run:as_stateful (fun () ->
+                mark_active ~f:(fun () ->
+                    let prover_block = x () in
+                    Run_state.set_as_prover !state true ;
+                    As_prover.run_prover prover_block ) )
+          in
+          Run_state.set_as_prover !state true ;
+          res )
+
     let run_and_check (type a) (x : unit -> (unit -> a) As_prover.t) :
         a Or_error.t =
       finalize_is_running (fun () ->
@@ -1337,6 +1349,11 @@ module Run = struct
     struct
       open M
 
+      let run_and_check_exn ~run t =
+        map (run_and_check_deferred_exn' ~run t ~map) ~f:(fun (x, get_value) ->
+            let x = Basic.As_prover.run x get_value in
+            x )
+
       let run_and_check ~run t =
         map
           (run_and_check_deferred' ~run t ~map ~return)
@@ -1348,6 +1365,20 @@ module Run = struct
       let as_stateful x state' =
         state := state' ;
         map (x ()) ~f:(fun a -> (!state, a))
+
+      let run_and_check_exn (type a) (x : unit -> (unit -> a) As_prover.t M.t) :
+          a M.t =
+        finalize_is_running (fun () ->
+            let mark_active = mark_active_deferred ~map in
+            let res =
+              run_and_check_exn ~run:as_stateful (fun () ->
+                  mark_active ~f:(fun () ->
+                      map (x ()) ~f:(fun prover_block ->
+                          Run_state.set_as_prover !state true ;
+                          As_prover.run_prover prover_block ) ) )
+            in
+            Run_state.set_as_prover !state true ;
+            res )
 
       let run_and_check (type a) (x : unit -> (unit -> a) As_prover.t M.t) :
           a Or_error.t M.t =
@@ -1363,6 +1394,9 @@ module Run = struct
             Run_state.set_as_prover !state true ;
             res )
     end
+
+    let check_exn x : unit =
+      finalize_is_running (fun () -> Perform.check_exn ~run:as_stateful x)
 
     let check x : unit Or_error.t =
       finalize_is_running (fun () -> Perform.check ~run:as_stateful x)

--- a/src/base/snark_intf.ml
+++ b/src/base/snark_intf.ml
@@ -1010,9 +1010,19 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
   (** Run a checked computation as the prover, checking the constraints. *)
   val run_and_check : 'a As_prover.t Checked.t -> 'a Or_error.t
 
+  (** Run a checked computation as the prover, checking the constraints.
+      Will raise an exception on failure.
+  *)
+  val run_and_check_exn : 'a As_prover.t Checked.t -> 'a
+
   (** Run a checked computation as the prover, returning [true] if the
       constraints are all satisfied, or [false] otherwise. *)
   val check : 'a Checked.t -> unit Or_error.t
+
+  (** Run a checked computation as the prover, raising an exception if any
+      constraints are not satisfied.
+  *)
+  val check_exn : 'a Checked.t -> unit
 
   (** Run the checked computation and generate the auxiliary input, but don't
       generate a proof.
@@ -1386,6 +1396,8 @@ module type Run_basic = sig
 
   val run_and_check : (unit -> (unit -> 'a) As_prover.t) -> 'a Or_error.t
 
+  val run_and_check_exn : (unit -> (unit -> 'a) As_prover.t) -> 'a
+
   module Run_and_check_deferred (M : sig
     type _ t
 
@@ -1395,7 +1407,11 @@ module type Run_basic = sig
   end) : sig
     val run_and_check :
       (unit -> (unit -> 'a) As_prover.t M.t) -> 'a Or_error.t M.t
+
+    val run_and_check_exn : (unit -> (unit -> 'a) As_prover.t M.t) -> 'a M.t
   end
+
+  val check_exn : (unit -> 'a) -> unit
 
   val check : (unit -> 'a) -> unit Or_error.t
 


### PR DESCRIPTION
This PR adds versions of `run_and_check` and `check` that don't capture the exception in an `Or_error.t`, instead allowing the exception itself to propagate. This allows e.g. SnarkyJS to handle the errors more directly.