### PR TITLE
Fix typo in author name in group_map.mli reference

### DIFF
--- a/group_map/group_map.mli
+++ b/group_map/group_map.mli
@@ -1,4 +1,4 @@
-(* Construction of Rational Points on Elliptic Curves over Finite Fields by Andrew Shallue and Christiaan E. van de Woestijne.
+(* Construction of Rational Points on Elliptic Curves over Finite Fields by Andrew Shallue and Christian E. van de Woestijne.
  * found at eg https://works.bepress.com/andrew_shallue/1/download/
  *)
 


### PR DESCRIPTION

---


**Description:**  
This pull request corrects a typo in the name of the referenced author in `group_map.mli`, changing "Christiaan" to the correct "Christian" E. van de Woestijne.  

---