### PR TITLE
Snarkyjs: Reduce loading time

### DIFF
--- a/src/base/backend_extended.ml
+++ b/src/base/backend_extended.ml
@@ -174,10 +174,6 @@ struct
 
     let t_of_sexp = Fn.compose of_bignum_bigint Bignum_bigint.t_of_sexp
 
-    let to_string = Fn.compose Bignum_bigint.to_string to_bignum_bigint
-
-    let of_string = Fn.compose of_bignum_bigint Bignum_bigint.of_string
-
     let%test_unit "project correctness" =
       Quickcheck.test
         Quickcheck.Generator.(

--- a/src/base/snark0.ml
+++ b/src/base/snark0.ml
@@ -464,11 +464,12 @@ struct
             (of_binary (lt_binary (xs :> Boolean.var list) (ys :> bool list)))
 
       let field_size_bits =
-        List.init Field.size_in_bits ~f:(fun i ->
-            Z.testbit
-              (Bignum_bigint.to_zarith_bigint Field.size)
-              Stdlib.(Field.size_in_bits - 1 - i) )
-        |> Bitstring_lib.Bitstring.Msb_first.of_list
+        lazy
+          ( List.init Field.size_in_bits ~f:(fun i ->
+                Z.testbit
+                  (Bignum_bigint.to_zarith_bigint Field.size)
+                  Stdlib.(Field.size_in_bits - 1 - i) )
+          |> Bitstring_lib.Bitstring.Msb_first.of_list )
 
       let unpack_full x =
         let module Bitstring = Bitstring_lib.Bitstring in
@@ -480,7 +481,7 @@ struct
         let%map () =
           lt_bitstring_value
             (Bitstring.Msb_first.of_lsb_first res)
-            field_size_bits
+            (Lazy.force field_size_bits)
           >>= Checked.Boolean.Assert.is_true
         in
         res

--- a/src/intf/field.ml
+++ b/src/intf/field.ml
@@ -3,6 +3,10 @@ module type S = sig
 
   val of_int : int -> t
 
+  val of_string : string -> t
+
+  val to_string : t -> string
+
   val one : t
 
   val zero : t


### PR DESCRIPTION
supports https://github.com/o1-labs/snarkyjs/pull/1073

- make computation of field size bits lazy so it doesn't block web page loading
  - `Z.testbit` is very slow. In the near future I hope to put more performant js implementations in place, and changes like this one will no longer be necessary
 - use `Field.to_string` and `Field.of_string` from the bindings instead of implementing it via `to_bignum_bigint` and `Bignum_bigint.to_string`
   - this just makes sense, because it gives us the flexibility of optimizing the implementation in JS
   - just a glimpse of many future similar changes that I'd like to do, avoiding the zarith bigint stubs which are slow