### PR TITLE
Remove polymorphism from `As_prover.t`, hoist `Typ.t`

### DIFF
--- a/src/base/as_prover0.ml
+++ b/src/base/as_prover0.ml
@@ -1,53 +1,56 @@
 open Core_kernel
 
-type ('a, 'f) t = ('a, 'f) Types.As_prover.t
+module Make
+    (Types : Types.Types
+               with type ('a, 'f) As_prover.t = ('f Cvar.t -> 'f) -> 'a) =
+struct
+  type ('a, 'f) t = ('a, 'f) Types.As_prover.t
 
-let map t ~f tbl =
-  let x = t tbl in
-  f x
+  let map t ~f tbl =
+    let x = t tbl in
+    f x
 
-let bind t ~f tbl =
-  let x = t tbl in
-  f x tbl
+  let bind t ~f tbl =
+    let x = t tbl in
+    f x tbl
 
-let return x _ = x
+  let return x _ = x
 
-let run t tbl = t tbl
+  let run t tbl = t tbl
 
-let get_state _tbl s = (s, s)
+  let get_state _tbl s = (s, s)
 
-let set_state s _tbl _ = (s, ())
+  let set_state s _tbl _ = (s, ())
 
-let modify_state f _tbl s = (f s, ())
+  let modify_state f _tbl s = (f s, ())
 
-let map2 x y ~f tbl =
-  let x = x tbl in
-  let y = y tbl in
-  f x y
+  let map2 x y ~f tbl =
+    let x = x tbl in
+    let y = y tbl in
+    f x y
 
-let read_var (v : 'var) : ('field, 'field) t = fun tbl -> tbl v
+  let read_var (v : 'var) : ('field, 'field) t = fun tbl -> tbl v
 
-let read
-    (Typ { var_to_fields; value_of_fields; _ } :
-      ('var, 'value, 'field, _) Types.Typ.t ) (var : 'var) : ('value, 'field) t
-    =
- fun tbl ->
-  let field_vars, aux = var_to_fields var in
-  let fields = Array.map ~f:tbl field_vars in
-  value_of_fields (fields, aux)
+  let read
+      (Typ { var_to_fields; value_of_fields; _ } :
+        ('var, 'value, 'field) Types.Typ.t ) (var : 'var) : ('value, 'field) t =
+   fun tbl ->
+    let field_vars, aux = var_to_fields var in
+    let fields = Array.map ~f:tbl field_vars in
+    value_of_fields (fields, aux)
 
-include Monad_let.Make2 (struct
-  type nonrec ('a, 'e) t = ('a, 'e) t
+  include Monad_let.Make2 (struct
+    type nonrec ('a, 'e) t = ('a, 'e) t
 
-  let map = `Custom map
+    let map = `Custom map
 
-  let bind = bind
+    let bind = bind
 
-  let return = return
-end)
+    let return = return
+  end)
 
-module Provider = struct
-  (** The different ways to generate a value of type ['a] for a circuit
+  module Provider = struct
+    (** The different ways to generate a value of type ['a] for a circuit
         witness over field ['f].
 
         This is one of:
@@ -56,29 +59,30 @@ module Provider = struct
         * [Both], attempting to dispatch an ['a Request.t], and falling back to
           the computation if the request is unhandled or raises an exception.
     *)
-  type nonrec ('a, 'f) t = (('a Request.t, 'f) t, ('a, 'f) t) Types.Provider.t
+    type nonrec ('a, 'f) t = ('a, 'f) Types.Provider.t
 
-  open Types.Provider
+    open Types.Provider
 
-  let run t tbl (handler : Request.Handler.t) =
-    match t with
-    | Request rc ->
-        let r = run rc tbl in
-        Request.Handler.run handler r
-    | Compute c ->
-        Some (run c tbl)
-    | Both (rc, c) -> (
-        let r = run rc tbl in
-        match Request.Handler.run handler r with
-        | None | (exception _) ->
-            Some (run c tbl)
-        | x ->
-            x )
-end
+    let run t tbl (handler : Request.Handler.t) =
+      match t with
+      | Request rc ->
+          let r = run rc tbl in
+          Request.Handler.run handler r
+      | Compute c ->
+          Some (run c tbl)
+      | Both (rc, c) -> (
+          let r = run rc tbl in
+          match Request.Handler.run handler r with
+          | None | (exception _) ->
+              Some (run c tbl)
+          | x ->
+              x )
+  end
 
-module Handle = struct
-  let value (t : ('var, 'value) Handle.t) : ('value, 'field) t =
-   fun _ -> Option.value_exn t.value
+  module Handle = struct
+    let value (t : ('var, 'value) Handle.t) : ('value, 'field) t =
+     fun _ -> Option.value_exn t.value
+  end
 end
 
 module type Extended = sig

--- a/src/base/as_prover0.ml
+++ b/src/base/as_prover0.ml
@@ -5,9 +5,11 @@ module Make (Backend : sig
     type t
   end
 end)
-(Types : Types.Types with type ('a, 'f) As_prover.t = ('f Cvar.t -> 'f) -> 'a) =
+(Types : Types.Types
+           with type 'a As_prover.t =
+             (Backend.Field.t Cvar.t -> Backend.Field.t) -> 'a) =
 struct
-  type 'a t = ('a, Backend.Field.t) Types.As_prover.t
+  type 'a t = 'a Types.As_prover.t
 
   let map t ~f tbl =
     let x = t tbl in
@@ -53,18 +55,7 @@ struct
   end)
 
   module Provider = struct
-    (** The different ways to generate a value of type ['a] for a circuit
-        witness over field ['f].
-
-        This is one of:
-        * a [Request], dispatching an ['a Request.t];
-        * [Compute], running a computation to generate the value;
-        * [Both], attempting to dispatch an ['a Request.t], and falling back to
-          the computation if the request is unhandled or raises an exception.
-    *)
-    type nonrec ('a, 'f) t = ('a, 'f) Types.Provider.t
-
-    open Types.Provider
+    include Types.Provider
 
     let run t tbl (handler : Request.Handler.t) =
       match t with

--- a/src/base/as_prover_intf.ml
+++ b/src/base/as_prover_intf.ml
@@ -3,7 +3,7 @@ module type Basic = sig
 
   type field
 
-  type 'a t = ('a, field) Types.As_prover.t
+  type 'a t = 'a Types.As_prover.t
 
   include Monad_let.S with type 'a t := 'a t
 
@@ -16,13 +16,12 @@ module type Basic = sig
   val read : ('var, 'value, field) Types.Typ.t -> 'var -> 'value t
 
   module Provider : sig
-    type ('a, 'f) t
+    type 'a t
 
-    val run :
-      ('a, field) t -> (field Cvar.t -> field) -> Request.Handler.t -> 'a option
+    val run : 'a t -> (field Cvar.t -> field) -> Request.Handler.t -> 'a option
   end
 
   module Handle : sig
-    val value : ('var, 'value) Handle.t -> ('value, field) Types.As_prover.t
+    val value : ('var, 'value) Handle.t -> 'value Types.As_prover.t
   end
 end

--- a/src/base/as_prover_intf.ml
+++ b/src/base/as_prover_intf.ml
@@ -1,4 +1,6 @@
 module type Basic = sig
+  module Types : Types.Types
+
   type ('a, 'f) t = ('a, 'f) Types.As_prover.t
 
   type field
@@ -12,7 +14,7 @@ module type Basic = sig
 
   val read_var : field Cvar.t -> (field, field) t
 
-  val read : ('var, 'value, field, _) Types.Typ.t -> 'var -> ('value, field) t
+  val read : ('var, 'value, field) Types.Typ.t -> 'var -> ('value, field) t
 
   module Provider : sig
     type ('a, 'f) t

--- a/src/base/as_prover_intf.ml
+++ b/src/base/as_prover_intf.ml
@@ -1,20 +1,19 @@
 module type Basic = sig
   module Types : Types.Types
 
-  type ('a, 'f) t = ('a, 'f) Types.As_prover.t
-
   type field
 
-  include Monad_let.S2 with type ('a, 'f) t := ('a, field) t
+  type 'a t = ('a, field) Types.As_prover.t
 
-  val run : ('a, field) t -> (field Cvar.t -> field) -> 'a
+  include Monad_let.S with type 'a t := 'a t
 
-  val map2 :
-    ('a, field) t -> ('b, field) t -> f:('a -> 'b -> 'c) -> ('c, field) t
+  val run : 'a t -> (field Cvar.t -> field) -> 'a
 
-  val read_var : field Cvar.t -> (field, field) t
+  val map2 : 'a t -> 'b t -> f:('a -> 'b -> 'c) -> 'c t
 
-  val read : ('var, 'value, field) Types.Typ.t -> 'var -> ('value, field) t
+  val read_var : field Cvar.t -> field t
+
+  val read : ('var, 'value, field) Types.Typ.t -> 'var -> 'value t
 
   module Provider : sig
     type ('a, 'f) t

--- a/src/base/checked.ml
+++ b/src/base/checked.ml
@@ -5,12 +5,12 @@ module Make (Field : sig
 
   val equal : t -> t -> bool
 end)
-(Basic : Checked_intf.Basic with type field = Field.t)
+(Types : Types.Types)
+(Basic : Checked_intf.Basic with type field = Field.t with module Types := Types)
 (As_prover : As_prover_intf.Basic
                with type field := Basic.field
-               with module Types := Basic.Types) :
-  Checked_intf.S with module Types = Basic.Types with type field = Basic.field =
-struct
+               with module Types := Types) :
+  Checked_intf.S with module Types := Types with type field = Field.t = struct
   include Basic
 
   let request_witness (typ : ('var, 'value, field) Types.Typ.t)

--- a/src/base/checked.ml
+++ b/src/base/checked.ml
@@ -6,7 +6,9 @@ module Make (Field : sig
   val equal : t -> t -> bool
 end)
 (Basic : Checked_intf.Basic with type field = Field.t)
-(As_prover : As_prover_intf.Basic with type field := Basic.field) :
+(As_prover : As_prover_intf.Basic
+               with type field := Basic.field
+               with module Types := Basic.Types) :
   Checked_intf.S with module Types = Basic.Types with type field = Basic.field =
 struct
   include Basic

--- a/src/base/checked.ml
+++ b/src/base/checked.ml
@@ -14,7 +14,7 @@ end)
   include Basic
 
   let request_witness (typ : ('var, 'value, field) Types.Typ.t)
-      (r : ('value Request.t, field) As_prover.t) =
+      (r : 'value Request.t As_prover.t) =
     let%map h = exists typ (Request r) in
     Handle.var h
 

--- a/src/base/checked_intf.ml
+++ b/src/base/checked_intf.ml
@@ -112,33 +112,7 @@ module type S = sig
 end
 
 module type Extended = sig
-  type field
-
-  module Types : Types.Types
-
-  type 'a t = ('a, field) Types.Checked.t
-
-  include
-    S
-      with module Types := Types
-      with type field := field
-       and type 'a t := ('a, field) Types.Checked.t
+  include S
 
   val run : 'a t -> field Run_state.t -> field Run_state.t * 'a
-end
-
-module Unextend
-    (Types : Types.Types)
-    (Checked : Extended with module Types := Types) :
-  S with module Types := Types with type field = Checked.field = struct
-  include (
-    Checked :
-      S
-        with module Types := Types
-        with type field := Checked.field
-         and type 'a t := ('a, Checked.field) Types.Checked.t )
-
-  type field = Checked.field
-
-  type 'a t = ('a, field) Types.Checked.t
 end

--- a/src/base/checked_intf.ml
+++ b/src/base/checked_intf.ml
@@ -9,7 +9,7 @@ module type Basic = sig
 
   val add_constraint : (field Cvar.t, field) Constraint.t -> (unit, field) t
 
-  val as_prover : (unit, field) As_prover0.t -> (unit, field) t
+  val as_prover : (unit, field) Types.As_prover.t -> (unit, field) t
 
   val mk_lazy : (unit -> ('a, 'f) t) -> ('a Lazy.t, 'f) t
 
@@ -43,13 +43,13 @@ module type S = sig
 
   include Monad_let.S2 with type ('a, 'f) t := ('a, 'f) t
 
-  val as_prover : (unit, field) As_prover0.t -> (unit, field) t
+  val as_prover : (unit, field) Types.As_prover.t -> (unit, field) t
 
   val mk_lazy : (unit -> ('a, 'f) t) -> ('a Lazy.t, 'f) t
 
   val request_witness :
        ('var, 'value, field) Types.Typ.t
-    -> ('value Request.t, field) As_prover0.t
+    -> ('value Request.t, field) Types.As_prover.t
     -> ('var, field) t
 
   val request :
@@ -59,14 +59,14 @@ module type S = sig
     -> ('var, field) t
 
   val exists_handle :
-       ?request:('value Request.t, field) As_prover0.t
-    -> ?compute:('value, field) As_prover0.t
+       ?request:('value Request.t, field) Types.As_prover.t
+    -> ?compute:('value, field) Types.As_prover.t
     -> ('var, 'value, field) Types.Typ.t
     -> (('var, 'value) Handle.t, field) t
 
   val exists :
-       ?request:('value Request.t, field) As_prover0.t
-    -> ?compute:('value, field) As_prover0.t
+       ?request:('value Request.t, field) Types.As_prover.t
+    -> ?compute:('value, field) Types.As_prover.t
     -> ('var, 'value, field) Types.Typ.t
     -> ('var, field) t
 
@@ -83,7 +83,7 @@ module type S = sig
 
   val handle_as_prover :
        (unit -> ('a, field) t)
-    -> (request -> response, field) As_prover0.t
+    -> (request -> response, field) Types.As_prover.t
     -> ('a, field) t
 
   val next_auxiliary : unit -> (int, field) t

--- a/src/base/checked_intf.ml
+++ b/src/base/checked_intf.ml
@@ -9,7 +9,7 @@ module type Basic = sig
 
   val add_constraint : (field Cvar.t, field) Constraint.t -> unit t
 
-  val as_prover : (unit, field) Types.As_prover.t -> unit t
+  val as_prover : unit Types.As_prover.t -> unit t
 
   val mk_lazy : (unit -> 'a t) -> 'a Lazy.t t
 
@@ -19,7 +19,7 @@ module type Basic = sig
 
   val exists :
        ('var, 'value, field) Types.Typ.t
-    -> ('value, field) Types.Provider.t
+    -> 'value Types.Provider.t
     -> ('var, 'value) Handle.t t
 
   val next_auxiliary : unit -> int t
@@ -42,13 +42,13 @@ module type S = sig
 
   include Monad_let.S with type 'a t := 'a t
 
-  val as_prover : (unit, field) Types.As_prover.t -> unit t
+  val as_prover : unit Types.As_prover.t -> unit t
 
   val mk_lazy : (unit -> 'a t) -> 'a Lazy.t t
 
   val request_witness :
        ('var, 'value, field) Types.Typ.t
-    -> ('value Request.t, field) Types.As_prover.t
+    -> 'value Request.t Types.As_prover.t
     -> 'var t
 
   val request :
@@ -58,14 +58,14 @@ module type S = sig
     -> 'var t
 
   val exists_handle :
-       ?request:('value Request.t, field) Types.As_prover.t
-    -> ?compute:('value, field) Types.As_prover.t
+       ?request:'value Request.t Types.As_prover.t
+    -> ?compute:'value Types.As_prover.t
     -> ('var, 'value, field) Types.Typ.t
     -> ('var, 'value) Handle.t t
 
   val exists :
-       ?request:('value Request.t, field) Types.As_prover.t
-    -> ?compute:('value, field) Types.As_prover.t
+       ?request:'value Request.t Types.As_prover.t
+    -> ?compute:'value Types.As_prover.t
     -> ('var, 'value, field) Types.Typ.t
     -> 'var t
 
@@ -81,7 +81,7 @@ module type S = sig
   val handle : (unit -> 'a t) -> (request -> response) -> 'a t
 
   val handle_as_prover :
-    (unit -> 'a t) -> (request -> response, field) Types.As_prover.t -> 'a t
+    (unit -> 'a t) -> (request -> response) Types.As_prover.t -> 'a t
 
   val next_auxiliary : unit -> int t
 

--- a/src/base/checked_intf.ml
+++ b/src/base/checked_intf.ml
@@ -1,74 +1,73 @@
 module type Basic = sig
   module Types : Types.Types
 
-  type ('a, 'f) t = ('a, 'f) Types.Checked.t
-
   type field
 
-  include Monad_let.S2 with type ('a, 'f) t := ('a, 'f) t
+  type 'a t = ('a, field) Types.Checked.t
 
-  val add_constraint : (field Cvar.t, field) Constraint.t -> (unit, field) t
+  include Monad_let.S with type 'a t := 'a t
 
-  val as_prover : (unit, field) Types.As_prover.t -> (unit, field) t
+  val add_constraint : (field Cvar.t, field) Constraint.t -> unit t
 
-  val mk_lazy : (unit -> ('a, 'f) t) -> ('a Lazy.t, 'f) t
+  val as_prover : (unit, field) Types.As_prover.t -> unit t
 
-  val with_label : string -> (unit -> ('a, field) t) -> ('a, field) t
+  val mk_lazy : (unit -> 'a t) -> 'a Lazy.t t
 
-  val with_handler :
-    Request.Handler.single -> (unit -> ('a, field) t) -> ('a, field) t
+  val with_label : string -> (unit -> 'a t) -> 'a t
+
+  val with_handler : Request.Handler.single -> (unit -> 'a t) -> 'a t
 
   val exists :
        ('var, 'value, field) Types.Typ.t
     -> ('value, field) Types.Provider.t
-    -> (('var, 'value) Handle.t, field) t
+    -> ('var, 'value) Handle.t t
 
-  val next_auxiliary : unit -> (int, field) t
+  val next_auxiliary : unit -> int t
 
-  val direct : (field Run_state.t -> field Run_state.t * 'a) -> ('a, field) t
+  val direct : (field Run_state.t -> field Run_state.t * 'a) -> 'a t
 
   val constraint_count :
        ?weight:((field Cvar.t, field) Constraint.t -> int)
     -> ?log:(?start:bool -> string -> int -> unit)
-    -> (unit -> ('a, field) t)
+    -> (unit -> 'a t)
     -> int
 end
 
 module type S = sig
   module Types : Types.Types
 
-  type ('a, 'f) t = ('a, 'f) Types.Checked.t
-
   type field
 
-  include Monad_let.S2 with type ('a, 'f) t := ('a, 'f) t
+  type 'a t = ('a, field) Types.Checked.t
 
-  val as_prover : (unit, field) Types.As_prover.t -> (unit, field) t
+  include Monad_let.S with type 'a t := 'a t
 
-  val mk_lazy : (unit -> ('a, 'f) t) -> ('a Lazy.t, 'f) t
+  val as_prover : (unit, field) Types.As_prover.t -> unit t
+
+  val mk_lazy : (unit -> 'a t) -> 'a Lazy.t t
 
   val request_witness :
        ('var, 'value, field) Types.Typ.t
     -> ('value Request.t, field) Types.As_prover.t
-    -> ('var, field) t
+    -> 'var t
 
   val request :
-       ?such_that:('var -> (unit, field) t)
+       ?such_that:('var -> unit t)
     -> ('var, 'value, field) Types.Typ.t
     -> 'value Request.t
-    -> ('var, field) t
+    -> 'var t
 
   val exists_handle :
        ?request:('value Request.t, field) Types.As_prover.t
     -> ?compute:('value, field) Types.As_prover.t
     -> ('var, 'value, field) Types.Typ.t
-    -> (('var, 'value) Handle.t, field) t
+    -> ('var, 'value) Handle.t t
 
   val exists :
        ?request:('value Request.t, field) Types.As_prover.t
     -> ?compute:('value, field) Types.As_prover.t
     -> ('var, 'value, field) Types.Typ.t
-    -> ('var, field) t
+    -> 'var t
 
   type response = Request.response
 
@@ -79,44 +78,36 @@ module type S = sig
         { request : 'a Request.t; respond : 'a Request.Response.t -> response }
         -> request
 
-  val handle : (unit -> ('a, field) t) -> (request -> response) -> ('a, field) t
+  val handle : (unit -> 'a t) -> (request -> response) -> 'a t
 
   val handle_as_prover :
-       (unit -> ('a, field) t)
-    -> (request -> response, field) Types.As_prover.t
-    -> ('a, field) t
+    (unit -> 'a t) -> (request -> response, field) Types.As_prover.t -> 'a t
 
-  val next_auxiliary : unit -> (int, field) t
+  val next_auxiliary : unit -> int t
 
-  val with_label : string -> (unit -> ('a, field) t) -> ('a, field) t
+  val with_label : string -> (unit -> 'a t) -> 'a t
 
   val assert_ :
-    ?label:Base.string -> (field Cvar.t, field) Constraint.t -> (unit, field) t
+    ?label:Base.string -> (field Cvar.t, field) Constraint.t -> unit t
 
   val assert_r1cs :
-       ?label:Base.string
-    -> field Cvar.t
-    -> field Cvar.t
-    -> field Cvar.t
-    -> (unit, field) t
+    ?label:Base.string -> field Cvar.t -> field Cvar.t -> field Cvar.t -> unit t
 
   val assert_square :
-    ?label:Base.string -> field Cvar.t -> field Cvar.t -> (unit, field) t
+    ?label:Base.string -> field Cvar.t -> field Cvar.t -> unit t
 
   val assert_all :
-       ?label:Base.string
-    -> (field Cvar.t, field) Constraint.t list
-    -> (unit, field) t
+    ?label:Base.string -> (field Cvar.t, field) Constraint.t list -> unit t
 
   val assert_equal :
-    ?label:Base.string -> field Cvar.t -> field Cvar.t -> (unit, field) t
+    ?label:Base.string -> field Cvar.t -> field Cvar.t -> unit t
 
-  val direct : (field Run_state.t -> field Run_state.t * 'a) -> ('a, field) t
+  val direct : (field Run_state.t -> field Run_state.t * 'a) -> 'a t
 
   val constraint_count :
        ?weight:((field Cvar.t, field) Constraint.t -> int)
     -> ?log:(?start:bool -> string -> int -> unit)
-    -> (unit -> ('a, field) t)
+    -> (unit -> 'a t)
     -> int
 end
 
@@ -131,7 +122,7 @@ module type Extended = sig
     S
       with module Types := Types
       with type field := field
-       and type ('a, 'f) t := ('a, 'f) Types.Checked.t
+       and type 'a t := ('a, field) Types.Checked.t
 
   val run : 'a t -> field Run_state.t -> field Run_state.t * 'a
 end
@@ -145,9 +136,9 @@ module Unextend
       S
         with module Types := Types
         with type field := Checked.field
-         and type ('a, 'f) t := ('a, 'f) Types.Checked.t )
+         and type 'a t := ('a, Checked.field) Types.Checked.t )
 
   type field = Checked.field
 
-  type ('a, 'f) t = ('a, 'f) Types.Checked.t
+  type 'a t = ('a, field) Types.Checked.t
 end

--- a/src/base/checked_intf.ml
+++ b/src/base/checked_intf.ml
@@ -136,14 +136,16 @@ module type Extended = sig
   val run : 'a t -> field Run_state.t -> field Run_state.t * 'a
 end
 
-module Unextend (Checked : Extended) :
-  S with module Types = Checked.Types with type field = Checked.field = struct
+module Unextend
+    (Types : Types.Types)
+    (Checked : Extended with module Types := Types) :
+  S with module Types := Types with type field = Checked.field = struct
   include (
     Checked :
       S
-        with module Types = Checked.Types
+        with module Types := Types
         with type field := Checked.field
-         and type ('a, 'f) t := ('a, 'f) Checked.Types.Checked.t )
+         and type ('a, 'f) t := ('a, 'f) Types.Checked.t )
 
   type field = Checked.field
 

--- a/src/base/checked_intf.ml
+++ b/src/base/checked_intf.ml
@@ -3,7 +3,7 @@ module type Basic = sig
 
   type field
 
-  type 'a t = ('a, field) Types.Checked.t
+  type 'a t = 'a Types.Checked.t
 
   include Monad_let.S with type 'a t := 'a t
 
@@ -38,7 +38,7 @@ module type S = sig
 
   type field
 
-  type 'a t = ('a, field) Types.Checked.t
+  type 'a t = 'a Types.Checked.t
 
   include Monad_let.S with type 'a t := 'a t
 

--- a/src/base/checked_runner.ml
+++ b/src/base/checked_runner.ml
@@ -14,7 +14,7 @@ type ('a, 'f) t =
 module Simple_types (Backend : Backend_extended.S) = Types.Make_types (struct
   type 'a checked = ('a, Backend.Field.t) t
 
-  type ('a, 'f) as_prover = ('f Cvar.t -> 'f) -> 'a
+  type 'a as_prover = (Backend.Field.t Cvar.t -> Backend.Field.t) -> 'a
 end)
 
 module Simple = struct
@@ -54,8 +54,7 @@ module Make_checked
     (Backend : Backend_extended.S)
     (Types : Types.Types
                with type 'a Checked.t = 'a Simple_types(Backend).Checked.t
-                and type ('a, 'f) As_prover.t =
-                 ('a, 'f) Simple_types(Backend).As_prover.t
+                and type 'a As_prover.t = 'a Simple_types(Backend).As_prover.t
                 and type ('var, 'value, 'aux, 'field, 'checked) Typ.typ' =
                  ( 'var
                  , 'value
@@ -311,7 +310,7 @@ module type Run_extras = sig
   val get_value : field Run_state.t -> cvar -> field
 
   val run_as_prover :
-       ('a, field) Types.As_prover.t option
+       'a Types.As_prover.t option
     -> field Run_state.t
     -> field Run_state.t * 'a option
 end
@@ -320,8 +319,7 @@ module Make
     (Backend : Backend_extended.S)
     (Types : Types.Types
                with type 'a Checked.t = 'a Simple_types(Backend).Checked.t
-                and type ('a, 'f) As_prover.t =
-                 ('a, 'f) Simple_types(Backend).As_prover.t
+                and type 'a As_prover.t = 'a Simple_types(Backend).As_prover.t
                 and type ('var, 'value, 'aux, 'field, 'checked) Typ.typ' =
                  ( 'var
                  , 'value

--- a/src/base/checked_runner.ml
+++ b/src/base/checked_runner.ml
@@ -15,7 +15,41 @@ module Simple_types = struct
   end
 
   module Typ = struct
-    include Types.Typ.T
+    (** The type [('var, 'value, 'field, 'checked) t] describes a mapping from
+      OCaml types to the variables and constraints they represent:
+      - ['value] is the OCaml type
+      - ['field] is the type of the field elements
+      - ['var] is some other type that contains some R1CS variables
+      - ['checked] is the type of checked computation that verifies the stored
+        contents as R1CS variables.
+
+      For convenience and readability, it is usually best to have the ['var]
+      type mirror the ['value] type in structure, for example:
+{[
+  type t = {b1 : bool; b2 : bool} (* 'value *)
+
+  let or (x : t) = x.b1 || x.b2
+
+  module Checked = struct
+    type t = {b1 : Snark.Boolean.var; b2 : Snark.Boolean.var} (* 'var *)
+
+    let or (x : t) = Snark.Boolean.(x.b1 || x.b2)
+  end
+]}*)
+    type ('var, 'value, 'aux, 'field, 'checked) typ' =
+      { var_to_fields : 'var -> 'field Cvar.t array * 'aux
+      ; var_of_fields : 'field Cvar.t array * 'aux -> 'var
+      ; value_to_fields : 'value -> 'field array * 'aux
+      ; value_of_fields : 'field array * 'aux -> 'value
+      ; size_in_field_elements : int
+      ; constraint_system_auxiliary : unit -> 'aux
+      ; check : 'var -> 'checked
+      }
+
+    type ('var, 'value, 'field, 'checked) typ =
+      | Typ :
+          ('var, 'value, 'aux, 'field, 'checked) typ'
+          -> ('var, 'value, 'field, 'checked) typ
 
     type ('var, 'value, 'f) t = ('var, 'value, 'f, (unit, 'f) Checked.t) typ
   end

--- a/src/base/checked_runner.ml
+++ b/src/base/checked_runner.ml
@@ -7,64 +7,15 @@ let eval_constraints = ref true
 
 let eval_constraints_ref = eval_constraints
 
-module Simple_types = struct
-  module Checked = struct
-    type ('a, 'f) t =
-      | Pure of 'a
-      | Function of ('f Run_state.t -> 'f Run_state.t * 'a)
-  end
+type ('a, 'f) t =
+  | Pure of 'a
+  | Function of ('f Run_state.t -> 'f Run_state.t * 'a)
 
-  module Typ = struct
-    (** The type [('var, 'value, 'field, 'checked) t] describes a mapping from
-      OCaml types to the variables and constraints they represent:
-      - ['value] is the OCaml type
-      - ['field] is the type of the field elements
-      - ['var] is some other type that contains some R1CS variables
-      - ['checked] is the type of checked computation that verifies the stored
-        contents as R1CS variables.
+module Simple_types = Types.Make_types (struct
+  type ('a, 'f) checked = ('a, 'f) t
 
-      For convenience and readability, it is usually best to have the ['var]
-      type mirror the ['value] type in structure, for example:
-{[
-  type t = {b1 : bool; b2 : bool} (* 'value *)
-
-  let or (x : t) = x.b1 || x.b2
-
-  module Checked = struct
-    type t = {b1 : Snark.Boolean.var; b2 : Snark.Boolean.var} (* 'var *)
-
-    let or (x : t) = Snark.Boolean.(x.b1 || x.b2)
-  end
-]}*)
-    type ('var, 'value, 'aux, 'field, 'checked) typ' =
-      { var_to_fields : 'var -> 'field Cvar.t array * 'aux
-      ; var_of_fields : 'field Cvar.t array * 'aux -> 'var
-      ; value_to_fields : 'value -> 'field array * 'aux
-      ; value_of_fields : 'field array * 'aux -> 'value
-      ; size_in_field_elements : int
-      ; constraint_system_auxiliary : unit -> 'aux
-      ; check : 'var -> 'checked
-      }
-
-    type ('var, 'value, 'field, 'checked) typ =
-      | Typ :
-          ('var, 'value, 'aux, 'field, 'checked) typ'
-          -> ('var, 'value, 'field, 'checked) typ
-
-    type ('var, 'value, 'f) t = ('var, 'value, 'f, (unit, 'f) Checked.t) typ
-  end
-
-  module As_prover = struct
-    type ('a, 'f) t = ('f Cvar.t -> 'f) -> 'a
-  end
-
-  module Provider = struct
-    include Types.Provider.T
-
-    type ('a, 'f) t =
-      (('a Request.t, 'f) As_prover.t, ('a, 'f) As_prover.t) provider
-  end
-end
+  type ('a, 'f) as_prover = ('f Cvar.t -> 'f) -> 'a
+end)
 
 module Simple = struct
   type 'f field = 'f

--- a/src/base/checked_runner.ml
+++ b/src/base/checked_runner.ml
@@ -74,9 +74,9 @@ struct
 
   type field = Backend.Field.t
 
-  include Types.Checked
+  type 'a t = ('a, field) Types.Checked.t
 
-  let eval : ('a, 'f) t -> run_state -> run_state * 'a = Simple.eval
+  let eval : 'a t -> run_state -> run_state * 'a = Simple.eval
 
   include Monad_let.Make2 (struct
     include Types.Checked

--- a/src/base/checked_runner.ml
+++ b/src/base/checked_runner.ml
@@ -327,7 +327,7 @@ module type Run_extras = sig
   val get_value : field Run_state.t -> cvar -> field
 
   val run_as_prover :
-       ('a, field) As_prover0.t option
+       ('a, field) Types.As_prover.t option
     -> field Run_state.t
     -> field Run_state.t * 'a option
 end
@@ -356,6 +356,7 @@ struct
 
   let clear_constraint_logger () = constraint_logger := None
 
+  module As_prover0 = As_prover0.Make (Types)
   module Checked_runner = Make_checked (Backend) (Types) (As_prover0)
 
   type run_state = Checked_runner.run_state

--- a/src/base/checked_runner.ml
+++ b/src/base/checked_runner.ml
@@ -68,28 +68,14 @@ end
 
 module Make_checked
     (Backend : Backend_extended.S)
-    (As_prover : As_prover_intf.Basic with type field := Backend.Field.t) =
+    (As_prover : As_prover_intf.Basic
+                   with type field := Backend.Field.t
+                    and type ('a, 'f) Types.Checked.t =
+                     ('a, Backend.Field.t) Simple.Types.Checked.t) =
 struct
   type run_state = Backend.Field.t Run_state.t
 
-  module Types = struct
-    module Checked = struct
-      type ('a, 'f) t = ('a, Backend.Field.t) Simple.Types.Checked.t
-    end
-
-    module Typ = struct
-      include Types.Typ.T
-
-      type ('var, 'value, 'f) t = ('var, 'value, 'f, (unit, 'f) Checked.t) typ
-    end
-
-    module Provider = struct
-      include Types.Provider.T
-
-      type ('a, 'f) t =
-        (('a Request.t, 'f) As_prover.t, ('a, 'f) As_prover.t) provider
-    end
-  end
+  module Types = As_prover.Types
 
   type field = Backend.Field.t
 
@@ -347,7 +333,34 @@ module Make (Backend : Backend_extended.S) = struct
 
   let clear_constraint_logger () = constraint_logger := None
 
-  module Checked_runner = Make_checked (Backend) (As_prover0)
+  module As_prover = struct
+    module Types = struct
+      module Checked = struct
+        type ('a, 'f) t = ('a, Backend.Field.t) Simple.Types.Checked.t
+      end
+
+      module Typ = struct
+        include Types.Typ.T
+
+        type ('var, 'value, 'f) t = ('var, 'value, 'f, (unit, 'f) Checked.t) typ
+      end
+
+      module Provider = struct
+        include Types.Provider.T
+
+        type ('a, 'f) t =
+          (('a Request.t, 'f) As_prover0.t, ('a, 'f) As_prover0.t) provider
+      end
+
+      module As_prover = struct
+        type ('a, 'f) t = ('a, 'f) As_prover0.t
+      end
+    end
+
+    include As_prover0
+  end
+
+  module Checked_runner = Make_checked (Backend) (As_prover)
 
   type run_state = Checked_runner.run_state
 

--- a/src/base/checked_runner.ml
+++ b/src/base/checked_runner.ml
@@ -341,7 +341,7 @@ struct
 
   let clear_constraint_logger () = constraint_logger := None
 
-  module As_prover0 = As_prover0.Make (Types)
+  module As_prover0 = As_prover0.Make (Backend) (Types)
   module Checked_runner = Make_checked (Backend) (Types) (As_prover0)
 
   type run_state = Checked_runner.run_state

--- a/src/base/checked_runner.ml
+++ b/src/base/checked_runner.ml
@@ -7,27 +7,29 @@ let eval_constraints = ref true
 
 let eval_constraints_ref = eval_constraints
 
-module Simple = struct
-  module Types = struct
-    module Checked = struct
-      type ('a, 'f) t =
-        | Pure of 'a
-        | Function of ('f Run_state.t -> 'f Run_state.t * 'a)
-    end
-
-    module Typ = struct
-      include Types.Typ.T
-
-      type ('var, 'value, 'f) t = ('var, 'value, 'f, (unit, 'f) Checked.t) typ
-    end
-
-    module Provider = struct
-      include Types.Provider.T
-
-      type ('a, 'f) t =
-        (('a Request.t, 'f) As_prover0.t, ('a, 'f) As_prover0.t) provider
-    end
+module Simple_types = struct
+  module Checked = struct
+    type ('a, 'f) t =
+      | Pure of 'a
+      | Function of ('f Run_state.t -> 'f Run_state.t * 'a)
   end
+
+  module Typ = struct
+    include Types.Typ.T
+
+    type ('var, 'value, 'f) t = ('var, 'value, 'f, (unit, 'f) Checked.t) typ
+  end
+
+  module Provider = struct
+    include Types.Provider.T
+
+    type ('a, 'f) t =
+      (('a Request.t, 'f) As_prover0.t, ('a, 'f) As_prover0.t) provider
+  end
+end
+
+module Simple = struct
+  module Types = Simple_types
 
   type 'f field = 'f
 

--- a/src/base/checked_runner.ml
+++ b/src/base/checked_runner.ml
@@ -29,18 +29,16 @@ module Simple_types = struct
 end
 
 module Simple = struct
-  module Types = Simple_types
-
   type 'f field = 'f
 
-  type ('a, 'f) t = ('a, 'f field) Types.Checked.t
+  type ('a, 'f) t = ('a, 'f field) Simple_types.Checked.t
 
   let eval (t : ('a, 'f) t) : 'f field Run_state.t -> 'f field Run_state.t * 'a
       =
     match t with Pure a -> fun s -> (s, a) | Function g -> g
 
   include Monad_let.Make2 (struct
-    type ('a, 'f) t = ('a, 'f field) Types.Checked.t
+    type ('a, 'f) t = ('a, 'f field) Simple_types.Checked.t
 
     let return x : _ t = Pure x
 
@@ -73,7 +71,7 @@ module Make_checked
     (As_prover : As_prover_intf.Basic
                    with type field := Backend.Field.t
                     and type ('a, 'f) Types.Checked.t =
-                     ('a, Backend.Field.t) Simple.Types.Checked.t) =
+                     ('a, Backend.Field.t) Simple_types.Checked.t) =
 struct
   type run_state = Backend.Field.t Run_state.t
 
@@ -338,7 +336,7 @@ module Make (Backend : Backend_extended.S) = struct
   module As_prover = struct
     module Types = struct
       module Checked = struct
-        type ('a, 'f) t = ('a, Backend.Field.t) Simple.Types.Checked.t
+        type ('a, 'f) t = ('a, Backend.Field.t) Simple_types.Checked.t
       end
 
       module Typ = struct

--- a/src/base/runners.ml
+++ b/src/base/runners.ml
@@ -163,14 +163,10 @@ struct
              ( 'input_var
              , 'input_value
              , field
-             , (unit, field) Types.Checked.t )
+             , unit Types.Checked.t )
              Types.Typ.typ
         -> return_typ:
-             ( 'retvar
-             , 'retval
-             , field
-             , (unit, field) Types.Checked.t )
-             Types.Typ.typ
+             ('retvar, 'retval, field, unit Types.Checked.t) Types.Typ.typ
         -> ('input_var, 'retvar, field, 'checked) t
     end = struct
       let allocate_public_inputs :
@@ -180,7 +176,7 @@ struct
                ( input_var
                , input_value
                , field
-               , (unit, field) Types.Checked.t )
+               , unit Types.Checked.t )
                Types.Typ.typ
           -> return_typ:(output_var, output_value, field) Types.Typ.t
           -> input_var * output_var =
@@ -213,7 +209,7 @@ struct
                ( input_var
                , input_value
                , field
-               , (unit, field) Types.Checked.t )
+               , unit Types.Checked.t )
                Types.Typ.typ
           -> return_typ:(retvar, retval, _) Types.Typ.t
           -> (input_var, retvar, field, checked) t =

--- a/src/base/runners.ml
+++ b/src/base/runners.ml
@@ -4,7 +4,9 @@ module Types0 = Types
 module Make
     (Backend : Backend_extended.S)
     (Checked : Checked_intf.Extended with type field = Backend.Field.t)
-    (As_prover : As_prover0.Extended with type field := Backend.Field.t)
+    (As_prover : As_prover0.Extended
+                   with type field := Backend.Field.t
+                   with module Types := Checked.Types)
     (Runner : Checked_runner.S
                 with module Types := Checked.Types
                 with type field := Backend.Field.t

--- a/src/base/runners.ml
+++ b/src/base/runners.ml
@@ -1,14 +1,16 @@
 open Core_kernel
-module Types0 = Types
 
 module Make
     (Backend : Backend_extended.S)
-    (Checked : Checked_intf.Extended with type field = Backend.Field.t)
+    (Types : Types.Types)
+    (Checked : Checked_intf.Extended
+                 with type field = Backend.Field.t
+                 with module Types := Types)
     (As_prover : As_prover0.Extended
                    with type field := Backend.Field.t
-                   with module Types := Checked.Types)
+                   with module Types := Types)
     (Runner : Checked_runner.S
-                with module Types := Checked.Types
+                with module Types := Types
                 with type field := Backend.Field.t
                  and type cvar := Backend.Cvar.t
                  and type constr := Backend.Constraint.t option
@@ -161,14 +163,14 @@ struct
              ( 'input_var
              , 'input_value
              , field
-             , (unit, field) Checked.Types.Checked.t )
-             Types0.Typ.typ
+             , (unit, field) Types.Checked.t )
+             Types.Typ.typ
         -> return_typ:
              ( 'retvar
              , 'retval
              , field
-             , (unit, field) Checked.Types.Checked.t )
-             Types0.Typ.typ
+             , (unit, field) Types.Checked.t )
+             Types.Typ.typ
         -> ('input_var, 'retvar, field, 'checked) t
     end = struct
       let allocate_public_inputs :
@@ -178,19 +180,14 @@ struct
                ( input_var
                , input_value
                , field
-               , (unit, field) Checked.Types.Checked.t )
+               , (unit, field) Types.Checked.t )
                Types.Typ.typ
-          -> return_typ:
-               ( output_var
-               , output_value
-               , field
-               , (unit, field) Checked.Types.Checked.t )
-               Types.Typ.t
+          -> return_typ:(output_var, output_value, field) Types.Typ.t
           -> input_var * output_var =
        fun next_input ~input_typ:(Typ input_typ) ~return_typ:(Typ return_typ) ->
         (* allocate variables for the public input and the public output *)
         let alloc_input
-            { Types0.Typ.var_of_fields
+            { Types.Typ.var_of_fields
             ; size_in_field_elements
             ; constraint_system_auxiliary
             ; _
@@ -216,9 +213,9 @@ struct
                ( input_var
                , input_value
                , field
-               , (unit, field) Checked.Types.Checked.t )
+               , (unit, field) Types.Checked.t )
                Types.Typ.typ
-          -> return_typ:(retvar, retval, _, _) Types.Typ.t
+          -> return_typ:(retvar, retval, _) Types.Typ.t
           -> (input_var, retvar, field, checked) t =
        fun ~input_typ ~return_typ ->
         let next_input = ref 0 in
@@ -298,7 +295,7 @@ struct
         }
 
       let receive_public_input :
-             ('input_var, 'input_value, _, _) Types.Typ.t
+             ('input_var, 'input_value, _) Types.Typ.t
           -> _ Types.Typ.t
           -> 'input_value
           -> _ =
@@ -389,7 +386,7 @@ struct
     let conv :
         type r_var r_value.
            (int -> _ -> r_var -> Field.Vector.t -> r_value)
-        -> ('input_var, 'input_value, _, _) Types.Typ.t
+        -> ('input_var, 'input_value, _) Types.Typ.t
         -> _ Types.Typ.t
         -> (unit -> 'input_var -> r_var)
         -> 'input_value
@@ -403,7 +400,7 @@ struct
     let generate_auxiliary_input :
            run:('a, 'checked) Runner.run
         -> input_typ:_ Types.Typ.t
-        -> return_typ:(_, _, _, _) Types.Typ.t
+        -> return_typ:(_, _, _) Types.Typ.t
         -> ?handlers:Handler.t list
         -> 'k_var
         -> 'k_value =

--- a/src/base/runners.ml
+++ b/src/base/runners.ml
@@ -6,7 +6,7 @@ module Make
     (Checked : Checked_intf.Extended
                  with type field = Backend.Field.t
                  with module Types := Types)
-    (As_prover : As_prover0.Extended
+    (As_prover : As_prover_intf.Basic
                    with type field := Backend.Field.t
                    with module Types := Types)
     (Runner : Checked_runner.S

--- a/src/base/snark0.ml
+++ b/src/base/snark0.ml
@@ -14,7 +14,7 @@ module Make_basic
     (Checked : Checked_intf.Extended
                  with type field = Backend.Field.t
                  with module Types := Types)
-    (As_prover : As_prover0.Extended
+    (As_prover : As_prover_intf.Basic
                    with type field := Backend.Field.t
                    with module Types := Types)
     (Runner : Runner.S
@@ -670,7 +670,7 @@ module Make (Backend : Backend_intf.S) = struct
 
   module Runner0 = Runner.Make (Backend_extended) (Types)
   module Checked_runner = Runner0.Checked_runner
-  module As_prover1 = As_prover0.Make (Types)
+  module As_prover1 = As_prover0.Make (Backend_extended) (Types)
   module Checked1 =
     Checked.Make (Backend.Field) (Types) (Checked_runner) (As_prover1)
 

--- a/src/base/snark0.ml
+++ b/src/base/snark0.ml
@@ -650,23 +650,7 @@ end
     See [Run.Make] for the same thing but for the imperative interface. *)
 module Make (Backend : Backend_intf.S) = struct
   module Backend_extended = Backend_extended.Make (Backend)
-
-  module Types = struct
-    include Runner.Simple_types
-
-    module Checked = struct
-      include Runner.Simple_types.Checked
-
-      type ('a, 'f) t = ('a, Backend.Field.t) Runner.Simple_types.Checked.t
-    end
-
-    module Typ = struct
-      include Runner.Simple_types.Typ
-
-      type ('var, 'value, 'f) t = ('var, 'value, 'f, (unit, 'f) Checked.t) typ
-    end
-  end
-
+  module Types = Runner.Simple_types (Backend_extended)
   module Runner0 = Runner.Make (Backend_extended) (Types)
   module Checked_runner = Runner0.Checked_runner
   module As_prover1 = As_prover0.Make (Backend_extended) (Types)
@@ -695,7 +679,7 @@ module Make (Backend : Backend_intf.S) = struct
 
     type field = Backend_extended.Field.t
 
-    type 'a t = ('a, field) Types.Checked.t
+    type 'a t = 'a Types.Checked.t
 
     let run = Runner0.run
   end

--- a/src/base/snark0.ml
+++ b/src/base/snark0.ml
@@ -25,11 +25,10 @@ module Make_basic
                  and type r1cs := Backend.R1CS_constraint_system.t) =
 struct
   open Backend
-  module Checked_S = Checked_intf.Unextend (Types) (Checked)
 
   module Typ = struct
     include Types.Typ
-    module T = Typ.Make (Types) (Checked_S)
+    module T = Typ.Make (Types) (Checked)
     include T.T
 
     type ('var, 'value) t = ('var, 'value, Field.t) T.t

--- a/src/base/snark0.ml
+++ b/src/base/snark0.ml
@@ -670,8 +670,9 @@ module Make (Backend : Backend_intf.S) = struct
 
   module Runner0 = Runner.Make (Backend_extended) (Types)
   module Checked_runner = Runner0.Checked_runner
+  module As_prover1 = As_prover0.Make (Types)
   module Checked1 =
-    Checked.Make (Backend.Field) (Types) (Checked_runner) (As_prover0)
+    Checked.Make (Backend.Field) (Types) (Checked_runner) (As_prover1)
 
   module Field_T = struct
     type field = Backend_extended.Field.t
@@ -682,7 +683,7 @@ module Make (Backend : Backend_intf.S) = struct
       (Field_T)
       (struct
         module Types = Types
-        include As_prover0
+        include As_prover1
       end)
 
   module Checked_for_basic = struct

--- a/src/base/snark0.ml
+++ b/src/base/snark0.ml
@@ -691,7 +691,7 @@ module Make (Backend : Backend_intf.S) = struct
       Checked1 :
         Checked_intf.S
           with module Types := Types
-          with type ('a, 'f) t := ('a, 'f) Checked1.t
+          with type 'a t := 'a Checked1.t
            and type field := Backend_extended.Field.t )
 
     type field = Backend_extended.Field.t

--- a/src/base/snark_intf.ml
+++ b/src/base/snark_intf.ml
@@ -710,7 +710,7 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
 
         This type specialises the {!type:As_prover.t} type for the backend's
         particular field and variable type. *)
-    type 'a t = ('a, field) As_prover0.t
+    type 'a t = (Field.Var.t -> Field.t) -> 'a
 
     type 'a as_prover = 'a t
 

--- a/src/base/snark_intf.ml
+++ b/src/base/snark_intf.ml
@@ -2,7 +2,6 @@ module Bignum_bigint = Bigint
 open Core_kernel
 module Constraint0 = Constraint
 module Boolean0 = Boolean
-module Typ0 = Typ
 
 module type Boolean_intf = sig
   type field_var
@@ -131,7 +130,7 @@ module type Typ_intf = sig
 
   type _ checked
 
-  type checked_unit
+  type 'field checked_unit
 
   type ('var, 'value, 'aux, 'field, 'checked) typ' =
     { var_to_fields : 'var -> 'field Cvar.t array * 'aux
@@ -151,7 +150,7 @@ module type Typ_intf = sig
   module Data_spec : sig
     type ('r_var, 'r_value, 'k_var, 'k_value, 'field) t =
       | ( :: ) :
-          ('var, 'value, 'field, checked_unit) typ
+          ('var, 'value, 'field, 'field checked_unit) typ
           * ('r_var, 'r_value, 'k_var, 'k_value, 'field) t
           -> ('r_var, 'r_value, 'var -> 'k_var, 'value -> 'k_value, 'field) t
       | [] : ('r_var, 'r_value, 'r_var, 'r_value, 'field) t
@@ -170,7 +169,7 @@ module type Typ_intf = sig
           example, that a [Boolean.t] is either a {!val:Field.zero} or a
           {!val:Field.one}.
     *)
-  type ('var, 'value) t = ('var, 'value, field, checked_unit) typ
+  type ('var, 'value) t = ('var, 'value, field, field checked_unit) typ
 
   (** Basic instances: *)
 
@@ -584,7 +583,7 @@ module type Basic = sig
       Typ_intf
         with type field := Field.t
          and type field_var := Field.Var.t
-         and type checked_unit := unit Checked.t
+         and type _ checked_unit := unit Checked.t
          and type _ checked := unit Checked.t
   end
 
@@ -1125,7 +1124,7 @@ module type Run_basic = sig
     (Typ_intf
       with type field := Field.Constant.t
        and type field_var := Field.t
-       and type checked_unit := unit Internal_Basic.Checked.t
+       and type _ checked_unit := unit Internal_Basic.Checked.t
        and type _ checked := unit)
 
   (** Representation of booleans within a field.

--- a/src/base/snark_intf.ml
+++ b/src/base/snark_intf.ml
@@ -1228,7 +1228,7 @@ module type Run_basic = sig
   and Internal_Basic :
     (Basic
       with type field = field
-       and type 'a Checked.t = ('a, field) Checked_runner.Simple.t
+       and type 'a Checked.t = ('a, field) Checked_runner.t
        and type ('var, 'value, 'aux, 'field, 'checked) Typ.typ' =
         ('var, 'value, 'aux, 'field, 'checked) Typ.typ'
        and type ('var, 'value, 'field, 'checked) Typ.typ =

--- a/src/base/typ.ml
+++ b/src/base/typ.ml
@@ -1,5 +1,4 @@
 open Core_kernel
-open Types.Typ
 
 module Data_spec0 = struct
   (** A list of {!type:Type.Typ.t} values, describing the inputs to a checked
@@ -75,18 +74,17 @@ module Intf = struct
 end
 
 module type Checked_monad = sig
-  type ('a, 'f) t
+  module Types : Types.Types
+
+  type ('a, 'f) t = ('a, 'f) Types.Checked.t
 
   type field
 
   include Monad_let.S2 with type ('a, 'e) t := ('a, 'e) t
-
-  module Types : Types.Types
 end
 
 module Make (Checked : Checked_monad) = struct
-  type ('var, 'value, 'field) t =
-    ('var, 'value, 'field, (unit, 'field) Checked.t) Types.Typ.t
+  type ('var, 'value, 'field) t = ('var, 'value, 'field) Checked.Types.Typ.t
 
   type ('var, 'value, 'field) typ = ('var, 'value, 'field) t
 

--- a/src/base/typ.ml
+++ b/src/base/typ.ml
@@ -1,46 +1,5 @@
 open Core_kernel
 
-module Data_spec0 = struct
-  (** A list of {!type:Type.Typ.t} values, describing the inputs to a checked
-      computation. The type [('r_var, 'r_value, 'k_var, 'k_value, 'field) t]
-      represents
-      - ['k_value] is the OCaml type of the computation
-      - ['r_value] is the OCaml type of the result
-      - ['k_var] is the type of the computation within the R1CS
-      - ['k_value] is the type of the result within the R1CS
-      - ['field] is the field over which the R1CS operates
-      - ['checked] is the type of checked computation that verifies the stored
-        contents as R1CS variables.
-
-      This functions the same as OCaml's default list type:
-{[
-  Data_spec.[typ1; typ2; typ3]
-
-  Data_spec.(typ1 :: typs)
-
-  let open Data_spec in
-  [typ1; typ2; typ3; typ4; typ5]
-
-  let open Data_spec in
-  typ1 :: typ2 :: typs
-
-]}
-      all function as you would expect.
-  *)
-  type ('r_var, 'r_value, 'k_var, 'k_value, 'f, 'checked) data_spec =
-    | ( :: ) :
-        ('var, 'value, 'f, 'checked) Types.Typ.t
-        * ('r_var, 'r_value, 'k_var, 'k_value, 'f, 'checked) data_spec
-        -> ( 'r_var
-           , 'r_value
-           , 'var -> 'k_var
-           , 'value -> 'k_value
-           , 'f
-           , 'checked )
-           data_spec
-    | [] : ('r_var, 'r_value, 'r_var, 'r_value, 'f, 'checked) data_spec
-end
-
 module Intf = struct
   module type S = sig
     type field

--- a/src/base/typ.ml
+++ b/src/base/typ.ml
@@ -35,11 +35,11 @@ end
 module type Checked_monad = sig
   module Types : Types.Types
 
-  type ('a, 'f) t = ('a, 'f) Types.Checked.t
-
   type field
 
-  include Monad_let.S2 with type ('a, 'e) t := ('a, 'e) t
+  type 'a t = ('a, field) Types.Checked.t
+
+  include Monad_let.S with type 'a t := 'a t
 end
 
 module Make
@@ -55,7 +55,7 @@ struct
 
     include
       Intf.S
-        with type 'field checked := (unit, 'field) Checked.t
+        with type 'field checked := unit Checked.t
          and type field := field
          and type field_var := field Cvar.t
   end

--- a/src/base/typ.ml
+++ b/src/base/typ.ml
@@ -83,8 +83,11 @@ module type Checked_monad = sig
   include Monad_let.S2 with type ('a, 'e) t := ('a, 'e) t
 end
 
-module Make (Checked : Checked_monad) = struct
-  type ('var, 'value, 'field) t = ('var, 'value, 'field) Checked.Types.Typ.t
+module Make
+    (Types : Types.Types)
+    (Checked : Checked_monad with module Types := Types) =
+struct
+  type ('var, 'value, 'field) t = ('var, 'value, 'field) Types.Typ.t
 
   type ('var, 'value, 'field) typ = ('var, 'value, 'field) t
 

--- a/src/base/typ.ml
+++ b/src/base/typ.ml
@@ -35,9 +35,7 @@ end
 module type Checked_monad = sig
   module Types : Types.Types
 
-  type field
-
-  type 'a t = ('a, field) Types.Checked.t
+  type 'a t = 'a Types.Checked.t
 
   include Monad_let.S with type 'a t := 'a t
 end

--- a/src/base/types.ml
+++ b/src/base/types.ml
@@ -22,7 +22,7 @@ end
 
 module type Types = sig
   module Checked : sig
-    type ('a, 'f) t
+    type 'a t
   end
 
   module Typ : sig
@@ -62,7 +62,7 @@ module type Types = sig
           ('var, 'value, 'aux, 'field, 'checked) typ'
           -> ('var, 'value, 'field, 'checked) typ
 
-    type ('var, 'value, 'f) t = ('var, 'value, 'f, (unit, 'f) Checked.t) typ
+    type ('var, 'value, 'f) t = ('var, 'value, 'f, unit Checked.t) typ
   end
 
   module As_prover : sig
@@ -78,13 +78,13 @@ module type Types = sig
 end
 
 module Make_types (Minimal : sig
-  type ('a, 'f) checked
+  type 'a checked
 
   type ('a, 'f) as_prover
 end) =
 struct
   module Checked = struct
-    type ('a, 'f) t = ('a, 'f) Minimal.checked
+    type 'a t = 'a Minimal.checked
   end
 
   module Typ = struct
@@ -124,7 +124,7 @@ struct
           ('var, 'value, 'aux, 'field, 'checked) typ'
           -> ('var, 'value, 'field, 'checked) typ
 
-    type ('var, 'value, 'f) t = ('var, 'value, 'f, (unit, 'f) Checked.t) typ
+    type ('var, 'value, 'f) t = ('var, 'value, 'f, unit Checked.t) typ
   end
 
   module As_prover = struct

--- a/src/base/types.ml
+++ b/src/base/types.ml
@@ -70,7 +70,41 @@ module type Types = sig
   end
 
   module Typ : sig
-    include module type of Typ.T
+    (** The type [('var, 'value, 'field, 'checked) t] describes a mapping from
+      OCaml types to the variables and constraints they represent:
+      - ['value] is the OCaml type
+      - ['field] is the type of the field elements
+      - ['var] is some other type that contains some R1CS variables
+      - ['checked] is the type of checked computation that verifies the stored
+        contents as R1CS variables.
+
+      For convenience and readability, it is usually best to have the ['var]
+      type mirror the ['value] type in structure, for example:
+{[
+  type t = {b1 : bool; b2 : bool} (* 'value *)
+
+  let or (x : t) = x.b1 || x.b2
+
+  module Checked = struct
+    type t = {b1 : Snark.Boolean.var; b2 : Snark.Boolean.var} (* 'var *)
+
+    let or (x : t) = Snark.Boolean.(x.b1 || x.b2)
+  end
+]}*)
+    type ('var, 'value, 'aux, 'field, 'checked) typ' =
+      { var_to_fields : 'var -> 'field Cvar.t array * 'aux
+      ; var_of_fields : 'field Cvar.t array * 'aux -> 'var
+      ; value_to_fields : 'value -> 'field array * 'aux
+      ; value_of_fields : 'field array * 'aux -> 'value
+      ; size_in_field_elements : int
+      ; constraint_system_auxiliary : unit -> 'aux
+      ; check : 'var -> 'checked
+      }
+
+    type ('var, 'value, 'field, 'checked) typ =
+      | Typ :
+          ('var, 'value, 'aux, 'field, 'checked) typ'
+          -> ('var, 'value, 'field, 'checked) typ
 
     type ('var, 'value, 'f) t = ('var, 'value, 'f, (unit, 'f) Checked.t) Typ.t
   end

--- a/src/base/types.ml
+++ b/src/base/types.ml
@@ -106,7 +106,11 @@ module type Types = sig
           ('var, 'value, 'aux, 'field, 'checked) typ'
           -> ('var, 'value, 'field, 'checked) typ
 
-    type ('var, 'value, 'f) t = ('var, 'value, 'f, (unit, 'f) Checked.t) Typ.t
+    type ('var, 'value, 'f) t = ('var, 'value, 'f, (unit, 'f) Checked.t) typ
+  end
+
+  module As_prover : sig
+    type ('a, 'f) t
   end
 
   module Provider : sig

--- a/src/base/types.ml
+++ b/src/base/types.ml
@@ -20,46 +20,6 @@ module Provider = struct
   type ('request, 'compute) t = ('request, 'compute) provider
 end
 
-module Typ = struct
-  module T = struct
-    (** The type [('var, 'value, 'field, 'checked) t] describes a mapping from
-      OCaml types to the variables and constraints they represent:
-      - ['value] is the OCaml type
-      - ['field] is the type of the field elements
-      - ['var] is some other type that contains some R1CS variables
-      - ['checked] is the type of checked computation that verifies the stored
-        contents as R1CS variables.
-
-      For convenience and readability, it is usually best to have the ['var]
-      type mirror the ['value] type in structure, for example:
-{[
-  type t = {b1 : bool; b2 : bool} (* 'value *)
-
-  let or (x : t) = x.b1 || x.b2
-
-  module Checked = struct
-    type t = {b1 : Snark.Boolean.var; b2 : Snark.Boolean.var} (* 'var *)
-
-    let or (x : t) = Snark.Boolean.(x.b1 || x.b2)
-  end
-]}*)
-    type ('var, 'value, 'aux, 'field, 'checked) typ' =
-      { var_to_fields : 'var -> 'field Cvar.t array * 'aux
-      ; var_of_fields : 'field Cvar.t array * 'aux -> 'var
-      ; value_to_fields : 'value -> 'field array * 'aux
-      ; value_of_fields : 'field array * 'aux -> 'value
-      ; size_in_field_elements : int
-      ; constraint_system_auxiliary : unit -> 'aux
-      ; check : 'var -> 'checked
-      }
-
-    type ('var, 'value, 'field, 'checked) typ =
-      | Typ :
-          ('var, 'value, 'aux, 'field, 'checked) typ'
-          -> ('var, 'value, 'field, 'checked) typ
-  end
-end
-
 module type Types = sig
   module Checked : sig
     type ('a, 'f) t

--- a/src/base/types.ml
+++ b/src/base/types.ml
@@ -76,3 +76,65 @@ module type Types = sig
       (('a Request.t, 'f) As_prover.t, ('a, 'f) As_prover.t) provider
   end
 end
+
+module Make_types (Minimal : sig
+  type ('a, 'f) checked
+
+  type ('a, 'f) as_prover
+end) =
+struct
+  module Checked = struct
+    type ('a, 'f) t = ('a, 'f) Minimal.checked
+  end
+
+  module Typ = struct
+    (** The type [('var, 'value, 'field, 'checked) t] describes a mapping from
+      OCaml types to the variables and constraints they represent:
+      - ['value] is the OCaml type
+      - ['field] is the type of the field elements
+      - ['var] is some other type that contains some R1CS variables
+      - ['checked] is the type of checked computation that verifies the stored
+        contents as R1CS variables.
+
+      For convenience and readability, it is usually best to have the ['var]
+      type mirror the ['value] type in structure, for example:
+{[
+  type t = {b1 : bool; b2 : bool} (* 'value *)
+
+  let or (x : t) = x.b1 || x.b2
+
+  module Checked = struct
+    type t = {b1 : Snark.Boolean.var; b2 : Snark.Boolean.var} (* 'var *)
+
+    let or (x : t) = Snark.Boolean.(x.b1 || x.b2)
+  end
+]}*)
+    type ('var, 'value, 'aux, 'field, 'checked) typ' =
+      { var_to_fields : 'var -> 'field Cvar.t array * 'aux
+      ; var_of_fields : 'field Cvar.t array * 'aux -> 'var
+      ; value_to_fields : 'value -> 'field array * 'aux
+      ; value_of_fields : 'field array * 'aux -> 'value
+      ; size_in_field_elements : int
+      ; constraint_system_auxiliary : unit -> 'aux
+      ; check : 'var -> 'checked
+      }
+
+    type ('var, 'value, 'field, 'checked) typ =
+      | Typ :
+          ('var, 'value, 'aux, 'field, 'checked) typ'
+          -> ('var, 'value, 'field, 'checked) typ
+
+    type ('var, 'value, 'f) t = ('var, 'value, 'f, (unit, 'f) Checked.t) typ
+  end
+
+  module As_prover = struct
+    type ('a, 'f) t = ('a, 'f) Minimal.as_prover
+  end
+
+  module Provider = struct
+    include Provider.T
+
+    type ('a, 'f) t =
+      (('a Request.t, 'f) As_prover.t, ('a, 'f) As_prover.t) provider
+  end
+end

--- a/src/base/types.ml
+++ b/src/base/types.ml
@@ -58,8 +58,6 @@ module Typ = struct
           ('var, 'value, 'aux, 'field, 'checked) typ'
           -> ('var, 'value, 'field, 'checked) typ
   end
-
-  include T
 end
 
 module type Types = sig

--- a/src/base/types.ml
+++ b/src/base/types.ml
@@ -60,8 +60,6 @@ module Typ = struct
   end
 
   include T
-
-  type ('var, 'value, 'field, 'checked) t = ('var, 'value, 'field, 'checked) typ
 end
 
 module type Types = sig

--- a/src/base/types.ml
+++ b/src/base/types.ml
@@ -66,21 +66,20 @@ module type Types = sig
   end
 
   module As_prover : sig
-    type ('a, 'f) t
+    type 'a t
   end
 
   module Provider : sig
     include module type of Provider.T
 
-    type ('a, 'f) t =
-      (('a Request.t, 'f) As_prover.t, ('a, 'f) As_prover.t) provider
+    type 'a t = ('a Request.t As_prover.t, 'a As_prover.t) provider
   end
 end
 
 module Make_types (Minimal : sig
   type 'a checked
 
-  type ('a, 'f) as_prover
+  type 'a as_prover
 end) =
 struct
   module Checked = struct
@@ -128,13 +127,12 @@ struct
   end
 
   module As_prover = struct
-    type ('a, 'f) t = ('a, 'f) Minimal.as_prover
+    type 'a t = 'a Minimal.as_prover
   end
 
   module Provider = struct
     include Provider.T
 
-    type ('a, 'f) t =
-      (('a Request.t, 'f) As_prover.t, ('a, 'f) As_prover.t) provider
+    type 'a t = ('a Request.t As_prover.t, 'a As_prover.t) provider
   end
 end

--- a/src/base/utils.ml
+++ b/src/base/utils.ml
@@ -7,7 +7,19 @@ let set_eval_constraints b = Runner.eval_constraints := b
 module Make
     (Backend : Backend_extended.S)
     (Checked : Checked_intf.Extended with type field = Backend.Field.t)
-    (As_prover : As_prover0.Extended with type field := Backend.Field.t)
+    (As_prover : As_prover0.Extended
+                   with type field := Backend.Field.t
+                   with module Types := Checked.Types)
+    (Typ : Snark_intf.Typ_intf
+             with type field := Backend.Field.t
+              and type field_var := Backend.Cvar.t
+              and type 'field checked_unit :=
+               (unit, 'field) Checked.Types.Checked.t
+              and type _ checked := unit Checked.t
+              and type ('var, 'value, 'aux, 'field, 'checked) typ' :=
+               ('var, 'value, 'aux, 'field, 'checked) Checked.Types.Typ.typ'
+              and type ('var, 'value, 'field, 'checked) typ :=
+               ('var, 'value, 'field, 'checked) Checked.Types.Typ.typ)
     (Runner : Runner.S
                 with module Types := Checked.Types
                 with type field := Backend.Field.t
@@ -18,18 +30,6 @@ struct
   open Backend
 
   open Runners.Make (Backend) (Checked) (As_prover) (Runner)
-
-  module Typ = struct
-    include Types.Typ.T
-    module T = Typ.Make (Checked_intf.Unextend (Checked))
-    include T.T
-
-    type ('var, 'value) t = ('var, 'value, Field.t) T.t
-
-    let unit : (unit, unit) t = unit ()
-
-    let field : (Cvar.t, Field.t) t = field ()
-  end
 
   open (
     Checked :
@@ -435,6 +435,4 @@ struct
       let all xs = And xs
     end
   end
-
-  module Typ2 = Typ
 end

--- a/src/base/utils.ml
+++ b/src/base/utils.ml
@@ -16,7 +16,7 @@ module Make
     (Typ : Snark_intf.Typ_intf
              with type field := Backend.Field.t
               and type field_var := Backend.Cvar.t
-              and type 'field checked_unit := (unit, 'field) Types.Checked.t
+              and type 'field checked_unit := unit Types.Checked.t
               and type _ checked := unit Checked.t
               and type ('var, 'value, 'aux, 'field, 'checked) typ' :=
                ('var, 'value, 'aux, 'field, 'checked) Types.Typ.typ'

--- a/src/base/utils.ml
+++ b/src/base/utils.ml
@@ -10,7 +10,7 @@ module Make
     (Checked : Checked_intf.Extended
                  with type field = Backend.Field.t
                  with module Types := Types)
-    (As_prover : As_prover0.Extended
+    (As_prover : As_prover_intf.Basic
                    with type field := Backend.Field.t
                    with module Types := Types)
     (Typ : Snark_intf.Typ_intf

--- a/src/base/utils.ml
+++ b/src/base/utils.ml
@@ -6,22 +6,24 @@ let set_eval_constraints b = Runner.eval_constraints := b
 
 module Make
     (Backend : Backend_extended.S)
-    (Checked : Checked_intf.Extended with type field = Backend.Field.t)
+    (Types : Types.Types)
+    (Checked : Checked_intf.Extended
+                 with type field = Backend.Field.t
+                 with module Types := Types)
     (As_prover : As_prover0.Extended
                    with type field := Backend.Field.t
-                   with module Types := Checked.Types)
+                   with module Types := Types)
     (Typ : Snark_intf.Typ_intf
              with type field := Backend.Field.t
               and type field_var := Backend.Cvar.t
-              and type 'field checked_unit :=
-               (unit, 'field) Checked.Types.Checked.t
+              and type 'field checked_unit := (unit, 'field) Types.Checked.t
               and type _ checked := unit Checked.t
               and type ('var, 'value, 'aux, 'field, 'checked) typ' :=
-               ('var, 'value, 'aux, 'field, 'checked) Checked.Types.Typ.typ'
+               ('var, 'value, 'aux, 'field, 'checked) Types.Typ.typ'
               and type ('var, 'value, 'field, 'checked) typ :=
-               ('var, 'value, 'field, 'checked) Checked.Types.Typ.typ)
+               ('var, 'value, 'field, 'checked) Types.Typ.typ)
     (Runner : Runner.S
-                with module Types := Checked.Types
+                with module Types := Types
                 with type field := Backend.Field.t
                  and type cvar := Backend.Cvar.t
                  and type constr := Backend.Constraint.t option
@@ -29,13 +31,11 @@ module Make
 struct
   open Backend
 
-  open Runners.Make (Backend) (Checked) (As_prover) (Runner)
+  open Runners.Make (Backend) (Types) (Checked) (As_prover) (Runner)
 
   open (
     Checked :
-      Checked_intf.Extended
-        with module Types := Checked.Types
-        with type field := field )
+      Checked_intf.Extended with module Types := Types with type field := field )
 
   (* [equal_constraints z z_inv r] asserts that
      if z = 0 then r = 1, or

--- a/src/base/utils.mli
+++ b/src/base/utils.mli
@@ -15,7 +15,7 @@ module Make : functor
   (Typ : Snark_intf.Typ_intf
            with type field := Backend.Field.t
             and type field_var := Backend.Cvar.t
-            and type 'field checked_unit := (unit, 'field) Types.Checked.t
+            and type 'field checked_unit := unit Types.Checked.t
             and type 'a checked := 'a Checked.t
             and type ('var, 'value, 'aux, 'field, 'checked) typ' :=
              ('var, 'value, 'aux, 'field, 'checked) Types.Typ.typ'
@@ -37,7 +37,7 @@ module Make : functor
        Checked.field Cvar0.t Boolean.t
     -> then_:Checked.field Cvar0.t
     -> else_:Checked.field Cvar0.t
-    -> (Checked.field Cvar0.t, Checked.field) Types.Checked.t
+    -> Checked.field Cvar0.t Types.Checked.t
 
   module Boolean : sig
     type var = Checked.field Cvar0.t Boolean.t
@@ -54,22 +54,20 @@ module Make : functor
          Checked.field Cvar0.t Boolean.t
       -> then_:var
       -> else_:var
-      -> (Checked.field Cvar0.t Boolean.t, Checked.field) Types.Checked.t
+      -> Checked.field Cvar0.t Boolean.t Types.Checked.t
 
     val _and_for_square_constraint_systems :
-         var
-      -> var
-      -> (Checked.field Cvar0.t Boolean.t, Checked.field) Types.Checked.t
+      var -> var -> Checked.field Cvar0.t Boolean.t Types.Checked.t
 
     val ( && ) : var -> var -> var Checked.t
 
     val ( &&& ) : var -> var -> var Checked.t
 
-    val ( || ) : var -> var -> (var, Checked.field) Types.Checked.t
+    val ( || ) : var -> var -> var Types.Checked.t
 
-    val ( ||| ) : var -> var -> (var, Checked.field) Types.Checked.t
+    val ( ||| ) : var -> var -> var Types.Checked.t
 
-    val any : var list -> (var, Checked.field) Types.Checked.t
+    val any : var list -> var Types.Checked.t
 
     val all : var list -> var Checked.t
 
@@ -81,50 +79,48 @@ module Make : functor
 
     val typ_unchecked : (var, value) Typ.t
 
-    val ( lxor ) : var -> var -> (var, Checked.field) Types.Checked.t
+    val ( lxor ) : var -> var -> var Types.Checked.t
 
     module Array : sig
       val num_true : var array -> Checked.field Cvar0.t
 
-      val any : var array -> (var, Checked.field) Types.Checked.t
+      val any : var array -> var Types.Checked.t
 
       val all : var array -> var Checked.t
 
       module Assert : sig
-        val any : var array -> (unit, Checked.field) Types.Checked.t
+        val any : var array -> unit Types.Checked.t
 
-        val all : var array -> (unit, Checked.field) Types.Checked.t
+        val all : var array -> unit Types.Checked.t
       end
     end
 
-    val equal : var -> var -> (var, Checked.field) Types.Checked.t
+    val equal : var -> var -> var Types.Checked.t
 
-    val of_field :
-         Backend.Cvar.t
-      -> (Backend.Cvar.t Boolean.t, Checked.field) Types.Checked.t
+    val of_field : Backend.Cvar.t -> Backend.Cvar.t Boolean.t Types.Checked.t
 
     module Unsafe : sig
       val of_cvar : Checked.field Cvar0.t -> var
     end
 
     module Assert : sig
-      val ( = ) : var -> var -> (unit, Checked.field) Types.Checked.t
+      val ( = ) : var -> var -> unit Types.Checked.t
 
-      val is_true : var -> (unit, Checked.field) Types.Checked.t
+      val is_true : var -> unit Types.Checked.t
 
-      val any : var list -> (unit, Checked.field) Types.Checked.t
+      val any : var list -> unit Types.Checked.t
 
-      val all : var list -> (unit, Checked.field) Types.Checked.t
+      val all : var list -> unit Types.Checked.t
 
-      val exactly_one : var list -> (unit, Checked.field) Types.Checked.t
+      val exactly_one : var list -> unit Types.Checked.t
     end
 
     module Expr : sig
       type t = Var of var | And of t list | Or of t list | Not of t
 
-      val eval : t -> (var, Checked.field) Types.Checked.t
+      val eval : t -> var Types.Checked.t
 
-      val assert_ : t -> (unit, Checked.field) Types.Checked.t
+      val assert_ : t -> unit Types.Checked.t
 
       val ( ! ) : var -> t
 
@@ -148,26 +144,25 @@ module Make : functor
        ?label:string
     -> Checked.field Cvar0.t
     -> Checked.field Cvar0.t
-    -> (Checked.field Cvar0.t, Checked.field) Types.Checked.t
+    -> Checked.field Cvar0.t Types.Checked.t
 
   val square :
        ?label:string
     -> Checked.field Cvar0.t
-    -> (Checked.field Cvar0.t, Checked.field) Types.Checked.t
+    -> Checked.field Cvar0.t Types.Checked.t
 
   val div :
        ?label:string
     -> Checked.field Cvar0.t
     -> Checked.field Cvar0.t
-    -> (Checked.field Cvar0.t, Checked.field) Types.Checked.t
+    -> Checked.field Cvar0.t Types.Checked.t
 
   val inv :
        ?label:string
     -> Checked.field Cvar0.t
-    -> (Checked.field Cvar0.t, Checked.field) Types.Checked.t
+    -> Checked.field Cvar0.t Types.Checked.t
 
-  val assert_non_zero :
-    Checked.field Cvar0.t -> (unit, Checked.field) Types.Checked.t
+  val assert_non_zero : Checked.field Cvar0.t -> unit Types.Checked.t
 
   val equal_vars :
     Checked.field Cvar0.t -> (Checked.field * Checked.field) As_prover.t
@@ -176,5 +171,5 @@ module Make : functor
        Checked.field Cvar0.t
     -> Checked.field Cvar0.t
     -> Checked.field Cvar0.t
-    -> (unit, Checked.field) Types.Checked.t
+    -> unit Types.Checked.t
 end

--- a/src/base/utils.mli
+++ b/src/base/utils.mli
@@ -5,22 +5,24 @@ val set_eval_constraints : bool -> unit
 
 module Make : functor
   (Backend : Backend_extended.S)
-  (Checked : Checked_intf.Extended with type field = Backend.Field.t)
+  (Types : Types.Types)
+  (Checked : Checked_intf.Extended
+               with type field = Backend.Field.t
+               with module Types := Types)
   (As_prover : As_prover0.Extended
                  with type field := Backend.Field.t
-                 with module Types := Checked.Types)
+                 with module Types := Types)
   (Typ : Snark_intf.Typ_intf
            with type field := Backend.Field.t
             and type field_var := Backend.Cvar.t
-            and type 'field checked_unit :=
-             (unit, 'field) Checked.Types.Checked.t
+            and type 'field checked_unit := (unit, 'field) Types.Checked.t
             and type 'a checked := 'a Checked.t
             and type ('var, 'value, 'aux, 'field, 'checked) typ' :=
-             ('var, 'value, 'aux, 'field, 'checked) Checked.Types.Typ.typ'
+             ('var, 'value, 'aux, 'field, 'checked) Types.Typ.typ'
             and type ('var, 'value, 'field, 'checked) typ :=
-             ('var, 'value, 'field, 'checked) Checked.Types.Typ.typ)
+             ('var, 'value, 'field, 'checked) Types.Typ.typ)
   (Runner : Runner.S
-              with module Types := Checked.Types
+              with module Types := Types
               with type field := Backend.Field.t
                and type cvar := Backend.Cvar.t
                and type constr := Backend.Constraint.t option
@@ -35,7 +37,7 @@ module Make : functor
        Checked.field Cvar0.t Boolean.t
     -> then_:Checked.field Cvar0.t
     -> else_:Checked.field Cvar0.t
-    -> (Checked.field Cvar0.t, Checked.field) Checked.Types.Checked.t
+    -> (Checked.field Cvar0.t, Checked.field) Types.Checked.t
 
   module Boolean : sig
     type var = Checked.field Cvar0.t Boolean.t
@@ -52,26 +54,22 @@ module Make : functor
          Checked.field Cvar0.t Boolean.t
       -> then_:var
       -> else_:var
-      -> ( Checked.field Cvar0.t Boolean.t
-         , Checked.field )
-         Checked.Types.Checked.t
+      -> (Checked.field Cvar0.t Boolean.t, Checked.field) Types.Checked.t
 
     val _and_for_square_constraint_systems :
          var
       -> var
-      -> ( Checked.field Cvar0.t Boolean.t
-         , Checked.field )
-         Checked.Types.Checked.t
+      -> (Checked.field Cvar0.t Boolean.t, Checked.field) Types.Checked.t
 
     val ( && ) : var -> var -> var Checked.t
 
     val ( &&& ) : var -> var -> var Checked.t
 
-    val ( || ) : var -> var -> (var, Checked.field) Checked.Types.Checked.t
+    val ( || ) : var -> var -> (var, Checked.field) Types.Checked.t
 
-    val ( ||| ) : var -> var -> (var, Checked.field) Checked.Types.Checked.t
+    val ( ||| ) : var -> var -> (var, Checked.field) Types.Checked.t
 
-    val any : var list -> (var, Checked.field) Checked.Types.Checked.t
+    val any : var list -> (var, Checked.field) Types.Checked.t
 
     val all : var list -> var Checked.t
 
@@ -83,51 +81,50 @@ module Make : functor
 
     val typ_unchecked : (var, value) Typ.t
 
-    val ( lxor ) : var -> var -> (var, Checked.field) Checked.Types.Checked.t
+    val ( lxor ) : var -> var -> (var, Checked.field) Types.Checked.t
 
     module Array : sig
       val num_true : var array -> Checked.field Cvar0.t
 
-      val any : var array -> (var, Checked.field) Checked.Types.Checked.t
+      val any : var array -> (var, Checked.field) Types.Checked.t
 
       val all : var array -> var Checked.t
 
       module Assert : sig
-        val any : var array -> (unit, Checked.field) Checked.Types.Checked.t
+        val any : var array -> (unit, Checked.field) Types.Checked.t
 
-        val all : var array -> (unit, Checked.field) Checked.Types.Checked.t
+        val all : var array -> (unit, Checked.field) Types.Checked.t
       end
     end
 
-    val equal : var -> var -> (var, Checked.field) Checked.Types.Checked.t
+    val equal : var -> var -> (var, Checked.field) Types.Checked.t
 
     val of_field :
          Backend.Cvar.t
-      -> (Backend.Cvar.t Boolean.t, Checked.field) Checked.Types.Checked.t
+      -> (Backend.Cvar.t Boolean.t, Checked.field) Types.Checked.t
 
     module Unsafe : sig
       val of_cvar : Checked.field Cvar0.t -> var
     end
 
     module Assert : sig
-      val ( = ) : var -> var -> (unit, Checked.field) Checked.Types.Checked.t
+      val ( = ) : var -> var -> (unit, Checked.field) Types.Checked.t
 
-      val is_true : var -> (unit, Checked.field) Checked.Types.Checked.t
+      val is_true : var -> (unit, Checked.field) Types.Checked.t
 
-      val any : var list -> (unit, Checked.field) Checked.Types.Checked.t
+      val any : var list -> (unit, Checked.field) Types.Checked.t
 
-      val all : var list -> (unit, Checked.field) Checked.Types.Checked.t
+      val all : var list -> (unit, Checked.field) Types.Checked.t
 
-      val exactly_one :
-        var list -> (unit, Checked.field) Checked.Types.Checked.t
+      val exactly_one : var list -> (unit, Checked.field) Types.Checked.t
     end
 
     module Expr : sig
       type t = Var of var | And of t list | Or of t list | Not of t
 
-      val eval : t -> (var, Checked.field) Checked.Types.Checked.t
+      val eval : t -> (var, Checked.field) Types.Checked.t
 
-      val assert_ : t -> (unit, Checked.field) Checked.Types.Checked.t
+      val assert_ : t -> (unit, Checked.field) Types.Checked.t
 
       val ( ! ) : var -> t
 
@@ -151,26 +148,26 @@ module Make : functor
        ?label:string
     -> Checked.field Cvar0.t
     -> Checked.field Cvar0.t
-    -> (Checked.field Cvar0.t, Checked.field) Checked.Types.Checked.t
+    -> (Checked.field Cvar0.t, Checked.field) Types.Checked.t
 
   val square :
        ?label:string
     -> Checked.field Cvar0.t
-    -> (Checked.field Cvar0.t, Checked.field) Checked.Types.Checked.t
+    -> (Checked.field Cvar0.t, Checked.field) Types.Checked.t
 
   val div :
        ?label:string
     -> Checked.field Cvar0.t
     -> Checked.field Cvar0.t
-    -> (Checked.field Cvar0.t, Checked.field) Checked.Types.Checked.t
+    -> (Checked.field Cvar0.t, Checked.field) Types.Checked.t
 
   val inv :
        ?label:string
     -> Checked.field Cvar0.t
-    -> (Checked.field Cvar0.t, Checked.field) Checked.Types.Checked.t
+    -> (Checked.field Cvar0.t, Checked.field) Types.Checked.t
 
   val assert_non_zero :
-    Checked.field Cvar0.t -> (unit, Checked.field) Checked.Types.Checked.t
+    Checked.field Cvar0.t -> (unit, Checked.field) Types.Checked.t
 
   val equal_vars :
     Checked.field Cvar0.t -> (Checked.field * Checked.field) As_prover.t
@@ -179,5 +176,5 @@ module Make : functor
        Checked.field Cvar0.t
     -> Checked.field Cvar0.t
     -> Checked.field Cvar0.t
-    -> (unit, Checked.field) Checked.Types.Checked.t
+    -> (unit, Checked.field) Types.Checked.t
 end

--- a/src/base/utils.mli
+++ b/src/base/utils.mli
@@ -9,7 +9,7 @@ module Make : functor
   (Checked : Checked_intf.Extended
                with type field = Backend.Field.t
                with module Types := Types)
-  (As_prover : As_prover0.Extended
+  (As_prover : As_prover_intf.Basic
                  with type field := Backend.Field.t
                  with module Types := Types)
   (Typ : Snark_intf.Typ_intf


### PR DESCRIPTION
This PR bundles a few changes. This can be broken into smaller pieces by commit if needed.

The goal of this PR is to remove the generalisation over `Field.t` from `Checked.t` and `As_prover.t`, allowing us to hoist `Typ.t` from the global implementation in `Types`. The result is a unique `Typ.t` type for each instantiation of snarky, allowing us to generate it from any checked backend (and in particular from a rust backend).

To achieve this, we
* create a new helper functor `Types.Make_types`
* remove the free field argument from `As_prover.t`
* replace uses of the concretised types with those from the shared `Types` module signature
* remove some unused or now-unnecessary type and functor machinery.

The recommended way to review this PR is to 'ignore whitespace' in the GitHub UI (or equivalently using `git diff --ignore-all-space`), to ignore the indentation changes resulting from functorisation.