### PR TITLE
Snarky/base: reintroduce to_json in cvar interface

### DIFF
--- a/src/base/cvar.mli
+++ b/src/base/cvar.mli
@@ -49,6 +49,8 @@ module type Intf = sig
 
   val ( * ) : field -> t -> t
 
+  val to_json : t -> Yojson.Safe.t
+
   val var_indices : t -> int list
 
   val to_constant : t -> field option

--- a/src/base/dune
+++ b/src/base/dune
@@ -3,7 +3,7 @@
  (public_name snarky.backendless)
  (inline_tests)
  (libraries bitstring_lib core_kernel h_list interval_union snarky_intf
-   bignum.bigint snarky_monad_lib)
+   bignum.bigint snarky_monad_lib yojson)
  (modules_without_implementation run_state_intf)
  (preprocess
   (pps ppx_sexp_conv ppx_bin_prot ppx_let ppx_hash ppx_compare


### PR DESCRIPTION
It has been removed for this reason: https://github.com/o1-labs/snarky/pull/876#discussion_r2068895719