### PR TITLE
Async requests

### DIFF
--- a/src/base/snark0.ml
+++ b/src/base/snark0.ml
@@ -1432,7 +1432,7 @@ module Run = struct
       Request.Handler.run (Run_state.handler !state) (req ())
       |> Option.value_exn ~message:"Unhandled request"
 
-    module Async' (Promise : Base.Monad.S) = struct
+    module Async_generic (Promise : Base.Monad.S) = struct
       let run_prover ~(else_ : unit -> 'a) (f : unit -> 'a Promise.t) :
           'a Promise.t =
         if Run_state.has_witness !state then (

--- a/src/base/snark0.ml
+++ b/src/base/snark0.ml
@@ -1428,6 +1428,16 @@ module Run = struct
       in
       Staged.stage finish_computation
 
+    module Async' (Promise : Base.Monad.S) = struct
+      let request (request : unit -> 'a Promise.t Request.t) =
+        let r = exists (Typ.Internal.ref ()) ~request ?compute:None in
+        match !r with
+        | Some p ->
+            Promise.map p ~f:(fun x -> Some x)
+        | None ->
+            Promise.return None
+    end
+
     let run_unchecked x =
       finalize_is_running (fun () ->
           Perform.run_unchecked ~run:as_stateful (fun () -> mark_active ~f:x) )

--- a/src/base/snark_intf.ml
+++ b/src/base/snark_intf.ml
@@ -1405,6 +1405,10 @@ module type Run_basic = sig
   (* Callback, low-level version of [as_prover] and [exists]. *)
   val as_prover_manual : int -> (field array option -> Field.t array) Staged.t
 
+  module Async' (Promise : Base.Monad.S) : sig
+    val request : (unit -> 'a Promise.t Request.t) -> 'a option Promise.t
+  end
+
   (** Generate the public input vector for a given statement. *)
   val generate_public_input :
     ('input_var, 'input_value) Typ.t -> 'input_value -> Field.Constant.Vector.t

--- a/src/base/snark_intf.ml
+++ b/src/base/snark_intf.ml
@@ -1405,7 +1405,7 @@ module type Run_basic = sig
   (* Callback, low-level version of [as_prover] and [exists]. *)
   val as_prover_manual : int -> (field array option -> Field.t array) Staged.t
 
-  module Async' (Promise : Base.Monad.S) : sig
+  module Async_generic (Promise : Base.Monad.S) : sig
     val as_prover : (unit -> unit Promise.t) -> unit Promise.t
 
     val unit_request : (unit -> unit Promise.t Request.t) -> unit Promise.t

--- a/src/base/snark_intf.ml
+++ b/src/base/snark_intf.ml
@@ -1406,7 +1406,9 @@ module type Run_basic = sig
   val as_prover_manual : int -> (field array option -> Field.t array) Staged.t
 
   module Async' (Promise : Base.Monad.S) : sig
-    val request : (unit -> 'a Promise.t Request.t) -> 'a option Promise.t
+    val as_prover : (unit -> unit Promise.t) -> unit Promise.t
+
+    val unit_request : (unit -> unit Promise.t Request.t) -> unit Promise.t
   end
 
   (** Generate the public input vector for a given statement. *)


### PR DESCRIPTION
This adds a small `Async_generic` module to snarky which functors over a `Promise` (any `Monad` actually) module and implements an async handler for a `unit Promise.t Request.t`, needed by https://github.com/MinaProtocol/mina/pull/15305

This could be easily extended in the future to support more general async versions of `exists`
