### PR TITLE
Abstract over the specific `Constraint.t` type used by the backing constraint system

### DIFF
--- a/src/base/backend_extended.ml
+++ b/src/base/backend_extended.ml
@@ -59,8 +59,6 @@ module type S = sig
     val to_constant : t -> Field.t option
   end
 
-  module R1CS_constraint_system : Constraint_system.S with module Field := Field
-
   module Constraint : sig
     type t = (Cvar.t, Field.t) Constraint.t [@@deriving sexp]
 
@@ -76,6 +74,11 @@ module type S = sig
 
     val log_constraint : t -> (Cvar.t -> Field.t) -> string
   end
+
+  module R1CS_constraint_system :
+    Constraint_system.S
+      with module Field := Field
+      with type constraint_ = Constraint.t
 
   module Run_state : Run_state_intf.S
 end

--- a/src/base/backend_extended.ml
+++ b/src/base/backend_extended.ml
@@ -64,22 +64,15 @@ module type S = sig
   module Constraint : sig
     type t = (Cvar.t, Field.t) Constraint.t [@@deriving sexp]
 
-    type 'k with_constraint_args = ?label:string -> 'k
+    val boolean : Cvar.t -> t
 
-    val boolean : (Cvar.t -> t) with_constraint_args
+    val equal : Cvar.t -> Cvar.t -> t
 
-    val equal : (Cvar.t -> Cvar.t -> t) with_constraint_args
+    val r1cs : Cvar.t -> Cvar.t -> Cvar.t -> t
 
-    val r1cs : (Cvar.t -> Cvar.t -> Cvar.t -> t) with_constraint_args
+    val square : Cvar.t -> Cvar.t -> t
 
-    val square : (Cvar.t -> Cvar.t -> t) with_constraint_args
-
-    val annotation : t -> string
-
-    val eval :
-         (Cvar.t, Field.t) Constraint.basic_with_annotation
-      -> (Cvar.t -> Field.t)
-      -> bool
+    val eval : (Cvar.t, Field.t) Constraint.t -> (Cvar.t -> Field.t) -> bool
   end
 
   module Run_state : Run_state_intf.S
@@ -208,16 +201,13 @@ module Make (Backend : Backend_intf.S) :
   end
 
   module Constraint = struct
-    open Constraint
     include Constraint.T
-
-    type 'k with_constraint_args = ?label:string -> 'k
 
     type t = (Cvar.t, Field.t) Constraint.t [@@deriving sexp]
 
     let m = (module Field : Snarky_intf.Field.S with type t = Field.t)
 
-    let eval { basic; _ } get_value = Constraint.Basic.eval m get_value basic
+    let eval basic get_value = Constraint.Basic.eval m get_value basic
   end
 
   module R1CS_constraint_system = R1CS_constraint_system

--- a/src/base/backend_extended.ml
+++ b/src/base/backend_extended.ml
@@ -93,7 +93,7 @@ module Make (Backend : Backend_intf.S) :
      and type Bigint.t = Backend.Bigint.t
      and type R1CS_constraint_system.t = Backend.R1CS_constraint_system.t
      and type Run_state.t = Backend.Run_state.t
-     and type Constraint.t = Backend.R1CS_constraint_system.constraint_ = struct
+     and type Constraint.t = Backend.Constraint.t = struct
   open Backend
 
   module Bigint = struct
@@ -209,42 +209,7 @@ module Make (Backend : Backend_intf.S) :
           None
   end
 
-  module Constraint = struct
-    include Constraint.T
-
-    type t = (Cvar.t, Field.t) Constraint.t [@@deriving sexp]
-
-    let m = (module Field : Snarky_intf.Field.S with type t = Field.t)
-
-    let eval basic get_value = Constraint.Basic.eval m get_value basic
-
-    let log_constraint (basic : t) get_value =
-      let open Constraint in
-      match basic with
-      | Boolean var ->
-          Format.(asprintf "Boolean %s" (Field.to_string (get_value var)))
-      | Equal (var1, var2) ->
-          Format.(
-            asprintf "Equal %s %s"
-              (Field.to_string (get_value var1))
-              (Field.to_string (get_value var2)))
-      | Square (var1, var2) ->
-          Format.(
-            asprintf "Square %s %s"
-              (Field.to_string (get_value var1))
-              (Field.to_string (get_value var2)))
-      | R1CS (var1, var2, var3) ->
-          Format.(
-            asprintf "R1CS %s %s %s"
-              (Field.to_string (get_value var1))
-              (Field.to_string (get_value var2))
-              (Field.to_string (get_value var3)))
-      | _ ->
-          Format.asprintf
-            !"%{sexp:(Field.t, Field.t) Constraint.basic}"
-            (Constraint.Basic.map basic ~f:get_value)
-  end
-
+  module Constraint = Constraint
   module R1CS_constraint_system = R1CS_constraint_system
   module Run_state = Run_state
 end

--- a/src/base/backend_extended.ml
+++ b/src/base/backend_extended.ml
@@ -80,7 +80,10 @@ module type S = sig
       with module Field := Field
       with type constraint_ = Constraint.t
 
-  module Run_state : Run_state_intf.S
+  module Run_state :
+    Run_state_intf.S
+      with type field := Field.t
+       and type constraint_ := Constraint.t
 end
 
 module Make (Backend : Backend_intf.S) :
@@ -89,7 +92,7 @@ module Make (Backend : Backend_intf.S) :
      and type Field.Vector.t = Backend.Field.Vector.t
      and type Bigint.t = Backend.Bigint.t
      and type R1CS_constraint_system.t = Backend.R1CS_constraint_system.t
-     and type 'field Run_state.t = 'field Backend.Run_state.t = struct
+     and type Run_state.t = Backend.Run_state.t = struct
   open Backend
 
   module Bigint = struct

--- a/src/base/backend_extended.ml
+++ b/src/base/backend_extended.ml
@@ -60,7 +60,7 @@ module type S = sig
   end
 
   module Constraint : sig
-    type t = (Cvar.t, Field.t) Constraint.t [@@deriving sexp]
+    type t [@@deriving sexp]
 
     val boolean : Cvar.t -> t
 
@@ -92,7 +92,8 @@ module Make (Backend : Backend_intf.S) :
      and type Field.Vector.t = Backend.Field.Vector.t
      and type Bigint.t = Backend.Bigint.t
      and type R1CS_constraint_system.t = Backend.R1CS_constraint_system.t
-     and type Run_state.t = Backend.Run_state.t = struct
+     and type Run_state.t = Backend.Run_state.t
+     and type Constraint.t = Backend.R1CS_constraint_system.constraint_ = struct
   open Backend
 
   module Bigint = struct

--- a/src/base/backend_intf.ml
+++ b/src/base/backend_intf.ml
@@ -5,13 +5,29 @@ module type S = sig
 
   val field_size : Bigint.t
 
+  module Constraint : sig
+    type t [@@deriving sexp]
+
+    val boolean : Field.t Cvar.t -> t
+
+    val equal : Field.t Cvar.t -> Field.t Cvar.t -> t
+
+    val r1cs : Field.t Cvar.t -> Field.t Cvar.t -> Field.t Cvar.t -> t
+
+    val square : Field.t Cvar.t -> Field.t Cvar.t -> t
+
+    val eval : t -> (Field.t Cvar.t -> Field.t) -> bool
+
+    val log_constraint : t -> (Field.t Cvar.t -> Field.t) -> string
+  end
+
   module R1CS_constraint_system :
     Constraint_system.S
       with module Field := Field
-      with type constraint_ = (Field.t Cvar.t, Field.t) Constraint.t
+      with type constraint_ = Constraint.t
 
   module Run_state :
     Run_state_intf.S
       with type field := Field.t
-       and type constraint_ := R1CS_constraint_system.constraint_
+       and type constraint_ := Constraint.t
 end

--- a/src/base/backend_intf.ml
+++ b/src/base/backend_intf.ml
@@ -10,5 +10,8 @@ module type S = sig
       with module Field := Field
       with type constraint_ = (Field.t Cvar.t, Field.t) Constraint.t
 
-  module Run_state : Run_state_intf.S
+  module Run_state :
+    Run_state_intf.S
+      with type field := Field.t
+       and type constraint_ := R1CS_constraint_system.constraint_
 end

--- a/src/base/backend_intf.ml
+++ b/src/base/backend_intf.ml
@@ -5,7 +5,10 @@ module type S = sig
 
   val field_size : Bigint.t
 
-  module R1CS_constraint_system : Constraint_system.S with module Field := Field
+  module R1CS_constraint_system :
+    Constraint_system.S
+      with module Field := Field
+      with type constraint_ = (Field.t Cvar.t, Field.t) Constraint.t
 
   module Run_state : Run_state_intf.S
 end

--- a/src/base/checked.ml
+++ b/src/base/checked.ml
@@ -69,23 +69,22 @@ end)
     in
     handle t (fun request -> (Option.value_exn !handler) request)
 
-  let assert_ ?label c = add_constraint (Constraint.override_label c label)
+  let assert_ c = add_constraint c
 
-  let assert_r1cs ?label a b c = assert_ (Constraint.r1cs ?label a b c)
+  let assert_r1cs a b c = assert_ (Constraint.r1cs a b c)
 
-  let assert_square ?label a c = assert_ (Constraint.square ?label a c)
+  let assert_square a c = assert_ (Constraint.square a c)
 
-  let assert_all ?label cs =
+  let assert_all cs =
     List.fold_right cs ~init:(return ()) ~f:(fun c (acc : _ t) ->
-        bind acc ~f:(fun () ->
-            add_constraint (Constraint.override_label c label) ) )
+        bind acc ~f:(fun () -> add_constraint c) )
 
-  let assert_equal ?label x y =
+  let assert_equal x y =
     match (x, y) with
     | Cvar.Constant x, Cvar.Constant y ->
         if Field.equal x y then return ()
         else
           failwithf !"assert_equal: %{sexp: Field.t} != %{sexp: Field.t}" x y ()
     | _ ->
-        assert_ (Constraint.equal ?label x y)
+        assert_ (Constraint.equal x y)
 end

--- a/src/base/checked.ml
+++ b/src/base/checked.ml
@@ -13,7 +13,8 @@ module Make
   Checked_intf.S
     with module Types := Types
     with type field = Backend.Field.t
-     and type run_state = Basic.run_state = struct
+     and type run_state = Basic.run_state
+     and type constraint_ = Basic.constraint_ = struct
   include Basic
 
   let request_witness (typ : ('var, 'value) Types.Typ.t)
@@ -71,9 +72,9 @@ module Make
 
   let assert_ c = add_constraint c
 
-  let assert_r1cs a b c = assert_ (Constraint.r1cs a b c)
+  let assert_r1cs a b c = assert_ (Backend.Constraint.r1cs a b c)
 
-  let assert_square a c = assert_ (Constraint.square a c)
+  let assert_square a c = assert_ (Backend.Constraint.square a c)
 
   let assert_all cs =
     List.fold_right cs ~init:(return ()) ~f:(fun c (acc : _ t) ->
@@ -89,5 +90,5 @@ module Make
               Backend.Field.t}"
             x y ()
     | _ ->
-        assert_ (Constraint.equal x y)
+        assert_ (Backend.Constraint.equal x y)
 end

--- a/src/base/checked_intf.ml
+++ b/src/base/checked_intf.ml
@@ -89,20 +89,15 @@ module type S = sig
 
   val with_label : string -> (unit -> 'a t) -> 'a t
 
-  val assert_ :
-    ?label:Base.string -> (field Cvar.t, field) Constraint.t -> unit t
+  val assert_ : (field Cvar.t, field) Constraint.t -> unit t
 
-  val assert_r1cs :
-    ?label:Base.string -> field Cvar.t -> field Cvar.t -> field Cvar.t -> unit t
+  val assert_r1cs : field Cvar.t -> field Cvar.t -> field Cvar.t -> unit t
 
-  val assert_square :
-    ?label:Base.string -> field Cvar.t -> field Cvar.t -> unit t
+  val assert_square : field Cvar.t -> field Cvar.t -> unit t
 
-  val assert_all :
-    ?label:Base.string -> (field Cvar.t, field) Constraint.t list -> unit t
+  val assert_all : (field Cvar.t, field) Constraint.t list -> unit t
 
-  val assert_equal :
-    ?label:Base.string -> field Cvar.t -> field Cvar.t -> unit t
+  val assert_equal : field Cvar.t -> field Cvar.t -> unit t
 
   val direct : (run_state -> run_state * 'a) -> 'a t
 

--- a/src/base/checked_intf.ml
+++ b/src/base/checked_intf.ml
@@ -31,7 +31,7 @@ module type Basic = sig
   val direct : (run_state -> run_state * 'a) -> 'a t
 
   val constraint_count :
-       ?weight:((field Cvar.t, field) Constraint.t -> int)
+       ?weight:(constraint_ -> int)
     -> ?log:(?start:bool -> string -> int -> unit)
     -> (unit -> 'a t)
     -> int
@@ -41,6 +41,8 @@ module type S = sig
   module Types : Types.Types
 
   type field
+
+  type constraint_
 
   type run_state
 
@@ -91,20 +93,20 @@ module type S = sig
 
   val with_label : string -> (unit -> 'a t) -> 'a t
 
-  val assert_ : (field Cvar.t, field) Constraint.t -> unit t
+  val assert_ : constraint_ -> unit t
 
   val assert_r1cs : field Cvar.t -> field Cvar.t -> field Cvar.t -> unit t
 
   val assert_square : field Cvar.t -> field Cvar.t -> unit t
 
-  val assert_all : (field Cvar.t, field) Constraint.t list -> unit t
+  val assert_all : constraint_ list -> unit t
 
   val assert_equal : field Cvar.t -> field Cvar.t -> unit t
 
   val direct : (run_state -> run_state * 'a) -> 'a t
 
   val constraint_count :
-       ?weight:((field Cvar.t, field) Constraint.t -> int)
+       ?weight:(constraint_ -> int)
     -> ?log:(?start:bool -> string -> int -> unit)
     -> (unit -> 'a t)
     -> int

--- a/src/base/checked_intf.ml
+++ b/src/base/checked_intf.ml
@@ -3,13 +3,15 @@ module type Basic = sig
 
   type field
 
+  type constraint_
+
   type 'a t = 'a Types.Checked.t
 
   type run_state
 
   include Monad_let.S with type 'a t := 'a t
 
-  val add_constraint : (field Cvar.t, field) Constraint.t -> unit t
+  val add_constraint : constraint_ -> unit t
 
   val as_prover : unit Types.As_prover.t -> unit t
 

--- a/src/base/checked_runner.ml
+++ b/src/base/checked_runner.ml
@@ -392,9 +392,9 @@ module type S = sig
   module State : sig
     val make :
          num_inputs:int
-      -> input:field Run_state.Vector.t
+      -> input:field Run_state_intf.Vector.t
       -> next_auxiliary:int ref
-      -> aux:field Run_state.Vector.t
+      -> aux:field Run_state_intf.Vector.t
       -> ?system:r1cs
       -> ?eval_constraints:bool
       -> ?handler:Request.Handler.t

--- a/src/base/checked_runner.ml
+++ b/src/base/checked_runner.ml
@@ -10,9 +10,7 @@ let eval_constraints_ref = eval_constraints
 module T (Backend : Backend_extended.S) = struct
   type 'a t =
     | Pure of 'a
-    | Function of
-        (   Backend.Field.t Backend.Run_state.t
-         -> Backend.Field.t Backend.Run_state.t * 'a )
+    | Function of (Backend.Run_state.t -> Backend.Run_state.t * 'a)
 end
 
 module Simple_types (Backend : Backend_extended.S) = Types.Make_types (struct
@@ -40,7 +38,7 @@ module Make_checked
                    with type field := Backend.Field.t
                    with module Types := Types) =
 struct
-  type run_state = Backend.Field.t Backend.Run_state.t
+  type run_state = Backend.Run_state.t
 
   type constraint_ = Backend.Constraint.t
 
@@ -48,9 +46,7 @@ struct
 
   type 'a t = 'a T(Backend).t =
     | Pure of 'a
-    | Function of
-        (   Backend.Field.t Backend.Run_state.t
-         -> Backend.Field.t Backend.Run_state.t * 'a )
+    | Function of (Backend.Run_state.t -> Backend.Run_state.t * 'a)
 
   let eval (t : 'a t) : run_state -> run_state * 'a =
     match t with Pure a -> fun s -> (s, a) | Function g -> g
@@ -85,7 +81,7 @@ struct
 
   open Backend
 
-  let get_value (t : Field.t Run_state.t) : Cvar.t -> Field.t =
+  let get_value (t : Run_state.t) : Cvar.t -> Field.t =
     let get_one i = Run_state.get_variable_value t i in
     Cvar.eval (`Return_values_will_be_mutated get_one)
 

--- a/src/base/checked_runner.ml
+++ b/src/base/checked_runner.ml
@@ -145,32 +145,6 @@ struct
             f ~at_label_boundary:(`End, lab) None ) ;
         (Run_state.set_stack s' stack, y) )
 
-  let log_constraint (basic : Constraint.t) s =
-    let open Constraint0 in
-    match basic with
-    | Boolean var ->
-        Format.(asprintf "Boolean %s" (Field.to_string (get_value s var)))
-    | Equal (var1, var2) ->
-        Format.(
-          asprintf "Equal %s %s"
-            (Field.to_string (get_value s var1))
-            (Field.to_string (get_value s var2)))
-    | Square (var1, var2) ->
-        Format.(
-          asprintf "Square %s %s"
-            (Field.to_string (get_value s var1))
-            (Field.to_string (get_value s var2)))
-    | R1CS (var1, var2, var3) ->
-        Format.(
-          asprintf "R1CS %s %s %s"
-            (Field.to_string (get_value s var1))
-            (Field.to_string (get_value s var2))
-            (Field.to_string (get_value s var3)))
-    | _ ->
-        Format.asprintf
-          !"%{sexp:(Field.t, Field.t) Constraint0.basic}"
-          (Constraint0.Basic.map basic ~f:(get_value s))
-
   let add_constraint (basic : Constraint.t)
       (Constraint_system.T ((module C), system) : Field.t Constraint_system.t) =
     C.add_constraint system basic
@@ -197,7 +171,8 @@ struct
                %s"
               (stack_to_string (Run_state.stack s))
               (Sexp.to_string (Constraint.sexp_of_t c))
-              (log_constraint c s) () ;
+              (Backend.Constraint.log_constraint c (get_value s))
+              () ;
           if not (Run_state.as_prover s) then
             Option.iter (Run_state.system s) ~f:(fun system ->
                 add_constraint c system ) ;

--- a/src/base/checked_runner.ml
+++ b/src/base/checked_runner.ml
@@ -143,7 +143,7 @@ struct
             f ~at_label_boundary:(`End, lab) None ) ;
         (Run_state.set_stack s' stack, y) )
 
-  let log_constraint ({ basic; _ } : Constraint.t) s =
+  let log_constraint (basic : Constraint.t) s =
     let open Constraint0 in
     match basic with
     | Boolean var ->
@@ -169,10 +169,9 @@ struct
           !"%{sexp:(Field.t, Field.t) Constraint0.basic}"
           (Constraint0.Basic.map basic ~f:(get_value s))
 
-  let add_constraint ~stack ({ basic; annotation } : Constraint.t)
+  let add_constraint (basic : Constraint.t)
       (Constraint_system.T ((module C), system) : Field.t Constraint_system.t) =
-    let label = Option.value annotation ~default:"<unknown>" in
-    C.add_constraint system basic ~label:(stack_to_string (label :: stack))
+    C.add_constraint system basic
 
   let add_constraint c : _ t =
     Function
@@ -189,19 +188,17 @@ struct
           then
             failwithf
               "Constraint unsatisfied (unreduced):\n\
-               %s\n\
                %s\n\n\
                Constraint:\n\
                %s\n\
                Data:\n\
                %s"
-              (Constraint.annotation c)
               (stack_to_string (Run_state.stack s))
               (Sexp.to_string (Constraint.sexp_of_t c))
               (log_constraint c s) () ;
           if not (Run_state.as_prover s) then
             Option.iter (Run_state.system s) ~f:(fun system ->
-                add_constraint ~stack:(Run_state.stack s) c system ) ;
+                add_constraint c system ) ;
           (s, ()) ) )
 
   let with_handler h t : _ t =

--- a/src/base/checked_runner.ml
+++ b/src/base/checked_runner.ml
@@ -1,5 +1,4 @@
 open Core_kernel
-module Constraint0 = Constraint
 
 let stack_to_string = String.concat ~sep:"\n"
 

--- a/src/base/checked_runner.ml
+++ b/src/base/checked_runner.ml
@@ -42,6 +42,8 @@ module Make_checked
 struct
   type run_state = Backend.Field.t Backend.Run_state.t
 
+  type constraint_ = Backend.Constraint.t
+
   type field = Backend.Field.t
 
   type 'a t = 'a T(Backend).t =

--- a/src/base/checked_runner.ml
+++ b/src/base/checked_runner.ml
@@ -146,7 +146,8 @@ struct
         (Run_state.set_stack s' stack, y) )
 
   let add_constraint (basic : Constraint.t)
-      (Constraint_system.T ((module C), system) : Field.t Constraint_system.t) =
+      (Constraint_system.T ((module C), system) :
+        (Field.t, Constraint.t) Constraint_system.t ) =
     C.add_constraint system basic
 
   let add_constraint c : _ t =

--- a/src/base/checked_runner.ml
+++ b/src/base/checked_runner.ml
@@ -400,9 +400,7 @@ module type S = sig
       -> ?handler:Request.Handler.t
       -> with_witness:bool
       -> ?log_constraint:
-           (   ?at_label_boundary:[ `End | `Start ] * string
-            -> (field Cvar.t, field) Constraint.t option
-            -> unit )
+           (?at_label_boundary:[ `End | `Start ] * string -> constr -> unit)
       -> unit
       -> run_state
   end

--- a/src/base/constraint.ml
+++ b/src/base/constraint.ml
@@ -161,30 +161,16 @@ let () =
   end in
   Basic.add_case (module M)
 
-type ('v, 'f) basic_with_annotation =
-  { basic : ('v, 'f) basic; annotation : string option }
-[@@deriving sexp]
-
-type ('v, 'f) t = ('v, 'f) basic_with_annotation [@@deriving sexp]
+type ('v, 'f) t = ('v, 'f) basic [@@deriving sexp]
 
 module T = struct
-  let create_basic ?label basic = { basic; annotation = label }
+  let equal x y = Equal (x, y)
 
-  let override_label { basic; annotation = a } label_opt =
-    { basic
-    ; annotation = (match label_opt with Some x -> Some x | None -> a)
-    }
+  let boolean x = Boolean x
 
-  let equal ?label x y = create_basic ?label (Equal (x, y))
+  let r1cs a b c = R1CS (a, b, c)
 
-  let boolean ?label x = create_basic ?label (Boolean x)
-
-  let r1cs ?label a b c = create_basic ?label (R1CS (a, b, c))
-
-  let square ?label a c = create_basic ?label (Square (a, c))
-
-  let annotation (t : _ t) =
-    match t.annotation with Some str -> str | None -> ""
+  let square a c = Square (a, c)
 end
 
 include T

--- a/src/base/constraint_system.ml
+++ b/src/base/constraint_system.ml
@@ -11,8 +11,7 @@ module type S = sig
 
   val finalize : t -> unit
 
-  val add_constraint :
-    ?label:string -> t -> (Field.t Cvar.t, Field.t) Constraint.basic -> unit
+  val add_constraint : t -> (Field.t Cvar.t, Field.t) Constraint.basic -> unit
 
   val digest : t -> Md5.t
 

--- a/src/base/constraint_system.ml
+++ b/src/base/constraint_system.ml
@@ -7,11 +7,13 @@ module type S = sig
 
   type t
 
+  type constraint_
+
   val create : unit -> t
 
   val finalize : t -> unit
 
-  val add_constraint : t -> (Field.t Cvar.t, Field.t) Constraint.basic -> unit
+  val add_constraint : t -> constraint_ -> unit
 
   val digest : t -> Md5.t
 
@@ -24,4 +26,11 @@ module type S = sig
   val get_rows_len : t -> int
 end
 
-type 'f t = T : (module S with type Field.t = 'f and type t = 't) * 't -> 'f t
+type ('f, 'constraint_) t =
+  | T :
+      (module S
+         with type Field.t = 'f
+          and type t = 't
+          and type constraint_ = 'constraint_ )
+      * 't
+      -> ('f, 'constraint_) t

--- a/src/base/run_state.ml
+++ b/src/base/run_state.ml
@@ -1,129 +1,138 @@
-module Vector = struct
-  open Core_kernel
-
-  type 'elt t = 'elt Run_state_intf.Vector.t =
-    | T :
-        (module Snarky_intf.Vector.S with type elt = 'elt and type t = 't)
-        * 't Type_equal.Id.t
-        * 't
-        -> 'elt t
-
-  let unit = Type_equal.Id.create ~name:"unit" Unit.sexp_of_t
-
-  let null : type a. a t =
-    let module T = struct
-      type elt = a
-
-      type t = unit
-
-      let create () = ()
-
-      let get _ _ = failwith "Vector.null: get"
-
-      let emplace_back _ _ = failwith "Vector.null: emplace_back"
-
-      let length () = 0
-    end in
-    T ((module T), unit, ())
-
-  let get (type x) (T ((module T), _, t) : x t) i = T.get t i
-
-  let emplace_back (type x) (T ((module T), _, t) : x t) x = T.emplace_back t x
-end
-
 let id = ref 0
 
-type 'field field = 'field
+module Make (Types : sig
+  type field
 
-type 'field constraint_ = ('field Cvar.t, 'field) Constraint.t
+  type constraint_
+end) =
+struct
+  module Vector = struct
+    open Core_kernel
 
-(** The internal state used to run a checked computation. *)
-type 'field t =
-  { id : int
-  ; system : ('field, 'field constraint_) Constraint_system.t option
-  ; input : 'field Vector.t
-  ; aux : 'field Vector.t
-  ; eval_constraints : bool
-  ; num_inputs : int
-  ; next_auxiliary : int ref
-  ; has_witness : bool
-  ; stack : string list
-  ; handler : Request.Handler.t
-  ; is_running : bool
-  ; as_prover : bool ref
-  ; log_constraint :
-      (   ?at_label_boundary:[ `Start | `End ] * string
-       -> 'field constraint_ option
-       -> unit )
-      option
-  }
+    type 'elt t = 'elt Run_state_intf.Vector.t =
+      | T :
+          (module Snarky_intf.Vector.S with type elt = 'elt and type t = 't)
+          * 't Type_equal.Id.t
+          * 't
+          -> 'elt t
 
-let make ~num_inputs ~input ~next_auxiliary ~aux ?system ~eval_constraints
-    ?log_constraint ?handler ~with_witness ?(stack = []) ?(is_running = true) ()
-    =
-  next_auxiliary := num_inputs ;
-  (* We can't evaluate the constraints if we are not computing over a value. *)
-  let eval_constraints = eval_constraints && with_witness in
-  let my_id = !id in
-  incr id ;
-  { id = my_id
-  ; system
-  ; input
-  ; aux
-  ; eval_constraints
-  ; num_inputs
-  ; next_auxiliary
-  ; has_witness = with_witness
-  ; stack
-  ; handler = Option.value handler ~default:Request.Handler.fail
-  ; is_running
-  ; as_prover = ref false
-  ; log_constraint
-  }
+    let unit = Type_equal.Id.create ~name:"unit" Unit.sexp_of_t
 
-let dump (t : _ t) =
-  Format.sprintf
-    "state { is_running: %B; as_prover: %B; has_witness: %B; eval_constraints: \
-     %B; num_inputs: %d; next_auxiliary: %d }\n"
-    t.is_running !(t.as_prover) t.has_witness t.eval_constraints t.num_inputs
-    !(t.next_auxiliary)
+    let null : type a. a t =
+      let module T = struct
+        type elt = a
 
-let get_variable_value { num_inputs; input; aux; _ } : int -> 'field =
- fun i ->
-  if i < num_inputs then Vector.get input i else Vector.get aux (i - num_inputs)
+        type t = unit
 
-let store_field_elt { next_auxiliary; aux; _ } x =
-  let v = !next_auxiliary in
-  incr next_auxiliary ; Vector.emplace_back aux x ; Cvar.Unsafe.of_index v
+        let create () = ()
 
-let alloc_var { next_auxiliary; _ } () =
-  let v = !next_auxiliary in
-  incr next_auxiliary ; Cvar.Unsafe.of_index v
+        let get _ _ = failwith "Vector.null: get"
 
-let id { id; _ } = id
+        let emplace_back _ _ = failwith "Vector.null: emplace_back"
 
-let has_witness { has_witness; _ } = has_witness
+        let length () = 0
+      end in
+      T ((module T), unit, ())
 
-let as_prover { as_prover; _ } = !as_prover
+    let get (type x) (T ((module T), _, t) : x t) i = T.get t i
 
-let set_as_prover t as_prover = t.as_prover := as_prover
+    let emplace_back (type x) (T ((module T), _, t) : x t) x =
+      T.emplace_back t x
+  end
 
-let stack { stack; _ } = stack
+  type field = Types.field
 
-let set_stack t stack = { t with stack }
+  type constraint_ = Types.constraint_
 
-let log_constraint { log_constraint; _ } = log_constraint
+  (** The internal state used to run a checked computation. *)
+  type t =
+    { id : int
+    ; system : (field, constraint_) Constraint_system.t option
+    ; input : field Vector.t
+    ; aux : field Vector.t
+    ; eval_constraints : bool
+    ; num_inputs : int
+    ; next_auxiliary : int ref
+    ; has_witness : bool
+    ; stack : string list
+    ; handler : Request.Handler.t
+    ; is_running : bool
+    ; as_prover : bool ref
+    ; log_constraint :
+        (   ?at_label_boundary:[ `Start | `End ] * string
+         -> constraint_ option
+         -> unit )
+        option
+    }
 
-let eval_constraints { eval_constraints; _ } = eval_constraints
+  let make ~num_inputs ~input ~next_auxiliary ~aux ?system ~eval_constraints
+      ?log_constraint ?handler ~with_witness ?(stack = []) ?(is_running = true)
+      () =
+    next_auxiliary := num_inputs ;
+    (* We can't evaluate the constraints if we are not computing over a value. *)
+    let eval_constraints = eval_constraints && with_witness in
+    let my_id = !id in
+    incr id ;
+    { id = my_id
+    ; system
+    ; input
+    ; aux
+    ; eval_constraints
+    ; num_inputs
+    ; next_auxiliary
+    ; has_witness = with_witness
+    ; stack
+    ; handler = Option.value handler ~default:Request.Handler.fail
+    ; is_running
+    ; as_prover = ref false
+    ; log_constraint
+    }
 
-let system { system; _ } = system
+  let dump (t : t) =
+    Format.sprintf
+      "state { is_running: %B; as_prover: %B; has_witness: %B; \
+       eval_constraints: %B; num_inputs: %d; next_auxiliary: %d }\n"
+      t.is_running !(t.as_prover) t.has_witness t.eval_constraints t.num_inputs
+      !(t.next_auxiliary)
 
-let handler { handler; _ } = handler
+  let get_variable_value { num_inputs; input; aux; _ } : int -> field =
+   fun i ->
+    if i < num_inputs then Vector.get input i
+    else Vector.get aux (i - num_inputs)
 
-let set_handler t handler = { t with handler }
+  let store_field_elt { next_auxiliary; aux; _ } x =
+    let v = !next_auxiliary in
+    incr next_auxiliary ; Vector.emplace_back aux x ; Cvar.Unsafe.of_index v
 
-let is_running { is_running; _ } = is_running
+  let alloc_var { next_auxiliary; _ } () =
+    let v = !next_auxiliary in
+    incr next_auxiliary ; Cvar.Unsafe.of_index v
 
-let set_is_running t is_running = { t with is_running }
+  let id { id; _ } = id
 
-let next_auxiliary { next_auxiliary; _ } = !next_auxiliary
+  let has_witness { has_witness; _ } = has_witness
+
+  let as_prover { as_prover; _ } = !as_prover
+
+  let set_as_prover t as_prover = t.as_prover := as_prover
+
+  let stack { stack; _ } = stack
+
+  let set_stack t stack = { t with stack }
+
+  let log_constraint { log_constraint; _ } = log_constraint
+
+  let eval_constraints { eval_constraints; _ } = eval_constraints
+
+  let system { system; _ } = system
+
+  let handler { handler; _ } = handler
+
+  let set_handler t handler = { t with handler }
+
+  let is_running { is_running; _ } = is_running
+
+  let set_is_running t is_running = { t with is_running }
+
+  let next_auxiliary { next_auxiliary; _ } = !next_auxiliary
+end

--- a/src/base/run_state.ml
+++ b/src/base/run_state.ml
@@ -36,7 +36,8 @@ let id = ref 0
 (** The internal state used to run a checked computation. *)
 type 'field t =
   { id : int
-  ; system : 'field Constraint_system.t option
+  ; system :
+      ('field, ('field Cvar.t, 'field) Constraint.t) Constraint_system.t option
   ; input : 'field Vector.t
   ; aux : 'field Vector.t
   ; eval_constraints : bool

--- a/src/base/run_state.ml
+++ b/src/base/run_state.ml
@@ -33,11 +33,14 @@ end
 
 let id = ref 0
 
+type 'field field = 'field
+
+type 'field constraint_ = ('field Cvar.t, 'field) Constraint.t
+
 (** The internal state used to run a checked computation. *)
 type 'field t =
   { id : int
-  ; system :
-      ('field, ('field Cvar.t, 'field) Constraint.t) Constraint_system.t option
+  ; system : ('field, 'field constraint_) Constraint_system.t option
   ; input : 'field Vector.t
   ; aux : 'field Vector.t
   ; eval_constraints : bool
@@ -50,7 +53,7 @@ type 'field t =
   ; as_prover : bool ref
   ; log_constraint :
       (   ?at_label_boundary:[ `Start | `End ] * string
-       -> ('field Cvar.t, 'field) Constraint.t option
+       -> 'field constraint_ option
        -> unit )
       option
   }

--- a/src/base/run_state.mli
+++ b/src/base/run_state.mli
@@ -1,1 +1,4 @@
-include Run_state_intf.S
+include
+  Run_state_intf.S_poly
+    with type 'field field = 'field
+     and type 'field constraint_ = ('field Cvar.t, 'field) Constraint.t

--- a/src/base/run_state.mli
+++ b/src/base/run_state.mli
@@ -1,4 +1,8 @@
-include
-  Run_state_intf.S_poly
-    with type 'field field = 'field
-     and type 'field constraint_ = ('field Cvar.t, 'field) Constraint.t
+module Make (Types : sig
+  type field
+
+  type constraint_
+end) :
+  Run_state_intf.S
+    with type field = Types.field
+     and type constraint_ = Types.constraint_

--- a/src/base/run_state_intf.mli
+++ b/src/base/run_state_intf.mli
@@ -32,7 +32,8 @@ module type S = sig
     -> input:'field Vector.t
     -> next_auxiliary:int ref
     -> aux:'field Vector.t
-    -> ?system:'field Constraint_system.t
+    -> ?system:
+         ('field, ('field Cvar.t, 'field) Constraint.t) Constraint_system.t
     -> eval_constraints:bool
     -> ?log_constraint:
          (   ?at_label_boundary:[ `End | `Start ] * string
@@ -75,7 +76,9 @@ module type S = sig
 
   val eval_constraints : 'field t -> bool
 
-  val system : 'field t -> 'field Constraint_system.t option
+  val system :
+       'field t
+    -> ('field, ('field Cvar.t, 'field) Constraint.t) Constraint_system.t option
 
   val handler : _ t -> Request.Handler.t
 

--- a/src/base/run_state_intf.mli
+++ b/src/base/run_state_intf.mli
@@ -7,7 +7,7 @@ module Vector : sig
         -> 'elt t
 end
 
-module type S_poly = sig
+module type S = sig
   module Vector : sig
     type 'elt t = 'elt Vector.t =
       | T :
@@ -25,84 +25,69 @@ module type S_poly = sig
     val emplace_back : 'x t -> 'x -> unit
   end
 
-  type 'field field
-
-  type 'field t
-
-  type 'field constraint_
-
-  val make :
-       num_inputs:int
-    -> input:'field field Vector.t
-    -> next_auxiliary:int ref
-    -> aux:'field field Vector.t
-    -> ?system:('field field, 'field constraint_) Constraint_system.t
-    -> eval_constraints:bool
-    -> ?log_constraint:
-         (   ?at_label_boundary:[ `End | `Start ] * string
-          -> 'field constraint_ option
-          -> unit )
-    -> ?handler:Request.Handler.t
-    -> with_witness:bool
-    -> ?stack:string list
-    -> ?is_running:bool
-    -> unit
-    -> 'field t
-
-  (** dumps some information about a state [t] *)
-  val dump : 'field t -> string
-
-  val get_variable_value : 'field t -> int -> 'field field
-
-  val store_field_elt : 'field t -> 'field field -> 'field field Cvar.t
-
-  val alloc_var : 'field field t -> unit -> 'field field Cvar.t
-
-  val id : _ t -> int
-
-  val has_witness : _ t -> bool
-
-  val as_prover : _ t -> bool
-
-  val set_as_prover : _ t -> bool -> unit
-
-  val stack : _ t -> string list
-
-  val set_stack : 'field field t -> string list -> 'field field t
-
-  val log_constraint :
-       'field t
-    -> (   ?at_label_boundary:[ `Start | `End ] * string
-        -> 'field constraint_ option
-        -> unit )
-       option
-
-  val eval_constraints : 'field t -> bool
-
-  val system :
-    'field t -> ('field field, 'field constraint_) Constraint_system.t option
-
-  val handler : _ t -> Request.Handler.t
-
-  val set_handler : 'field t -> Request.Handler.t -> 'field t
-
-  val is_running : _ t -> bool
-
-  val set_is_running : 'f t -> bool -> 'f t
-
-  val next_auxiliary : _ t -> int
-end
-
-module type S = sig
   type field
 
   type t
 
   type constraint_
 
-  include
-    S_poly
-      with type _ field := field
-       and type _ t := t
-       and type _ constraint_ := constraint_
+  val make :
+       num_inputs:int
+    -> input:field Vector.t
+    -> next_auxiliary:int ref
+    -> aux:field Vector.t
+    -> ?system:(field, constraint_) Constraint_system.t
+    -> eval_constraints:bool
+    -> ?log_constraint:
+         (   ?at_label_boundary:[ `End | `Start ] * string
+          -> constraint_ option
+          -> unit )
+    -> ?handler:Request.Handler.t
+    -> with_witness:bool
+    -> ?stack:string list
+    -> ?is_running:bool
+    -> unit
+    -> t
+
+  (** dumps some information about a state [t] *)
+  val dump : t -> string
+
+  val get_variable_value : t -> int -> field
+
+  val store_field_elt : t -> field -> field Cvar.t
+
+  val alloc_var : t -> unit -> field Cvar.t
+
+  val id : t -> int
+
+  val has_witness : t -> bool
+
+  val as_prover : t -> bool
+
+  val set_as_prover : t -> bool -> unit
+
+  val stack : t -> string list
+
+  val set_stack : t -> string list -> t
+
+  val log_constraint :
+       t
+    -> (   ?at_label_boundary:[ `Start | `End ] * string
+        -> constraint_ option
+        -> unit )
+       option
+
+  val eval_constraints : t -> bool
+
+  val system : t -> (field, constraint_) Constraint_system.t option
+
+  val handler : t -> Request.Handler.t
+
+  val set_handler : t -> Request.Handler.t -> t
+
+  val is_running : t -> bool
+
+  val set_is_running : t -> bool -> t
+
+  val next_auxiliary : t -> int
 end

--- a/src/base/run_state_intf.mli
+++ b/src/base/run_state_intf.mli
@@ -7,7 +7,7 @@ module Vector : sig
         -> 'elt t
 end
 
-module type S = sig
+module type S_poly = sig
   module Vector : sig
     type 'elt t = 'elt Vector.t =
       | T :
@@ -25,19 +25,22 @@ module type S = sig
     val emplace_back : 'x t -> 'x -> unit
   end
 
+  type 'field field
+
   type 'field t
+
+  type 'field constraint_
 
   val make :
        num_inputs:int
-    -> input:'field Vector.t
+    -> input:'field field Vector.t
     -> next_auxiliary:int ref
-    -> aux:'field Vector.t
-    -> ?system:
-         ('field, ('field Cvar.t, 'field) Constraint.t) Constraint_system.t
+    -> aux:'field field Vector.t
+    -> ?system:('field field, 'field constraint_) Constraint_system.t
     -> eval_constraints:bool
     -> ?log_constraint:
          (   ?at_label_boundary:[ `End | `Start ] * string
-          -> ('field Cvar.t, 'field) Constraint.t option
+          -> 'field constraint_ option
           -> unit )
     -> ?handler:Request.Handler.t
     -> with_witness:bool
@@ -49,11 +52,11 @@ module type S = sig
   (** dumps some information about a state [t] *)
   val dump : 'field t -> string
 
-  val get_variable_value : 'field t -> int -> 'field
+  val get_variable_value : 'field t -> int -> 'field field
 
-  val store_field_elt : 'field t -> 'field -> 'field Cvar.t
+  val store_field_elt : 'field t -> 'field field -> 'field field Cvar.t
 
-  val alloc_var : 'field t -> unit -> 'field Cvar.t
+  val alloc_var : 'field field t -> unit -> 'field field Cvar.t
 
   val id : _ t -> int
 
@@ -65,20 +68,19 @@ module type S = sig
 
   val stack : _ t -> string list
 
-  val set_stack : 'field t -> string list -> 'field t
+  val set_stack : 'field field t -> string list -> 'field field t
 
   val log_constraint :
        'field t
     -> (   ?at_label_boundary:[ `Start | `End ] * string
-        -> ('field Cvar.t, 'field) Constraint.t option
+        -> 'field constraint_ option
         -> unit )
        option
 
   val eval_constraints : 'field t -> bool
 
   val system :
-       'field t
-    -> ('field, ('field Cvar.t, 'field) Constraint.t) Constraint_system.t option
+    'field t -> ('field field, 'field constraint_) Constraint_system.t option
 
   val handler : _ t -> Request.Handler.t
 
@@ -89,4 +91,18 @@ module type S = sig
   val set_is_running : 'f t -> bool -> 'f t
 
   val next_auxiliary : _ t -> int
+end
+
+module type S = sig
+  type field
+
+  type t
+
+  type constraint_
+
+  include
+    S_poly
+      with type _ field := field
+       and type _ t := t
+       and type _ constraint_ := constraint_
 end

--- a/src/base/runners.ml
+++ b/src/base/runners.ml
@@ -8,7 +8,7 @@ module Make
     (Checked : Checked_intf.Extended
                  with module Types := Types
                  with type field = Backend.Field.t
-                  and type run_state = Backend.Field.t Backend.Run_state.t)
+                  and type run_state = Backend.Run_state.t)
     (As_prover : As_prover_intf.Basic
                    with type field := Backend.Field.t
                    with module Types := Types)
@@ -18,7 +18,7 @@ module Make
                  and type cvar := Backend.Cvar.t
                  and type constr := Backend.Constraint.t option
                  and type r1cs := Backend.R1CS_constraint_system.t
-                 and type run_state = Backend.Field.t Backend.Run_state.t) =
+                 and type run_state = Backend.Run_state.t) =
 struct
   open Backend
 
@@ -156,16 +156,16 @@ struct
       v
 
     module Constraint_system_builder : sig
-      type ('input_var, 'return_var, 'field, 'checked) t =
-        { run_computation : 'a. ('input_var -> 'field Run_state.t -> 'a) -> 'a
+      type ('input_var, 'return_var, 'checked) t =
+        { run_computation : 'a. ('input_var -> Run_state.t -> 'a) -> 'a
         ; finish_computation :
-            'field Run_state.t * 'return_var -> R1CS_constraint_system.t
+            Run_state.t * 'return_var -> R1CS_constraint_system.t
         }
 
       val build :
            input_typ:('input_var, 'input_value) Types.Typ.typ
         -> return_typ:('retvar, 'retval) Types.Typ.typ
-        -> ('input_var, 'retvar, field, 'checked) t
+        -> ('input_var, 'retvar, 'checked) t
     end = struct
       let allocate_public_inputs :
           type input_var input_value output_var output_value.
@@ -190,17 +190,17 @@ struct
         let retval = alloc_input return_typ in
         (var, retval)
 
-      type ('input_var, 'return_var, 'field, 'checked) t =
-        { run_computation : 'a. ('input_var -> 'field Run_state.t -> 'a) -> 'a
+      type ('input_var, 'return_var, 'checked) t =
+        { run_computation : 'a. ('input_var -> Run_state.t -> 'a) -> 'a
         ; finish_computation :
-            'field Run_state.t * 'return_var -> R1CS_constraint_system.t
+            Run_state.t * 'return_var -> R1CS_constraint_system.t
         }
 
       let build :
           type checked input_var input_value retvar retval.
              input_typ:(input_var, input_value) Types.Typ.typ
           -> return_typ:(retvar, retval) Types.Typ.t
-          -> (input_var, retvar, field, checked) t =
+          -> (input_var, retvar, checked) t =
        fun ~input_typ ~return_typ ->
         let next_input = ref 0 in
         (* allocate variables for the public input and the public output *)
@@ -308,9 +308,9 @@ struct
 
     module Witness_builder = struct
       type ('input_var, 'return_var, 'return_value, 'field, 'checked) t =
-        { run_computation : 'a. ('input_var -> 'field Run_state.t -> 'a) -> 'a
+        { run_computation : 'a. ('input_var -> Run_state.t -> 'a) -> 'a
         ; finish_witness_generation :
-            'field Run_state.t * 'return_var -> Proof_inputs.t * 'return_value
+            Run_state.t * 'return_var -> Proof_inputs.t * 'return_value
         }
 
       let auxiliary_input ?(handlers = ([] : Handler.t list)) ~input_typ

--- a/src/base/runners.ml
+++ b/src/base/runners.ml
@@ -8,7 +8,8 @@ module Make
     (Checked : Checked_intf.Extended
                  with module Types := Types
                  with type field = Backend.Field.t
-                  and type run_state = Backend.Run_state.t)
+                  and type run_state = Backend.Run_state.t
+                  and type constraint_ = Backend.Constraint.t)
     (As_prover : As_prover_intf.Basic
                    with type field := Backend.Field.t
                    with module Types := Types)

--- a/src/base/snark0.ml
+++ b/src/base/snark0.ml
@@ -655,7 +655,7 @@ module Make (Backend : Backend_intf.S) = struct
   module Checked_runner = Runner0.Checked_runner
   module As_prover1 = As_prover0.Make (Backend_extended) (Types)
   module Checked1 =
-    Checked.Make (Backend.Field) (Types) (Checked_runner) (As_prover1)
+    Checked.Make (Backend_extended) (Types) (Checked_runner) (As_prover1)
 
   module Field_T = struct
     type field = Backend_extended.Field.t

--- a/src/base/snark0.ml
+++ b/src/base/snark0.ml
@@ -116,9 +116,7 @@ struct
       let open Let_syntax in
       let%bind bits = choose_preimage_unchecked v ~length in
       let lc = packing_sum bits in
-      let%map () =
-        assert_r1cs ~label:"Choose_preimage" lc (Cvar.constant Field.one) v
-      in
+      let%map () = assert_r1cs lc (Cvar.constant Field.one) v in
       bits
 
     let choose_preimage_flagged (v : Cvar.t) ~length =
@@ -394,7 +392,7 @@ struct
           | _ ->
               Checked.assert_non_zero v
 
-        let equal x y = Checked.assert_equal ~label:"Checked.Assert.equal" x y
+        let equal x y = Checked.assert_equal x y
 
         let not_equal (x : t) (y : t) =
           match (x, y) with
@@ -568,7 +566,7 @@ struct
         let open Checked in
         Base.List.map (chunk_for_equality t1 t2) ~f:(fun (x1, x2) ->
             Constraint.equal (Cvar1.pack x1) (Cvar1.pack x2) )
-        |> assert_all ~label:"Bitstring.Assert.equal"
+        |> assert_all
     end
   end
 
@@ -1186,13 +1184,13 @@ module Run = struct
         active_counters := counters ;
         raise exn
 
-    let assert_ ?label c = run (assert_ ?label c)
+    let assert_ c = run (assert_ c)
 
-    let assert_all ?label c = run (assert_all ?label c)
+    let assert_all c = run (assert_all c)
 
-    let assert_r1cs ?label a b c = run (assert_r1cs ?label a b c)
+    let assert_r1cs a b c = run (assert_r1cs a b c)
 
-    let assert_square ?label x y = run (assert_square ?label x y)
+    let assert_square x y = run (assert_square x y)
 
     let as_prover p = run (as_prover (As_prover.run_prover p))
 

--- a/src/base/snark0.ml
+++ b/src/base/snark0.ml
@@ -16,7 +16,8 @@ module Make_basic
     (Checked : Checked_intf.Extended
                  with module Types := Types
                  with type field = Backend.Field.t
-                  and type run_state = Backend.Run_state.t)
+                  and type run_state = Backend.Run_state.t
+                  and type constraint_ = Backend.Constraint.t)
     (As_prover : As_prover_intf.Basic
                    with type field := Backend.Field.t
                    with module Types := Types)
@@ -77,7 +78,8 @@ struct
         Checked_intf.Extended
           with module Types := Types
           with type field := field
-           and type run_state = Backend.Run_state.t )
+           and type run_state = Backend.Run_state.t
+           and type constraint_ = Backend.Constraint.t )
 
     let perform req = request_witness Typ.unit req
 
@@ -565,7 +567,7 @@ struct
       let equal t1 t2 =
         let open Checked in
         Base.List.map (chunk_for_equality t1 t2) ~f:(fun (x1, x2) ->
-            Constraint.equal (Cvar1.pack x1) (Cvar1.pack x2) )
+            Backend.Constraint.equal (Cvar1.pack x1) (Cvar1.pack x2) )
         |> assert_all
     end
   end
@@ -676,7 +678,8 @@ module Make (Backend : Backend_intf.S) = struct
           with module Types := Types
           with type 'a t := 'a Checked1.t
            and type field := Backend_extended.Field.t
-           and type run_state = Backend.Run_state.t )
+           and type run_state = Backend.Run_state.t
+           and type constraint_ = Backend_extended.Constraint.t )
 
     type field = Backend_extended.Field.t
 

--- a/src/base/snark0.ml
+++ b/src/base/snark0.ml
@@ -1584,8 +1584,10 @@ module Run = struct
   end
 end
 
-type 'field m = (module Snark_intf.Run with type field = 'field)
+type 'field m = (module Snark_intf.Run_with_constraint with type field = 'field)
 
-let make (type field) (module Backend : Backend_intf.S with type Field.t = field)
-    : field m =
+let make (type field)
+    (module Backend : Backend_intf.S
+      with type Field.t = field
+       and type Constraint.t = (field Cvar.t, field) Constraint.t ) : field m =
   (module Run.Make (Backend))

--- a/src/base/snark0.ml
+++ b/src/base/snark0.ml
@@ -16,7 +16,7 @@ module Make_basic
     (Checked : Checked_intf.Extended
                  with module Types := Types
                  with type field = Backend.Field.t
-                  and type run_state = Backend.Field.t Backend.Run_state.t)
+                  and type run_state = Backend.Run_state.t)
     (As_prover : As_prover_intf.Basic
                    with type field := Backend.Field.t
                    with module Types := Types)
@@ -26,7 +26,7 @@ module Make_basic
                  and type cvar := Backend.Cvar.t
                  and type constr := Backend.Constraint.t option
                  and type r1cs := Backend.R1CS_constraint_system.t
-                 and type run_state = Backend.Field.t Backend.Run_state.t) =
+                 and type run_state = Backend.Run_state.t) =
 struct
   open Backend
 
@@ -77,7 +77,7 @@ struct
         Checked_intf.Extended
           with module Types := Types
           with type field := field
-           and type run_state = Backend.Field.t Backend.Run_state.t )
+           and type run_state = Backend.Run_state.t )
 
     let perform req = request_witness Typ.unit req
 
@@ -676,7 +676,7 @@ module Make (Backend : Backend_intf.S) = struct
           with module Types := Types
           with type 'a t := 'a Checked1.t
            and type field := Backend_extended.Field.t
-           and type run_state = Backend.Field.t Backend.Run_state.t )
+           and type run_state = Backend.Run_state.t )
 
     type field = Backend_extended.Field.t
 

--- a/src/base/snark0.ml
+++ b/src/base/snark0.ml
@@ -1584,10 +1584,8 @@ module Run = struct
   end
 end
 
-type 'field m = (module Snark_intf.Run_with_constraint with type field = 'field)
+type 'field m = (module Snark_intf.Run with type field = 'field)
 
-let make (type field)
-    (module Backend : Backend_intf.S
-      with type Field.t = field
-       and type Constraint.t = (field Cvar.t, field) Constraint.t ) : field m =
+let make (type field) (module Backend : Backend_intf.S with type Field.t = field)
+    : field m =
   (module Run.Make (Backend))

--- a/src/base/snark0.mli
+++ b/src/base/snark0.mli
@@ -37,10 +37,6 @@ module Run : sig
        and type Constraint.t = Backend.Constraint.t
 end
 
-type 'field m = (module Snark_intf.Run_with_constraint with type field = 'field)
+type 'field m = (module Snark_intf.Run with type field = 'field)
 
-val make :
-     (module Backend_intf.S
-        with type Field.t = 'field
-         and type Constraint.t = ('field Cvar.t, 'field) Constraint.t )
-  -> 'field m
+val make : (module Backend_intf.S with type Field.t = 'field) -> 'field m

--- a/src/base/snark0.mli
+++ b/src/base/snark0.mli
@@ -25,6 +25,7 @@ module Make (Backend : Backend_intf.S) :
      and type Bigint.t = Backend.Bigint.t
      and type R1CS_constraint_system.t = Backend.R1CS_constraint_system.t
      and type Field.Vector.t = Backend.Field.Vector.t
+     and type Constraint.t = Backend.Constraint.t
 
 module Run : sig
   module Make (Backend : Backend_intf.S) :
@@ -33,8 +34,13 @@ module Run : sig
        and type Bigint.t = Backend.Bigint.t
        and type R1CS_constraint_system.t = Backend.R1CS_constraint_system.t
        and type Field.Constant.Vector.t = Backend.Field.Vector.t
+       and type Constraint.t = Backend.Constraint.t
 end
 
-type 'field m = (module Snark_intf.Run with type field = 'field)
+type 'field m = (module Snark_intf.Run_with_constraint with type field = 'field)
 
-val make : (module Backend_intf.S with type Field.t = 'field) -> 'field m
+val make :
+     (module Backend_intf.S
+        with type Field.t = 'field
+         and type Constraint.t = ('field Cvar.t, 'field) Constraint.t )
+  -> 'field m

--- a/src/base/snark_intf.ml
+++ b/src/base/snark_intf.ml
@@ -1431,12 +1431,3 @@ module type Run = sig
        and type var = Field.t
        and type t := M.t
 end
-
-module type Run_with_constraint = sig
-  type field
-
-  include
-    Run
-      with type Constraint.t = (field Cvar.t, field) Constraint.basic
-       and type field := field
-end

--- a/src/base/snark_intf.ml
+++ b/src/base/snark_intf.ml
@@ -278,24 +278,22 @@ module type Constraint_intf = sig
     *)
   type t = (field_var, field) Constraint0.t
 
-  type 'k with_constraint_args = ?label:string -> 'k
-
   (** A constraint that asserts that the field variable is a boolean: either
         {!val:Field.zero} or {!val:Field.one}.
     *)
-  val boolean : (field_var -> t) with_constraint_args
+  val boolean : field_var -> t
 
   (** A constraint that asserts that the field variable arguments are equal.
     *)
-  val equal : (field_var -> field_var -> t) with_constraint_args
+  val equal : field_var -> field_var -> t
 
   (** A bare rank-1 constraint. *)
-  val r1cs : (field_var -> field_var -> field_var -> t) with_constraint_args
+  val r1cs : field_var -> field_var -> field_var -> t
 
   (** A constraint that asserts that the first variable squares to the
         second, ie. [square x y] => [x*x = y] within the field.
     *)
-  val square : (field_var -> field_var -> t) with_constraint_args
+  val square : field_var -> field_var -> t
 end
 
 module type Field_var_intf = sig
@@ -802,30 +800,23 @@ let multiply3 (x : Field.Var.t) (y : Field.Var.t) (z : Field.Var.t)
     type t = request -> response
   end
 
-  (** Add a constraint to the constraint system, optionally with the label
-      given by [label]. *)
-  val assert_ : ?label:string -> Constraint.t -> unit Checked.t
+  (** Add a constraint to the constraint system. *)
+  val assert_ : Constraint.t -> unit Checked.t
 
-  (** Add all of the constraints in the list to the constraint system,
-      optionally with the label given by [label].
-  *)
-  val assert_all : ?label:string -> Constraint.t list -> unit Checked.t
+  (** Add all of the constraints in the list to the constraint system. *)
+  val assert_all : Constraint.t list -> unit Checked.t
 
-  (** Add a rank-1 constraint to the constraint system, optionally with the
-      label given by [label].
+  (** Add a rank-1 constraint to the constraint system.
 
       See {!val:Constraint.r1cs} for more information on rank-1 constraints.
   *)
-  val assert_r1cs :
-    ?label:string -> Field.Var.t -> Field.Var.t -> Field.Var.t -> unit Checked.t
+  val assert_r1cs : Field.Var.t -> Field.Var.t -> Field.Var.t -> unit Checked.t
 
-  (** Add a 'square' constraint to the constraint system, optionally with the
-      label given by [label].
+  (** Add a 'square' constraint to the constraint system.
 
       See {!val:Constraint.square} for more information.
   *)
-  val assert_square :
-    ?label:string -> Field.Var.t -> Field.Var.t -> unit Checked.t
+  val assert_square : Field.Var.t -> Field.Var.t -> unit Checked.t
 
   (** Run an {!module:As_prover} block. *)
   val as_prover : unit As_prover.t -> unit Checked.t
@@ -1266,13 +1257,13 @@ module type Run_basic = sig
     type t = request -> response
   end
 
-  val assert_ : ?label:string -> Constraint.t -> unit
+  val assert_ : Constraint.t -> unit
 
-  val assert_all : ?label:string -> Constraint.t list -> unit
+  val assert_all : Constraint.t list -> unit
 
-  val assert_r1cs : ?label:string -> Field.t -> Field.t -> Field.t -> unit
+  val assert_r1cs : Field.t -> Field.t -> Field.t -> unit
 
-  val assert_square : ?label:string -> Field.t -> Field.t -> unit
+  val assert_square : Field.t -> Field.t -> unit
 
   val as_prover : (unit -> unit) As_prover.t -> unit
 

--- a/src/base/snark_intf.ml
+++ b/src/base/snark_intf.ml
@@ -1,6 +1,5 @@
 module Bignum_bigint = Bigint
 open Core_kernel
-module Constraint0 = Constraint
 module Boolean0 = Boolean
 
 module type Boolean_intf = sig
@@ -276,7 +275,7 @@ module type Constraint_intf = sig
         any time we want to multiply our *variables*, we need to add a new
         rank-1 constraint.
     *)
-  type t = (field_var, field) Constraint0.t
+  type t
 
   (** A constraint that asserts that the field variable is a boolean: either
         {!val:Field.zero} or {!val:Field.one}.
@@ -1211,7 +1210,8 @@ module type Run_basic = sig
       }
   end
 
-  and Internal_Basic : (Basic with type field = field)
+  and Internal_Basic :
+    (Basic with type field = field and type Constraint.t = Constraint.t)
 
   module Bitstring_checked : sig
     type t = Boolean.var list
@@ -1430,4 +1430,13 @@ module type Run = sig
        and type bool_var := Boolean.var
        and type var = Field.t
        and type t := M.t
+end
+
+module type Run_with_constraint = sig
+  type field
+
+  include
+    Run
+      with type Constraint.t = (field Cvar.t, field) Constraint.basic
+       and type field := field
 end

--- a/src/base/utils.ml
+++ b/src/base/utils.ml
@@ -12,7 +12,8 @@ module Make
     (Checked : Checked_intf.Extended
                  with module Types := Types
                  with type field = Backend.Field.t
-                  and type run_state = Backend.Run_state.t)
+                  and type run_state = Backend.Run_state.t
+                  and type constraint_ = Backend.Constraint.t)
     (As_prover : As_prover_intf.Basic
                    with type field := Backend.Field.t
                    with module Types := Types)
@@ -37,7 +38,10 @@ struct
 
   open (
     Checked :
-      Checked_intf.Extended with module Types := Types with type field := field )
+      Checked_intf.Extended
+        with module Types := Types
+        with type field := field
+         and type constraint_ := Constraint.t )
 
   (* [equal_constraints z z_inv r] asserts that
      if z = 0 then r = 1, or

--- a/src/base/utils.ml
+++ b/src/base/utils.ml
@@ -12,7 +12,7 @@ module Make
     (Checked : Checked_intf.Extended
                  with module Types := Types
                  with type field = Backend.Field.t
-                  and type run_state = Backend.Field.t Backend.Run_state.t)
+                  and type run_state = Backend.Run_state.t)
     (As_prover : As_prover_intf.Basic
                    with type field := Backend.Field.t
                    with module Types := Types)
@@ -29,7 +29,7 @@ module Make
                  and type cvar := Backend.Cvar.t
                  and type constr := Backend.Constraint.t option
                  and type r1cs := Backend.R1CS_constraint_system.t
-                 and type run_state = Backend.Field.t Backend.Run_state.t) =
+                 and type run_state = Backend.Run_state.t) =
 struct
   open Backend
 

--- a/src/base/utils.ml
+++ b/src/base/utils.ml
@@ -45,8 +45,8 @@ struct
   *)
   let equal_constraints (z : Cvar.t) (z_inv : Cvar.t) (r : Cvar.t) =
     Checked.assert_all
-      [ Constraint.r1cs ~label:"equals_1" z_inv z Cvar.(constant Field.one - r)
-      ; Constraint.r1cs ~label:"equals_2" r z (Cvar.constant Field.zero)
+      [ Constraint.r1cs z_inv z Cvar.(constant Field.one - r)
+      ; Constraint.r1cs r z (Cvar.constant Field.zero)
       ]
 
   (* [equal_vars z] computes [(r, z_inv)] that satisfy the constraints in
@@ -130,10 +130,7 @@ struct
                         if Field.(equal zero x) then Field.zero
                         else Backend.Field.inv x ))
             in
-            let%map () =
-              assert_r1cs ~label:"field_inverse" x x_inv
-                (Cvar.constant Field.one)
-            in
+            let%map () = assert_r1cs x x_inv (Cvar.constant Field.one) in
             x_inv )
 
   let div ?(label = "Checked.div") (x : Cvar.t) (y : Cvar.t) =
@@ -277,10 +274,7 @@ struct
       in
       Typ
         { typ with
-          check =
-            (fun v ->
-              Checked.assert_
-                (Constraint.boolean ~label:"boolean-alloc" (v :> Cvar.t)) )
+          check = (fun v -> Checked.assert_ (Constraint.boolean (v :> Cvar.t)))
         }
 
     let typ_unchecked : (var, value) Typ.t =

--- a/src/base/utils.mli
+++ b/src/base/utils.mli
@@ -11,7 +11,7 @@ module Make : functor
   (Checked : Checked_intf.Extended
                with module Types := Types
                with type field = Backend.Field.t
-                and type run_state = Backend.Field.t Backend.Run_state.t)
+                and type run_state = Backend.Run_state.t)
   (As_prover : As_prover_intf.Basic
                  with type field := Backend.Field.t
                  with module Types := Types)
@@ -28,7 +28,7 @@ module Make : functor
                and type cvar := Backend.Cvar.t
                and type constr := Backend.Constraint.t option
                and type r1cs := Backend.R1CS_constraint_system.t
-               and type run_state = Backend.Field.t Backend.Run_state.t)
+               and type run_state = Backend.Run_state.t)
   -> sig
   val equal :
        Checked.field Cvar0.t

--- a/src/base/utils.mli
+++ b/src/base/utils.mli
@@ -11,7 +11,8 @@ module Make : functor
   (Checked : Checked_intf.Extended
                with module Types := Types
                with type field = Backend.Field.t
-                and type run_state = Backend.Run_state.t)
+                and type run_state = Backend.Run_state.t
+                and type constraint_ = Backend.Constraint.t)
   (As_prover : As_prover_intf.Basic
                  with type field := Backend.Field.t
                  with module Types := Types)


### PR DESCRIPTION
This PR builds on https://github.com/o1-labs/snarky/pull/858, delivering on a large part of the promise of previous iterations: this allows us to define a constraint-system-specific constraint enum instead of overloading the snarky one. In particular, this gives the ability to have safe rust FFI types for constraint system generation, by only allowing the specific constraints that it supports.

As part of the pre-work that built up to this, we have also ensured that a `Typ.t` for any particular constraint definition is compatible with only the constraint systems that support it, ensuring that we get better type safety for OCaml / JS too.