### PR TITLE
[develop] Compute the size of the concatenation of all fixed and runtime lookup tables

### DIFF
--- a/src/base/backend_intf.ml
+++ b/src/base/backend_intf.ml
@@ -24,6 +24,8 @@ module type Constraint_system_intf = sig
 
   val get_concatenated_fixed_lookup_table_size : t -> int
 
+  val get_concatenated_runtime_lookup_table_size : t -> int
+
   val get_rows_len : t -> int
 end
 

--- a/src/base/backend_intf.ml
+++ b/src/base/backend_intf.ml
@@ -22,6 +22,8 @@ module type Constraint_system_intf = sig
 
   val get_public_input_size : t -> int Core_kernel.Set_once.t
 
+  val get_concatenated_fixed_lookup_table_size : t -> int
+
   val get_rows_len : t -> int
 end
 

--- a/src/base/snark_intf.ml
+++ b/src/base/snark_intf.ml
@@ -1118,6 +1118,8 @@ module type Run_basic = sig
 
     val get_concatenated_fixed_lookup_table_size : t -> int
 
+    val get_concatenated_runtime_lookup_table_size : t -> int
+
     val get_rows_len : t -> int
   end
 

--- a/src/base/snark_intf.ml
+++ b/src/base/snark_intf.ml
@@ -1116,6 +1116,8 @@ module type Run_basic = sig
 
     val get_public_input_size : t -> int Core_kernel.Set_once.t
 
+    val get_concatenated_fixed_lookup_table_size : t -> int
+
     val get_rows_len : t -> int
   end
 


### PR DESCRIPTION
Related to https://github.com/MinaProtocol/mina/pull/14004