### PR TITLE
Fix Docs Workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch: {}
 
 jobs:
   release:

--- a/scripts/build-website.sh
+++ b/scripts/build-website.sh
@@ -5,7 +5,7 @@ set -ex
 rm -rf website/website/pages/api || true
 cp -r _build/default/_doc/_html/ website/website/pages/api
 echo "* binary" > website/website/pages/api/.gitattributes
-rm website/website/pages/api/highlight.pack.js
+# rm website/website/pages/api/highlight.pack.js
 
 # Fix css and js URLs
 pushd website/website/pages/api;


### PR DESCRIPTION
This pull request includes two changes: enabling manual triggering of the documentation workflow and commenting out the removal of a JavaScript file during the website build process which is causing the workflow to fail.

Workflow configuration updates:

* [`.github/workflows/docs.yml`](diffhunk://#diff-9cf2000c53760d837a449f874e53f792819108d3a4bf346336d0f7d082deae2cR7): Added `workflow_dispatch` to allow manual triggering of the documentation workflow.

Website build script changes:

* [`scripts/build-website.sh`](diffhunk://#diff-3093f21b5e4c5867821079fa9a72c26ddd97f42a6c022fa384a3bfa2598575daL8-R8): Commented out the line that removes `highlight.pack.js` from the API documentation directory, the file doesn't exist anymore. I'll investigate deeper with ability of manually triggering the workflow.