### PR TITLE
ppx: remove unused ppx_tools

### DIFF
--- a/ppx/dune
+++ b/ppx/dune
@@ -2,6 +2,6 @@
  (name ppx_snarky)
  (public_name ppx_snarky)
  (kind ppx_rewriter)
- (libraries ppxlib ppx_tools core_kernel)
+ (libraries core_kernel ppxlib)
  (preprocess
   (pps ppxlib.metaquot ppx_sexp_conv)))

--- a/ppx_snarky.opam
+++ b/ppx_snarky.opam
@@ -16,7 +16,6 @@ depends: [
   "ocaml" {>= "4.07.0"}
   "core" {>= "v0.14" & < "v0.15" }
   "ppxlib"
-  "ppx_tools"
   "ppx_sexp_conv"
   "dune"                {build & >= "2.0"}
 ]


### PR DESCRIPTION
It is also not support for OCaml >= 5.1