### PR TITLE
Unname some functor params that are not directly referred in the inte…

### DIFF
--- a/group_map/group_map.mli
+++ b/group_map/group_map.mli
@@ -33,7 +33,7 @@ module type S = sig
         include Field_intf.S
 
         val constant : Constant.t -> t
-      end) (Params : sig
+      end) (_ : sig
         val params : Constant.t Params.t
       end) : sig
     val potential_xs : F.t -> F.t * F.t * F.t

--- a/src/base/utils.mli
+++ b/src/base/utils.mli
@@ -19,11 +19,11 @@ module Make : functor
             and type ('var, 'value, 'aux) typ' :=
              ('var, 'value, 'aux) Types.Typ.typ'
             and type ('var, 'value) typ := ('var, 'value) Types.Typ.typ)
-  (Runner : Runner.S
-              with module Types := Types
-              with type constr := Backend.Constraint.t option
-               and type r1cs := Backend.R1CS_constraint_system.t
-               and type run_state = Backend.Run_state.t)
+  (_ : Runner.S
+         with module Types := Types
+         with type constr := Backend.Constraint.t option
+          and type r1cs := Backend.R1CS_constraint_system.t
+          and type run_state = Backend.Run_state.t)
   -> sig
   val equal :
     Types.field_var -> Types.field_var -> Types.field_var Boolean.t Checked.t


### PR DESCRIPTION
…rface

As title. This is motivated by o1js's side. 

Running
```
nix run o1js#generate-bindings --max-jobs auto
``` 
On `dw/bump-up-rust-nightly` I got this error message:

```
> o1js@2.12.0 build:jsoo:node
> ./scripts/build/jsoo/build-node.sh

[jsoo-build-node] • building JSOO artifacts for node...
Checking if jemalloc is available... Yes, using jemalloc as an allocator
File "src/mina/src/lib/snarky/group_map/group_map.mli", line 36, characters 12-18:
36 |       end) (Params : sig
                 ^^^^^^
Error (warning 67 [unused-functor-parameter]): unused functor parameter Params.
File "src/mina/src/lib/snarky/src/base/utils.mli", line 22, characters 3-9:
22 |   (Runner : Runner.S
        ^^^^^^
Error (warning 67 [unused-functor-parameter]): unused functor parameter Runner.
File "src/mina/src/lib/mina_stdlib/bounded_types.ml", line 127, characters 2-42:
127 |   Bin_prot.Utils.Make_binable_without_uuid (struct
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Alert legacy: module Core_kernel.Bin_prot.Utils.Make_binable_without_uuid
Use [Make_binable_with_uuid] if possible.
File "src/mina/src/lib/mina_stdlib/bounded_types.ml", line 127, characters 2-42:
127 |   Bin_prot.Utils.Make_binable_without_uuid (struct
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Alert legacy: module Core_kernel.Bin_prot.Utils.Make_binable_without_uuid
Use [Make_binable_with_uuid] if possible.
[jsoo-build-node] ✖ JSOO build node failed (command: dune build ${TARGETS[@]/#/$JSOO_PATH/})
[build-o1js-node-artifacts.sh] ✖ Node artifacts build failed (command: npm run build:jsoo:node)
[update-o1js-bindings.sh] ✖ Update bindings failed (command: "$@")
```